### PR TITLE
ci: Add Dependabot configuration to prevent breaking updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,135 @@
+# Dependabot Configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/
+#       dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# This configuration prevents automatic major version bumps which can introduce
+# breaking changes (e.g., eslint-config-next 14.x -> 16.x requires ESLint 9.x).
+
+version: 2
+updates:
+  # Frontend (npm) dependencies
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    # Prevent major version bumps - these require manual review
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    # Group related dependencies to reduce PR noise
+    groups:
+      # Keep Next.js and its ESLint config in sync
+      nextjs:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+      # Group all ESLint-related packages
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+        exclude-patterns:
+          - "eslint-config-next"  # Handled in nextjs group
+      # Group React ecosystem
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # Group TypeScript tooling
+      typescript:
+        patterns:
+          - "typescript"
+          - "@types/node"
+      # Group styling tools
+      styling:
+        patterns:
+          - "tailwindcss"
+          - "postcss"
+          - "autoprefixer"
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "build(deps-frontend)"
+
+  # Backend (pip) dependencies
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    # Prevent major version bumps
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      # Group FastAPI ecosystem
+      fastapi:
+        patterns:
+          - "fastapi"
+          - "uvicorn"
+          - "starlette"
+      # Group database dependencies
+      database:
+        patterns:
+          - "sqlalchemy"
+          - "asyncpg"
+          - "pgvector"
+      # Group Pydantic ecosystem
+      pydantic:
+        patterns:
+          - "pydantic"
+          - "pydantic-settings"
+      # Group LLM providers
+      llm-providers:
+        patterns:
+          - "anthropic"
+          - "httpx"
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "build(deps-backend)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci(deps)"
+
+  # Docker dependencies
+  - package-ecosystem: "docker"
+    directory: "/api"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build(deps-docker)"
+
+  - package-ecosystem: "docker"
+    directory: "/frontend"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build(deps-docker)"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to control automatic dependency updates
- Prevent automatic major version bumps which can introduce breaking changes
- Group related dependencies to ensure compatibility and reduce PR noise

## Problem

PR #3 from Dependabot attempted to upgrade `eslint-config-next` from 14.1.0 to 16.1.3, which requires ESLint 9.x. However, the project uses ESLint 8.x, causing CI to fail with peer dependency conflicts.

## Solution

This configuration:

1. **Prevents major version bumps** - Ignores `version-update:semver-major` for all dependencies
2. **Groups related packages** - Ensures packages that must stay in sync are updated together:
   - `next` + `eslint-config-next` (must match major versions)
   - ESLint ecosystem packages
   - React ecosystem packages
   - FastAPI ecosystem packages
   - Database packages
3. **Covers all ecosystems** - npm, pip, GitHub Actions, and Docker
4. **Adds labels** - For easier PR management

## Test plan

- [ ] Verify dependabot.yml passes yamllint
- [ ] Wait for next Dependabot run to confirm configuration is picked up
- [ ] Verify future Dependabot PRs respect the major version ignore rule

🤖 Generated with [Claude Code](https://claude.ai/claude-code)