### PR TITLE
fix(feedback): Create feedback tables during database initialization

### DIFF
--- a/api/scripture/database.py
+++ b/api/scripture/database.py
@@ -95,13 +95,16 @@ DbSession = Annotated[AsyncSession, Depends(get_db_session)]
 
 async def init_db():
     """Initialize database tables."""
-    from .models import Base
+    from feedback.models import Base as FeedbackBase
+
+    from .models import Base as ScriptureBase
 
     async with engine.begin() as conn:
         # Create pgvector extension
         await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-        # Create all tables
-        await conn.run_sync(Base.metadata.create_all)
+        # Create all tables from both models
+        await conn.run_sync(ScriptureBase.metadata.create_all)
+        await conn.run_sync(FeedbackBase.metadata.create_all)
 
 
 async def close_db():


### PR DESCRIPTION
## Summary
- Fixed feedback thumbs up/down not working - submissions were failing silently
- Root cause: The feedback module had its own SQLAlchemy `Base` (`declarative_base()`) but `init_db()` only created tables from the scripture module's Base
- The `feedback` and `contact_submissions` tables were never being created

## Changes
- Modified `init_db()` to import and create tables from both `ScriptureBase` and `FeedbackBase`

## Test plan
- [ ] Deploy to staging/production
- [ ] Test thumbs up feedback on a chat response
- [ ] Test thumbs down feedback on a chat response
- [ ] Verify feedback is stored in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)