### PR TITLE
fix(scripts): Improve load_bible.py progress output for CI visibility

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -61,6 +61,15 @@ on:
         required: false
         default: true
         type: boolean
+      force_database_seed:
+        description: "Force reload Bible data even if already loaded"
+        required: false
+        default: false
+        type: boolean
+      bible_translation:
+        description: "Specific translation to load (e.g., 'kjv', 'ita1927'). Leave empty for all."
+        required: false
+        type: string
 
 env:
   BACKEND_APP_NAME: bible-app-backend
@@ -568,8 +577,24 @@ jobs:
         run: |
           export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}?sslmode=require"
           cd scripts
-          echo "Loading Bible translations..."
-          python load_bible.py --all
+
+          # Build command flags
+          FORCE_FLAG=""
+          TRANSLATION_FLAG="--all"
+
+          if [ "${{ inputs.force_database_seed }}" == "true" ]; then
+            FORCE_FLAG="--force"
+            echo "Force mode enabled - will reload translations"
+          fi
+
+          if [ -n "${{ inputs.bible_translation }}" ]; then
+            TRANSLATION_FLAG="--translation ${{ inputs.bible_translation }}"
+            echo "Loading specific translation: ${{ inputs.bible_translation }}"
+          else
+            echo "Loading all translations..."
+          fi
+
+          python load_bible.py $TRANSLATION_FLAG $FORCE_FLAG
 
       - name: Generate Embeddings
         env:

--- a/scripts/load_bible.py
+++ b/scripts/load_bible.py
@@ -24,6 +24,8 @@ import os
 import httpx
 from pathlib import Path
 import sys
+import time
+from datetime import datetime
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "api"))
@@ -112,29 +114,39 @@ BIBLE_BOOKS = [
 CI_MODE_BOOKS = ["1 Corinthians"]
 
 
+def log(message: str, flush: bool = True):
+    """Print timestamped log message and flush immediately for CI visibility."""
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    print(f"[{timestamp}] {message}", flush=flush)
+
+
 async def download_translation(translation_code: str, output_path: Path) -> dict:
     """Download Bible translation JSON."""
     config = TRANSLATIONS[translation_code]
 
     if output_path.exists():
-        print(f"📖 Loading {config['name']} from cache: {output_path}")
+        log(f"📖 Loading {config['name']} from cache: {output_path}")
         with open(output_path, encoding="utf-8") as f:
             return json.load(f)
 
-    print(f"📥 Downloading {config['name']} ({config['language']}) from {config['source']}")
-    print(f"    URL: {config['url']}")
+    log(f"📥 Downloading {config['name']} ({config['language']}) from {config['source']}")
+    log(f"    URL: {config['url']}")
 
+    start_time = time.time()
     async with httpx.AsyncClient(timeout=120.0) as client:
         response = await client.get(config["url"], follow_redirects=True)
         response.raise_for_status()
         data = response.json()
+
+    elapsed = time.time() - start_time
+    log(f"    Downloaded in {elapsed:.1f}s")
 
     # Save for future use
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
 
-    print(f"💾 Saved to: {output_path}")
+    log(f"💾 Saved to: {output_path}")
     return data
 
 
@@ -316,7 +328,7 @@ async def load_translation_metadata(session, translation_code: str):
         }
     )
     await session.commit()
-    print(f"✅ Loaded translation metadata: {config['name']} ({config['code']})")
+    log(f"✅ Loaded translation metadata: {config['name']} ({config['code']})")
 
 
 async def ensure_books_and_chapters(session) -> dict:
@@ -328,11 +340,12 @@ async def ensure_books_and_chapters(session) -> dict:
 
     if book_count == 66:
         # Books already exist, fetch IDs
+        log("📚 Books already loaded, fetching IDs...")
         result = await session.execute(text("SELECT id, name FROM books"))
         book_ids = {row[1]: row[0] for row in result.fetchall()}
         return book_ids
 
-    print("📚 Loading books and chapters (one-time setup)...")
+    log("📚 Loading books and chapters (one-time setup)...")
 
     # Insert books
     book_ids = {}
@@ -387,7 +400,7 @@ async def ensure_books_and_chapters(session) -> dict:
             )
 
     await session.commit()
-    print(f"✅ Loaded {len(book_ids)} books with chapters")
+    log(f"✅ Loaded {len(book_ids)} books with chapters")
 
     return book_ids
 
