### PR TITLE
fix(ci): Add ARM_USE_CLI=false to prevent Terraform CLI auth conflict

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -386,6 +386,12 @@ jobs:
 
       - name: Terraform Init
         working-directory: deployment
+        env:
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_USE_CLI: "false"
         run: |
           terraform init \
             -backend-config="storage_account_name=${{ secrets.TF_STORAGE_ACCOUNT }}" \
@@ -400,6 +406,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_USE_CLI: "false"
         run: |
           terraform apply \
             -var-file="terraform.tfvars" \


### PR DESCRIPTION
When Azure CLI is logged in with a Service Principal, Terraform's AzureRM provider detects it and tries to use CLI auth, which fails. Setting ARM_USE_CLI=false forces Terraform to use the ARM_* environment variables for Service Principal authentication instead.