### PR TITLE
fix(scripts): Improve load_bible.py with progress output and skip-if-loaded

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -70,6 +70,11 @@ on:
         description: "Specific translation to load (e.g., 'kjv', 'ita1927'). Leave empty for all."
         required: false
         type: string
+      skip_embeddings:
+        description: "Skip embedding generation (requires Azure OpenAI)"
+        required: false
+        default: true
+        type: boolean
 
 env:
   BACKEND_APP_NAME: bible-app-backend
@@ -597,19 +602,33 @@ jobs:
           python load_bible.py $TRANSLATION_FLAG $FORCE_FLAG
 
       - name: Generate Embeddings
+        if: inputs.skip_embeddings != true
         env:
           DB_USER: ${{ secrets.TF_VAR_DB_ADMIN_USERNAME }}
           DB_PASS: ${{ secrets.TF_VAR_DB_ADMIN_PASSWORD }}
           DB_HOST: ${{ steps.db.outputs.db_host }}
           DB_NAME: ${{ secrets.TF_VAR_DB_NAME }}
-          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_EMBEDDING_DEPLOYMENT: "text-embedding-3-small"
         run: |
+          # Check if Azure OpenAI is configured
+          if [ -z "$AZURE_OPENAI_ENDPOINT" ]; then
+            echo "⏭️ Skipping embedding generation"
+            echo "   Reason: AZURE_OPENAI_ENDPOINT secret not configured"
+            exit 0
+          fi
+
           export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}?sslmode=require"
           cd scripts
           echo "Generating embeddings with Azure OpenAI..."
           python create_azure_embeddings.py
+
+      - name: Skip Embeddings Notice
+        if: inputs.skip_embeddings == true
+        run: |
+          echo "⏭️ Skipping embedding generation"
+          echo "   Reason: skip_embeddings=true"
 
       - name: Verify Database
         env:


### PR DESCRIPTION
## Summary

Improves the `load_bible.py` script and workflow for better CI visibility and control.

### Progress Output
- Add timestamps to all log messages (`[HH:MM:SS]` prefix)
- Show translation progress (`[1/4] Loading: KJV...`)
- Show book progress (`[1/66] Genesis (50 chapters)...`)
- Show verse counts per book after loading
- Show elapsed time for downloads and overall process
- Flush output immediately so CI logs update in real-time

### Skip-if-Loaded Optimization
- Check if translation already exists (≥30,000 verses)
- Skip loading if already present, saving significant time
- Add `--force` flag to reload translations if needed

### New Workflow Inputs
| Input | Description | Default |
|-------|-------------|---------|
| `skip_database_seed` | Skip database seeding entirely | `true` |
| `force_database_seed` | Force reload even if already loaded | `false` |
| `bible_translation` | Specific translation to load | empty (all) |
| `skip_embeddings` | Skip embedding generation | `true` |

### Embedding Configuration
- Uses `vars.AZURE_OPENAI_ENDPOINT` (environment variable)
- Uses `secrets.AZURE_OPENAI_API_KEY` (secret)
- Skips gracefully if not configured

## Test Command

```bash
gh workflow run "Build and Deploy to Azure" \
  -f skip_build=true \
  -f skip_database_seed=false \
  -f skip_embeddings=false \
  -f bible_translation=kjv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)