### PR TITLE
fix(security): MED-004 - Remove hardcoded default DB credentials

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -53,9 +53,10 @@ class Settings(BaseSettings):
     azure_openai_api_key: str | None = None
     azure_embedding_deployment: str = "text-embedding-3-small"
 
-    # Database
+    # Database - MUST be configured via DATABASE_URL environment variable
+    # Default is a non-functional placeholder to prevent accidental use of hardcoded credentials
     database_url: str = (
-        "postgresql://bible:bible123@localhost:5432/bibledb"  # pragma: allowlist secret
+        "postgresql://CONFIGURE_ME:CONFIGURE_ME@localhost:5432/bibledb"  # pragma: allowlist secret
     )
 
     # Chat Settings


### PR DESCRIPTION
## Summary

Replace hardcoded default database credentials with a non-functional placeholder to prevent accidental use in production.

## Security Issue

**MED-004**: Hardcoded default `bible:bible123` credentials could be used if `.env` is not configured, exposing the database with known credentials.

## Changes

- `api/config.py`: Changed default `DATABASE_URL` from working credentials to placeholder `CONFIGURE_ME:CONFIGURE_ME`

## Migration

Users **MUST** set `DATABASE_URL` in their `.env` file. If not configured, the application will fail to connect (which is the desired behavior).

Example `.env` configuration:
```
DATABASE_URL=postgresql://bible:bible123@localhost:5432/bibledb
```

## Merge Order

No dependencies - can be merged independently of other security fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)