### PR TITLE
fix(ci): Respect skip_build flag in workflow_dispatch

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -111,7 +111,7 @@ jobs:
   build-backend:
     needs: changes
     if: |
-      (needs.changes.outputs.backend == 'true') ||
+      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.backend == 'true') ||
       (github.event_name == 'workflow_dispatch' &&
        inputs.skip_build != true &&
        (inputs.deploy_component == 'both' || inputs.deploy_component == 'backend'))
@@ -168,7 +168,7 @@ jobs:
   build-frontend:
     needs: changes
     if: |
-      (needs.changes.outputs.frontend == 'true') ||
+      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.frontend == 'true') ||
       (github.event_name == 'workflow_dispatch' &&
        inputs.skip_build != true &&
        (inputs.deploy_component == 'both' || inputs.deploy_component == 'frontend'))


### PR DESCRIPTION
## Summary
- Fixed `skip_build=true` being ignored when file changes were detected
- Fixed `skip_build=true` without `image_tag` failing instead of using deployed images

## Problem 1: skip_build ignored
The build job conditions checked for file changes first, ignoring `skip_build`:
```yaml
if: |
  (needs.changes.outputs.backend == 'true') ||  # <-- runs anyway if files changed\!
  (github.event_name == 'workflow_dispatch' && inputs.skip_build \!= true && ...)
```

## Problem 2: skip_build without image_tag fails
When `skip_build=true` without providing an `image_tag`, the workflow tried to use the current commit SHA as the image tag - which doesn't exist because nothing was built.

## Fixes

### Fix 1: Respect skip_build flag
Only consider file changes for non-workflow_dispatch events:
```yaml
if: |
  (github.event_name \!= 'workflow_dispatch' && needs.changes.outputs.backend == 'true') ||
  (github.event_name == 'workflow_dispatch' && inputs.skip_build \!= true && ...)
```

### Fix 2: Three modes for image selection
1. **skip_build=true without image_tag**: use currently deployed images
2. **skip_build=true with image_tag**: verify and use specified tag
3. **Normal build**: use new images for built components

## Test plan
- [ ] `skip_build=true` without `image_tag` - should use deployed images
- [ ] `skip_build=true` with `image_tag` - should verify and use that tag
- [ ] `skip_build=false` - should build and deploy new images
- [ ] Push to main with file changes - should build normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)