### PR TITLE
fix(ci): Skip Azure deploy workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -110,11 +110,14 @@ jobs:
   # ---------------------------------------------------------------------------
   build-backend:
     needs: changes
+    # Skip for Dependabot PRs (no access to secrets) and apply normal build logic
     if: |
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.backend == 'true') ||
-      (github.event_name == 'workflow_dispatch' &&
-       inputs.skip_build != true &&
-       (inputs.deploy_component == 'both' || inputs.deploy_component == 'backend'))
+      github.actor != 'dependabot[bot]' && (
+        (github.event_name != 'workflow_dispatch' && needs.changes.outputs.backend == 'true') ||
+        (github.event_name == 'workflow_dispatch' &&
+         inputs.skip_build != true &&
+         (inputs.deploy_component == 'both' || inputs.deploy_component == 'backend'))
+      )
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
@@ -167,11 +170,14 @@ jobs:
   # ---------------------------------------------------------------------------
   build-frontend:
     needs: changes
+    # Skip for Dependabot PRs (no access to secrets) and apply normal build logic
     if: |
-      (github.event_name != 'workflow_dispatch' && needs.changes.outputs.frontend == 'true') ||
-      (github.event_name == 'workflow_dispatch' &&
-       inputs.skip_build != true &&
-       (inputs.deploy_component == 'both' || inputs.deploy_component == 'frontend'))
+      github.actor != 'dependabot[bot]' && (
+        (github.event_name != 'workflow_dispatch' && needs.changes.outputs.frontend == 'true') ||
+        (github.event_name == 'workflow_dispatch' &&
+         inputs.skip_build != true &&
+         (inputs.deploy_component == 'both' || inputs.deploy_component == 'frontend'))
+      )
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
- Skip Azure build/deploy jobs for Dependabot PRs since they can't access secrets

## Problem
Dependabot PRs show as "failing" because:
1. Azure deploy workflow runs on PRs
2. Build jobs try to "Login to Azure"
3. Dependabot PRs don't have access to repository secrets
4. Jobs fail, making the entire PR appear failed

Meanwhile, the actual tests (CI/CD - Test Application) all pass.

## Fix
Added `github.actor \!= 'dependabot[bot]'` condition to `build-backend` and `build-frontend` jobs so they are skipped for Dependabot PRs.

The test workflow still runs and validates code changes.

## Impact
After merging, Dependabot PRs will show their true status based on actual test results, not deploy failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)