### PR TITLE
fix(security): MED-002 - Change debug default to False

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
     # Application
     app_name: str = "Bible Inspiration Chat"
     app_version: str = "0.1.0"
-    debug: bool = True
+    debug: bool = False  # Set DEBUG=true in .env for development
 
     # LLM Configuration
     llm_provider: Literal["ollama", "claude", "openai", "openrouter"] = "ollama"


### PR DESCRIPTION
## Summary

Change debug mode default from `True` to `False` to prevent accidental exposure of verbose error messages in production.

## Security Issue

**MED-002**: Debug mode enabled by default could expose sensitive information through verbose error messages in production environments.

## Changes

- `api/config.py`: Changed `debug: bool = True` to `debug: bool = False`

## For Development

To enable debug mode for local development, set in `.env`:
```
DEBUG=true
```

## Merge Order

No dependencies - can be merged independently of other security fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)