### PR TITLE
fix(security): LOW-001 - Remove HTTP from CORS production origins

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -126,13 +126,13 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
+        # Local development (HTTP is fine for localhost)
         "http://localhost:3000",
         "http://127.0.0.1:3000",
         "http://localhost:3001",
         "http://127.0.0.1:3001",
+        # Production (HTTPS only - no HTTP to prevent MitM attacks)
         "https://getinspiredbythebible.ai4you.sh",
-        "http://getinspiredbythebible.ai4you.sh",
-        # Add production domains here
     ],
     allow_credentials=True,
     allow_methods=["*"],


### PR DESCRIPTION
## Summary

Remove HTTP origin for production domain from CORS configuration to prevent potential Man-in-the-Middle attacks.

## Security Issue

**LOW-001**: CORS configuration allowed `http://getinspiredbythebible.ai4you.sh` alongside HTTPS, potentially enabling MitM attacks on the production site.

## Changes

- `api/main.py`: Removed `http://getinspiredbythebible.ai4you.sh` from CORS origins
- Local development HTTP origins (localhost:3000, etc.) are retained

## Impact

Production frontend must use HTTPS. This is already the expected behavior.

## Merge Order

No dependencies - can be merged independently of other security fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)