@@ -413,6 +426,9 @@ async def load_verses(session, translation_code: str, bible_data: list, books_fi
     normalized_data = normalize_bible_data(bible_data, config["source"])
 
     verse_count = 0
+    total_books = len(normalized_data)
+    books_loaded = 0
+    start_time = time.time()
 
     for book_idx, book_data in enumerate(normalized_data):
         # Get book name - handle both dict and list formats
@@ -432,14 +448,18 @@ async def load_verses(session, translation_code: str, bible_data: list, books_fi
 
         book_id = book_ids.get(standard_name)
         if not book_id:
-            print(f"  ⚠️ Unknown book: {local_name} -> {standard_name}")
+            log(f"  ⚠️ Unknown book: {local_name} -> {standard_name}")
             continue
 
         # Skip if not in filter (when filter is specified)
         if books_filter and standard_name not in books_filter:
             continue
 
-        print(f"  📖 Loading {standard_name} ({translation_code})...")
+        books_loaded += 1
+        book_verse_count = 0
+        num_chapters = len(chapters)
+
+        log(f"  📖 [{books_loaded}/{total_books}] {standard_name} ({num_chapters} chapters)...")
 
         # Get chapter IDs for this book
         chapter_result = await session.execute(
@@ -478,8 +498,13 @@ async def load_verses(session, translation_code: str, bible_data: list, books_fi
                     }
                 )
                 verse_count += 1
+                book_verse_count += 1
 
         await session.commit()
+        log(f"      ✓ {standard_name}: {book_verse_count:,} verses loaded")
+
+    elapsed = time.time() - start_time
+    log(f"  ⏱️  Completed in {elapsed:.1f}s ({verse_count:,} total verses)")
 
     return verse_count
 
@@ -500,11 +525,30 @@ def convert_db_url_for_asyncpg(database_url: str) -> str:
     return database_url
 
 
+async def check_translation_loaded(session, translation_code: str) -> tuple[bool, int]:
+    """Check if a translation is already loaded in the database.
+
+    Returns:
+        Tuple of (is_loaded, verse_count)
+    """
+    try:
+        result = await session.execute(
+            text("SELECT COUNT(*) FROM verses WHERE translation = :code"),
+            {"code": translation_code}
+        )
+        count = result.scalar() or 0
+        # Consider loaded if we have at least 30,000 verses (full Bible has ~31,000)
+        return count >= 30000, count
+    except Exception:
+        return False, 0
+
+
 async def load_translation_to_db(
     database_url: str,
     translation_code: str,
     embedding_dimensions: int = 1024,
     books_filter: list = None,
+    force: bool = False,
 ):
     """Load a specific Bible translation into the database.
 
@@ -513,6 +557,7 @@ async def load_translation_to_db(
         translation_code: Translation code (e.g., 'kjv', 'ita1927')
         embedding_dimensions: Vector dimensions (1024 for Ollama, 1536 for Azure OpenAI)
         books_filter: Optional list of book names to load (None = all books)
+        force: Force reload even if translation already exists
     """
 
     database_url = convert_db_url_for_asyncpg(database_url)
@@ -528,6 +573,14 @@ async def load_translation_to_db(
         # Ensure schema exists with correct embedding dimensions
         await ensure_schema(session, embedding_dimensions)
 
+        # Check if translation is already loaded (skip check in CI mode with filter)
+        if not force and not books_filter:
+            is_loaded, existing_count = await check_translation_loaded(session, translation_code)
+            if is_loaded:
+                log(f"⏭️  Skipping {TRANSLATIONS[translation_code]['name']} - already loaded ({existing_count:,} verses)")
+                await engine.dispose()
+                return
+
         # Load translation metadata
         await load_translation_metadata(session, translation_code)
 
@@ -540,12 +593,12 @@ async def load_translation_to_db(
 
         # Load verses
         if books_filter:
-            print(f"\n📝 Loading verses for {TRANSLATIONS[translation_code]['name']} (filtered: {', '.join(books_filter)})...")
+            log(f"📝 Loading verses for {TRANSLATIONS[translation_code]['name']} (filtered: {', '.join(books_filter)})...")
         else:
-            print(f"\n📝 Loading verses for {TRANSLATIONS[translation_code]['name']}...")
+            log(f"📝 Loading verses for {TRANSLATIONS[translation_code]['name']}...")
         verse_count = await load_verses(session, translation_code, bible_data, books_filter)
 
-        print(f"✅ Loaded {verse_count:,} verses for {translation_code}")
+        log(f"✅ Loaded {verse_count:,} verses for {translation_code}")
 
     await engine.dispose()
 
@@ -580,14 +633,19 @@ async def main():
         action="store_true",
         help="CI mode: load only 1 Corinthians (minimal data for testing semantic search)"
     )
+    parser.add_argument(
+        "--force", "-f",
+        action="store_true",
+        help="Force reload translations even if already loaded"
+    )
 
     args = parser.parse_args()
 
     # List translations and exit
     if args.list:
-        print("\n📚 Available translations:")
+        log("📚 Available translations:")
         for trans in list_available_translations():
-            print(f"  - {trans['code']:<12} {trans['name']:<30} ({trans['language']})")
+            log(f"  - {trans['code']:<12} {trans['name']:<30} ({trans['language']})")
         return
 
     # Get database URL
@@ -604,8 +662,8 @@ async def main():
         translations_to_load = list(TRANSLATIONS.keys())
     elif args.translation:
         if args.translation not in TRANSLATIONS:
-            print(f"❌ Unknown translation: {args.translation}")
-            print(f"   Available: {', '.join(TRANSLATIONS.keys())}")
+            log(f"❌ Unknown translation: {args.translation}")
+            log(f"   Available: {', '.join(TRANSLATIONS.keys())}")
             return
         translations_to_load = [args.translation]
     else:
@@ -616,25 +674,29 @@ async def main():
     books_filter = CI_MODE_BOOKS if args.ci else None
 
     # Load each translation
-    print(f"\n🗄️  Database: {database_url}")
-    print(f"📐 Embedding dimensions: {embedding_dimensions}")
-    print(f"📖 Translations to load: {', '.join(translations_to_load)}")
+    total_translations = len(translations_to_load)
+    log(f"🗄️  Database: {database_url}")
+    log(f"📐 Embedding dimensions: {embedding_dimensions}")
+    log(f"📖 Translations to load: {total_translations} ({', '.join(translations_to_load)})")
     if books_filter:
-        print(f"📚 CI mode: loading only {', '.join(books_filter)}\n")
-    else:
-        print()
+        log(f"📚 CI mode: loading only {', '.join(books_filter)}")
 
-    for trans_code in translations_to_load:
-        print(f"\n{'='*60}")
-        print(f"Loading: {TRANSLATIONS[trans_code]['name']} ({trans_code})")
-        print(f"{'='*60}")
-        await load_translation_to_db(database_url, trans_code, embedding_dimensions, books_filter)
+    if args.force:
+        log("⚠️  Force mode: will reload all translations even if they exist")
 
-    print("\n🎉 All translations loaded successfully!")
-    print("\nNext step: Run create_embeddings.py to generate semantic search vectors")
-    print("Example: python create_embeddings.py --translation ita1927")
+    overall_start = time.time()
+    for idx, trans_code in enumerate(translations_to_load, 1):
+        log(f"\n{'='*60}")
+        log(f"[{idx}/{total_translations}] Loading: {TRANSLATIONS[trans_code]['name']} ({trans_code})")
+        log(f"{'='*60}")
+        await load_translation_to_db(database_url, trans_code, embedding_dimensions, books_filter, args.force)
+
+    overall_elapsed = time.time() - overall_start
+    log(f"\n🎉 All {total_translations} translations loaded successfully in {overall_elapsed:.1f}s!")
+    log("\nNext step: Run create_embeddings.py to generate semantic search vectors")
+    log("Example: python create_embeddings.py --translation ita1927")
     if embedding_dimensions == 1536:
-        print("   (or create_azure_embeddings.py for Azure OpenAI)")
+        log("   (or create_azure_embeddings.py for Azure OpenAI)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Improves the `load_bible.py` script and workflow for better CI visibility and control.

### Progress Output
- Add timestamps to all log messages (`[HH:MM:SS]` prefix)
- Show translation progress (`[1/4] Loading: KJV...`)
- Show book progress (`[1/66] Genesis (50 chapters)...`)
- Show verse counts per book after loading
- Show elapsed time for downloads and overall process
- Flush output immediately so CI logs update in real-time

### Skip-if-Loaded Optimization
- Check if translation already exists (≥30,000 verses)
- Skip loading if already present, saving significant time
- Add `--force` flag to reload translations if needed

### New Workflow Inputs
- `force_database_seed`: Force reload even if already loaded
- `bible_translation`: Load specific translation (e.g., `kjv`, `ita1927`)

## Example Output

When translations already loaded:
```
[09:15:23] [1/4] Loading: King James Version (kjv)
[09:15:23] ⏭️  Skipping King James Version - already loaded (31,102 verses)
[09:15:23] [2/4] Loading: Italian Riveduta (ita1927)  
[09:15:23] ⏭️  Skipping Italian Riveduta - already loaded (31,086 verses)
[09:15:24] 🎉 All 4 translations loaded successfully in 1.2s\!
```

When loading fresh:
```
[09:15:23] [1/4] Loading: King James Version (kjv)
[09:15:24]   📖 [1/66] Genesis (50 chapters)...
[09:15:25]       ✓ Genesis: 1,533 verses loaded
...
```

## Manual Trigger Example

```bash
gh workflow run "Build and Deploy to Azure" \
  --ref main \
  -f skip_build=true \
  -f deploy_component=frontend \
  -f skip_database_seed=false \
  -f bible_translation=kjv \
  -f force_database_seed=true
```

## Test plan

- [ ] CI workflow test with skip-if-loaded
- [ ] CI workflow test with specific translation
- [ ] CI workflow test with force reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)