### PR TITLE
fix(ci): Fix seed-database job being skipped when skip_build=true

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -306,11 +306,13 @@ jobs:
     # Deploy if:
     # - At least one build succeeded AND neither failed (normal flow), OR
     # - Manual trigger with skip_build=true (deploy existing images)
+    # Note: always() must wrap entire condition to evaluate when builds are skipped
     if: >-
-      always() && github.event_name != 'pull_request' && ((needs.build-backend.result == 'success' ||
-      needs.build-frontend.result == 'success') &&
-       needs.build-backend.result != 'failure' && needs.build-frontend.result != 'failure') ||
-      (github.event_name == 'workflow_dispatch' && inputs.skip_build == true)
+      always() && github.event_name != 'pull_request' && (
+        ((needs.build-backend.result == 'success' || needs.build-frontend.result == 'success') &&
+         needs.build-backend.result != 'failure' && needs.build-frontend.result != 'failure') ||
+        (inputs.skip_build == true)
+      )
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -543,9 +545,14 @@ jobs:
   # ---------------------------------------------------------------------------
   seed-database:
     needs: [changes, deploy]
+    # Run if:
+    # - Scripts changed (auto-trigger), OR
+    # - Manual trigger with skip_database_seed=false
+    # Note: always() needed to evaluate when deploy is skipped, but only run if deploy didn't fail
     if: >-
-      github.event_name != 'pull_request' && ((needs.changes.outputs.scripts == 'true') ||
-       (github.event_name == 'workflow_dispatch' && inputs.skip_database_seed != true))
+      always() && github.event_name != 'pull_request' && needs.deploy.result != 'failure' &&
+      ((needs.changes.outputs.scripts == 'true') ||
+       (github.event_name == 'workflow_dispatch' && inputs.skip_database_seed == false))
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
## Summary
- Fixed seed-database job being skipped when `skip_build=true`
- Fixed deploy job condition operator precedence

## Problem
When running workflow with `skip_build=true` and `skip_database_seed=false`, the seed-database job was skipped because:

1. **Deploy job**: The `always()` didn't cover the skip_build condition due to operator precedence:
   ```yaml
   # Before: always() only applies to first part of OR
   always() && ... || (inputs.skip_build == true)
   ```

2. **Seed-database job**: No `always()` meant it was auto-skipped when deploy was skipped

## Fix

### Deploy job
Wrapped entire condition so `always()` applies to everything:
```yaml
always() && github.event_name \!= 'pull_request' && (
  (...build conditions...) ||
  (inputs.skip_build == true)
)
```

### Seed-database job
Added `always()` and explicit boolean check:
```yaml
always() && github.event_name \!= 'pull_request' &&
needs.deploy.result \!= 'failure' &&
(... || inputs.skip_database_seed == false)
```

## Test plan
- [ ] Run with `skip_build=true`, `skip_database_seed=false` - seed-database should run
- [ ] Run with `skip_build=true`, `skip_database_seed=true` - seed-database should be skipped
- [ ] Normal push - should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)