### PR TITLE
feat(infra): Add SMTP2GO email configuration to Terraform

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -249,6 +249,7 @@ jobs:
       TF_VAR_openrouter_api_key: ${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
       TF_VAR_claude_api_key: ${{ secrets.TF_VAR_CLAUDE_API_KEY }}
       TF_VAR_cloudflare_origin_cert_password: ${{ secrets.TF_VAR_CLOUDFLARE_ORIGIN_CERT_PASSWORD }}
+      TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -19,6 +19,7 @@
 #   TF_VAR_DB_ADMIN_PASSWORD    - Database admin password
 #   TF_VAR_OPENROUTER_API_KEY   - OpenRouter API key
 #   TF_VAR_CLAUDE_API_KEY       - Claude API key (if using Claude)
+#   TF_VAR_SMTP2GO_API_KEY      - SMTP2GO API key (for email notifications)
 #   CLOUDFLARE_ORIGIN_CERT_B64  - Base64-encoded Cloudflare Origin Certificate
 #   TF_VAR_CLOUDFLARE_ORIGIN_CERT_PASSWORD - Certificate password (if any)
 #
@@ -177,6 +178,7 @@ jobs:
       TF_VAR_openrouter_api_key: ${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
       TF_VAR_claude_api_key: ${{ secrets.TF_VAR_CLAUDE_API_KEY }}
       TF_VAR_cloudflare_origin_cert_password: ${{ secrets.TF_VAR_CLOUDFLARE_ORIGIN_CERT_PASSWORD }}
+      TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
 
     steps:
       - name: Checkout
@@ -338,6 +340,7 @@ jobs:
       TF_VAR_openrouter_api_key: ${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
       TF_VAR_claude_api_key: ${{ secrets.TF_VAR_CLAUDE_API_KEY }}
       TF_VAR_cloudflare_origin_cert_password: ${{ secrets.TF_VAR_CLOUDFLARE_ORIGIN_CERT_PASSWORD }}
+      TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
 
     steps:
       - name: Checkout
@@ -406,6 +409,7 @@ jobs:
       TF_VAR_openrouter_api_key: ${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
       TF_VAR_claude_api_key: ${{ secrets.TF_VAR_CLAUDE_API_KEY }}
       TF_VAR_cloudflare_origin_cert_password: ${{ secrets.TF_VAR_CLOUDFLARE_ORIGIN_CERT_PASSWORD }}
+      TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
 
     steps:
       - name: Checkout

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -152,6 +152,25 @@ locals {
       "EMBEDDING_PROVIDER" = {
         value = "azure_openai"
       }
+    } : {},
+
+    # SMTP2GO email notification configuration
+    var.smtp2go_enabled ? {
+      "CONTACT_NOTIFICATION_EMAIL" = {
+        value = var.contact_notification_email
+      }
+      "SMTP2GO_API_KEY" = {
+        secret_name = "smtp2go-api-key" # pragma: allowlist secret
+      }
+      "SMTP2GO_ENABLED" = {
+        value = "true"
+      }
+      "SMTP2GO_SENDER_EMAIL" = {
+        value = var.smtp2go_sender_email
+      }
+      "SMTP2GO_SENDER_NAME" = {
+        value = var.smtp2go_sender_name
+      }
     } : {}
   )
 
@@ -376,6 +395,15 @@ resource "azurerm_container_app" "backend" {
     content {
       name  = "azure-openai-key"
       value = azurerm_cognitive_account.openai[0].primary_access_key
+    }
+  }
+
+  # SMTP2GO API Key secret (if email notifications enabled)
+  dynamic "secret" {
+    for_each = var.smtp2go_enabled ? [1] : []
+    content {
+      name  = "smtp2go-api-key"
+      value = var.smtp2go_api_key
     }
   }
 

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -113,3 +113,9 @@ budget_alert_emails = ["zioalex@gmail.com"]
 # -----------------------------------------------------------------------------
 
 custom_domain_frontend = "getinspiredbythebible.ai4you.sh"
+
+# email settings
+smtp2go_enabled      = true
+smtp2go_sender_email = "noreply@getinspiredbythebible.ai4you.sh"
+smtp2go_sender_name  = "Bible Inspiration"
+contact_notification_email = "getinspiredbythebible@ai4you.sh"# SMTP2GO config

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -360,3 +360,38 @@ variable "budget_alert_emails" {
   type        = list(string)
   default     = []
 }
+
+# -----------------------------------------------------------------------------
+# Email Notifications (SMTP2GO) Configuration
+# -----------------------------------------------------------------------------
+
+variable "smtp2go_enabled" {
+  description = "Enable email notifications via SMTP2GO"
+  type        = bool
+  default     = false
+}
+
+variable "smtp2go_api_key" {
+  description = "SMTP2GO API key (required if smtp2go_enabled=true)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "smtp2go_sender_email" {
+  description = "Sender email address for notifications"
+  type        = string
+  default     = "noreply@ai4you.sh"
+}
+
+variable "smtp2go_sender_name" {
+  description = "Sender name for notifications"
+  type        = string
+  default     = "Bible Inspiration"
+}
+
+variable "contact_notification_email" {
+  description = "Email address to receive contact form notifications"
+  type        = string
+  default     = "getinspiredbythebible@ai4you.sh"
+}


### PR DESCRIPTION
## Summary
- Add SMTP2GO variable definitions to `deployment/variables.tf`
- Add SMTP2GO environment variables to backend container in `deployment/main.tf`
- Add `smtp2go-api-key` secret to container app (conditional on `smtp2go_enabled`)
- Pass `TF_VAR_smtp2go_api_key` in both GitHub Actions workflows
- Add email settings to `terraform.tfvars`

## Test plan
- [ ] Verify Terraform plan succeeds with new variables
- [ ] Verify GitHub secret `TF_VAR_SMTP2GO_API_KEY` is configured (already done)
- [ ] Deploy and test contact form submission triggers email notification

🤖 Generated with [Claude Code](https://claude.ai/code)