### PR TITLE
fix(api): Fix import sorting and align isort with ruff

### DIFF
--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -7,11 +7,12 @@ conversation management to create meaningful spiritual dialogues.
 
 from typing import AsyncIterator
 
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from config import settings
 from providers import ChatMessage, EmbeddingProvider, LLMProvider
-from pydantic import BaseModel
 from scripture import ScriptureSearchService, SearchResults
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from .prompts import SYSTEM_PROMPT, build_search_context_prompt
 

--- a/api/main.py
+++ b/api/main.py
@@ -6,10 +6,11 @@ Main FastAPI application entry point.
 
 from contextlib import asynccontextmanager
 
-from config import settings
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+
+from config import settings
 from providers import ProviderError, check_providers_health
 from routes import chat_router, scripture_router
 from scripture import close_db, init_db

--- a/api/providers/factory.py
+++ b/api/providers/factory.py
@@ -7,8 +7,9 @@ This module provides dependency injection for FastAPI routes.
 from functools import lru_cache
 from typing import Annotated
 
-from config import Settings, settings
 from fastapi import Depends
+
+from config import Settings, settings
 
 from .base import EmbeddingProvider, LLMProvider
 from .claude import ClaudeProvider

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -27,6 +27,16 @@ exclude = [
     "*.pyc",
 ]
 
+[tool.ruff.lint.isort]
+# Match isort's black profile for consistency between ruff and isort
+force-single-line = false
+combine-as-imports = true
+
+[tool.isort]
+profile = "black"
+line_length = 100
+skip_gitignore = true
+
 [tool.mypy]
 python_version = "3.12"
 warn_return_any = true

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -4,9 +4,10 @@ Chat API routes.
 
 import json
 
-from chat import ChatRequest, ChatResponse, ChatService
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
+
+from chat import ChatRequest, ChatResponse, ChatService
 from providers import EmbeddingProviderDep, LLMProviderDep
 from scripture import DbSession
 

--- a/api/routes/scripture.py
+++ b/api/routes/scripture.py
@@ -3,8 +3,9 @@ Scripture API routes - Bible data and search endpoints.
 """
 
 from fastapi import APIRouter, HTTPException, Query
-from providers import EmbeddingProviderDep
 from pydantic import BaseModel
+
+from providers import EmbeddingProviderDep
 from scripture import (
     DbSession,
     ScriptureRepository,

--- a/api/scripture/database.py
+++ b/api/scripture/database.py
@@ -4,10 +4,11 @@ Database connection and session management.
 
 from typing import Annotated, AsyncGenerator
 
-from config import settings
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
+
+from config import settings
 
 
 def get_async_database_url() -> str:

--- a/api/scripture/models.py
+++ b/api/scripture/models.py
@@ -6,10 +6,11 @@ Defines the schema for storing Bible verses with vector embeddings.
 
 from typing import Any
 
-from config import settings
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import Column, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import declarative_base, relationship
+
+from config import settings
 
 Base: Any = declarative_base()
 

--- a/api/scripture/search.py
+++ b/api/scripture/search.py
@@ -2,9 +2,10 @@
 Scripture Search Service - Combines semantic search with scripture data.
 """
 
-from providers import EmbeddingProvider
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from providers import EmbeddingProvider
 
 from .repository import ScriptureRepository
 


### PR DESCRIPTION
## Summary

- Fix import sorting issues in all Python files
- Add isort configuration to `pyproject.toml` for consistency with ruff

## Problem

PR #9 removed `continue-on-error: true` from CI, which exposed pre-existing import sorting violations (I001 errors). There was also a conflict between isort (pre-commit) and ruff (CI) due to different default configurations.

## Solution

1. **Fix imports** - Used `ruff check --fix` to sort all imports
2. **Align configurations** - Added matching settings to `pyproject.toml`:

```toml
[tool.ruff.lint.isort]
force-single-line = false
combine-as-imports = true

[tool.isort]
profile = "black"
line_length = 100
```

## Files Modified

- `api/pyproject.toml` - Added isort and ruff.lint.isort configurations
- 8 Python files with import sorting fixes

## Test plan

- [ ] Verify `ruff check . --select I` passes
- [ ] Verify `isort --check .` passes
- [ ] CI should pass after this PR is merged

**Note:** This PR should be merged before PR #9 to ensure CI passes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)