### PR TITLE
fix(security): LOW-003 - Move user location logging to DEBUG level

### DIFF
--- a/api/routes/church.py
+++ b/api/routes/church.py
@@ -52,7 +52,9 @@ async def search_churches(request: ChurchSearchRequest) -> ChurchSearchResponse:
     Proxies to disciplestoday.org's church finder API.
     """
     location = request.location.strip()
-    logger.info(f"Church search request for location: '{location}'")
+    logger.info("Church search request received")
+    # Log location at debug level only to avoid PII in production logs
+    logger.debug(f"Church search location: '{location}'")
 
     if not location:
         logger.warning("Church search rejected: empty location")
@@ -63,7 +65,8 @@ async def search_churches(request: ChurchSearchRequest) -> ChurchSearchResponse:
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            logger.info(f"Sending POST to {api_url} with body: {request_body}")
+            # Log at debug level only to avoid PII in production logs
+            logger.debug(f"Sending POST to {api_url} with body: {request_body}")
             response = await client.post(api_url, json=request_body)
 
             logger.info(


### PR DESCRIPTION
## Summary

Move user location logging from INFO to DEBUG level to prevent PII from appearing in production logs.

## Security Issue

**LOW-003**: User-submitted location data (PII) was being logged at INFO level, which typically appears in production logs.

## Changes

- `api/routes/church.py`: 
  - Changed location logging from `logger.info` to `logger.debug`
  - Added non-PII INFO log for basic observability ("Church search request received")

## Impact

- Production logs (INFO level) will no longer contain user location data
- Location data is still available in DEBUG logs for troubleshooting

## Merge Order

No dependencies - can be merged independently of other security fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)