### PR TITLE
test(coverage): Add tests for chat, routes, and main (88% -> 93%)

### DIFF
--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -1,0 +1,788 @@
+"""
+Tests for chat service and prompts modules.
+
+Coverage targets:
+- chat/prompts.py: get_system_prompt, get_verse_lookup_prompt, get_prayer_lookup_prompt,
+  build_search_context_prompt, build_conversation_context, detect_intent_prompt
+- chat/service.py: ChatService.chat, chat_stream, _search_scripture,
+  _lookup_direct_verses, _merge_direct_verses, _determine_prompt_type, _build_messages,
+  get_verse_context
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chat.prompts import (
+    LANGUAGE_NAMES,
+    SYSTEM_PROMPT,
+    build_conversation_context,
+    build_search_context_prompt,
+    detect_intent_prompt,
+    get_prayer_lookup_prompt,
+    get_system_prompt,
+    get_verse_lookup_prompt,
+)
+from chat.service import (
+    ChatRequest,
+    ChatResponse,
+    ChatService,
+    ConversationMessage,
+)
+from providers import LLMResponse
+from scripture.search import SearchResults, VerseResult
+
+# ==================== Prompts Tests ====================
+
+
+class TestGetSystemPrompt:
+    """Tests for get_system_prompt()."""
+
+    def test_english_default(self):
+        result = get_system_prompt()
+        assert "respond in English" in result.lower() or "writing in English" in result
+
+    def test_english_explicit(self):
+        result = get_system_prompt("en")
+        assert "The user is writing in English" in result
+
+    def test_italian(self):
+        result = get_system_prompt("it")
+        assert "Italian" in result
+        assert "You MUST respond entirely in" in result
+        assert "Do not switch to English" in result
+
+    def test_german(self):
+        result = get_system_prompt("de")
+        assert "German" in result
+        assert "You MUST respond entirely in" in result
+
+    def test_spanish(self):
+        result = get_system_prompt("es")
+        assert "Spanish" in result
+
+    def test_french(self):
+        result = get_system_prompt("fr")
+        assert "French" in result
+
+    def test_portuguese(self):
+        result = get_system_prompt("pt")
+        assert "Portuguese" in result
+
+    def test_unknown_language_falls_back(self):
+        result = get_system_prompt("xx")
+        # Should still produce a valid prompt (falls back to English name)
+        assert "language_instruction" not in result
+        assert len(result) > 100
+
+    def test_contains_template_content(self):
+        result = get_system_prompt("en")
+        assert "compassionate spiritual companion" in result
+        assert "Scripture Context" in result or "scripture" in result.lower()
+
+
+class TestGetVerseLookupPrompt:
+    """Tests for get_verse_lookup_prompt()."""
+
+    def test_english_default(self):
+        result = get_verse_lookup_prompt()
+        assert "writing in English" in result
+
+    def test_english_explicit(self):
+        result = get_verse_lookup_prompt("en")
+        assert "writing in English" in result
+
+    def test_non_english(self):
+        result = get_verse_lookup_prompt("it")
+        assert "Italian" in result
+        assert "You MUST respond entirely in" in result
+
+    def test_contains_verse_content(self):
+        result = get_verse_lookup_prompt("en")
+        assert "Bible study companion" in result or "Bible verse" in result.lower()
+
+
+class TestGetPrayerLookupPrompt:
+    """Tests for get_prayer_lookup_prompt()."""
+
+    def test_english_default(self):
+        result = get_prayer_lookup_prompt()
+        assert "writing in English" in result
+
+    def test_english_explicit(self):
+        result = get_prayer_lookup_prompt("en")
+        assert "writing in English" in result
+
+    def test_non_english(self):
+        result = get_prayer_lookup_prompt("de")
+        assert "German" in result
+        assert "You MUST respond entirely in" in result
+
+    def test_contains_prayer_content(self):
+        result = get_prayer_lookup_prompt("en")
+        assert "prayer" in result.lower()
+
+
+class TestBuildSearchContextPrompt:
+    """Tests for build_search_context_prompt()."""
+
+    def test_with_verses(self):
+        results = {
+            "verses": [{"reference": "John 3:16", "text": "For God so loved the world..."}],
+            "passages": [],
+        }
+        result = build_search_context_prompt(results)
+        assert "Scripture Context" in result
+        assert "John 3:16" in result
+        assert "For God so loved the world" in result
+        assert "verified biblical texts" in result
+
+    def test_with_passages(self):
+        results = {
+            "verses": [],
+            "passages": [
+                {
+                    "title": "The Lord's Prayer",
+                    "reference": "Matthew 6:9-13",
+                    "text": "Our Father, who art in heaven...",
+                }
+            ],
+        }
+        result = build_search_context_prompt(results)
+        assert "Scripture Context" in result
+        assert "The Lord's Prayer" in result
+        assert "Matthew 6:9-13" in result
+
+    def test_with_both_verses_and_passages(self):
+        results = {
+            "verses": [{"reference": "John 3:16", "text": "For God so loved the world..."}],
+            "passages": [
+                {
+                    "title": "The Lord's Prayer",
+                    "reference": "Matthew 6:9-13",
+                    "text": "Our Father...",
+                }
+            ],
+        }
+        result = build_search_context_prompt(results)
+        assert "John 3:16" in result
+        assert "The Lord's Prayer" in result
+
+    def test_empty_results(self):
+        results = {"verses": [], "passages": []}
+        result = build_search_context_prompt(results)
+        assert "No specific Bible verses were found" in result
+
+    def test_no_keys(self):
+        result = build_search_context_prompt({})
+        assert "No specific Bible verses were found" in result
+
+    def test_long_passage_truncated(self):
+        long_text = "x" * 1000
+        results = {
+            "verses": [],
+            "passages": [
+                {
+                    "title": "Long Passage",
+                    "reference": "Genesis 1:1-31",
+                    "text": long_text,
+                }
+            ],
+        }
+        result = build_search_context_prompt(results)
+        assert "..." in result
+        # Should not contain the full 1000-char text
+        assert long_text not in result
+
+    def test_passage_under_500_not_truncated(self):
+        short_text = "x" * 499
+        results = {
+            "verses": [],
+            "passages": [
+                {
+                    "title": "Short Passage",
+                    "reference": "Genesis 1:1",
+                    "text": short_text,
+                }
+            ],
+        }
+        result = build_search_context_prompt(results)
+        assert short_text in result
+
+
+class TestBuildConversationContext:
+    """Tests for build_conversation_context()."""
+
+    def test_empty_messages(self):
+        result = build_conversation_context([])
+        assert result == ""
+
+    def test_single_message(self):
+        messages = [{"role": "user", "content": "Hello"}]
+        result = build_conversation_context(messages)
+        assert "Conversation Context" in result
+        assert "**User**: Hello" in result
+
+    def test_user_and_assistant(self):
+        messages = [
+            {"role": "user", "content": "Help me"},
+            {"role": "assistant", "content": "I'd be happy to help"},
+        ]
+        result = build_conversation_context(messages)
+        assert "**User**: Help me" in result
+        assert "**Assistant**: I'd be happy to help" in result
+
+    def test_long_message_truncated(self):
+        long_content = "x" * 300
+        messages = [{"role": "user", "content": long_content}]
+        result = build_conversation_context(messages)
+        assert "..." in result
+        assert long_content not in result
+
+    def test_keeps_last_six_messages(self):
+        messages = [{"role": "user", "content": f"Message {i}"} for i in range(10)]
+        result = build_conversation_context(messages)
+        # Should only have the last 6 messages
+        assert "Message 4" in result
+        assert "Message 9" in result
+        # Should not have the first 4 messages
+        assert "Message 0" not in result
+        assert "Message 3" not in result
+
+    def test_message_under_200_not_truncated(self):
+        content = "x" * 199
+        messages = [{"role": "user", "content": content}]
+        result = build_conversation_context(messages)
+        assert content in result
+
+
+class TestDetectIntentPrompt:
+    """Tests for detect_intent_prompt()."""
+
+    def test_generates_prompt(self):
+        result = detect_intent_prompt("I am feeling sad")
+        assert "I am feeling sad" in result
+        assert "COMFORT" in result
+        assert "GUIDANCE" in result
+        assert "CURIOSITY" in result
+        assert "VERSE_LOOKUP" in result
+        assert "GENERAL" in result
+
+    def test_prompt_asks_for_category(self):
+        result = detect_intent_prompt("test message")
+        assert "category" in result.lower()
+
+
+class TestLanguageNames:
+    """Tests for LANGUAGE_NAMES constant."""
+
+    def test_has_expected_languages(self):
+        assert "en" in LANGUAGE_NAMES
+        assert "it" in LANGUAGE_NAMES
+        assert "de" in LANGUAGE_NAMES
+        assert "es" in LANGUAGE_NAMES
+        assert "fr" in LANGUAGE_NAMES
+        assert "pt" in LANGUAGE_NAMES
+
+
+class TestSystemPromptConstant:
+    """Tests for the SYSTEM_PROMPT constant (backward compat)."""
+
+    def test_system_prompt_is_english(self):
+        assert "writing in English" in SYSTEM_PROMPT
+
+
+# ==================== Chat Service Tests ====================
+
+
+def _make_chat_service():
+    """Create a ChatService with mocked dependencies."""
+    db_session = AsyncMock()
+    llm_provider = AsyncMock()
+    llm_provider.provider_name = "test-provider"
+    embedding_provider = AsyncMock()
+    embedding_provider.embed = AsyncMock()
+
+    service = ChatService(db_session, llm_provider, embedding_provider)
+    return service, llm_provider, embedding_provider
+
+
+class TestChatServiceDeterminePromptType:
+    """Tests for ChatService._determine_prompt_type()."""
+
+    def test_default_type(self):
+        service, _, _ = _make_chat_service()
+        result = service._determine_prompt_type(False, None)
+        assert result == "default"
+
+    def test_verse_lookup_type(self):
+        service, _, _ = _make_chat_service()
+        result = service._determine_prompt_type(True, None)
+        assert result == "verse_lookup"
+
+    def test_prayer_lookup_type(self):
+        service, _, _ = _make_chat_service()
+        prayer_ref = MagicMock()
+        prayer_ref.name = "Lord's Prayer"
+        result = service._determine_prompt_type(True, prayer_ref)
+        assert result == "prayer_lookup"
+
+    def test_prayer_ref_without_verse_lookup(self):
+        service, _, _ = _make_chat_service()
+        prayer_ref = MagicMock()
+        result = service._determine_prompt_type(False, prayer_ref)
+        assert result == "default"
+
+
+class TestChatServiceBuildMessages:
+    """Tests for ChatService._build_messages()."""
+
+    def test_default_prompt(self):
+        service, _, _ = _make_chat_service()
+        messages = service._build_messages(
+            user_message="Hello",
+            history=[],
+        )
+        assert len(messages) == 2  # system + user
+        assert messages[0].role == "system"
+        assert messages[-1].role == "user"
+        assert messages[-1].content == "Hello"
+
+    def test_with_history(self):
+        service, _, _ = _make_chat_service()
+        history = [
+            ConversationMessage(role="user", content="First message"),
+            ConversationMessage(role="assistant", content="First response"),
+        ]
+        messages = service._build_messages(
+            user_message="Second message",
+            history=history,
+        )
+        # system + 2 history + user
+        assert len(messages) == 4
+        assert messages[1].content == "First message"
+        assert messages[2].content == "First response"
+        assert messages[3].content == "Second message"
+
+    def test_with_search_context(self):
+        service, _, _ = _make_chat_service()
+        messages = service._build_messages(
+            user_message="Hello",
+            history=[],
+            search_context="## Scripture Context\nSome verses here",
+        )
+        system_msg = messages[0]
+        assert "Scripture Context" in system_msg.content
+
+    def test_verse_lookup_prompt_type(self):
+        service, _, _ = _make_chat_service()
+        messages = service._build_messages(
+            user_message="Tell me about John 3:16",
+            history=[],
+            prompt_type="verse_lookup",
+        )
+        system_msg = messages[0]
+        assert (
+            "Bible study companion" in system_msg.content
+            or "Bible verse" in system_msg.content.lower()
+        )
+
+    def test_prayer_lookup_prompt_type(self):
+        service, _, _ = _make_chat_service()
+        messages = service._build_messages(
+            user_message="Tell me about the Hail Mary",
+            history=[],
+            prompt_type="prayer_lookup",
+        )
+        system_msg = messages[0]
+        assert "prayer" in system_msg.content.lower()
+
+    def test_non_english_language(self):
+        service, _, _ = _make_chat_service()
+        messages = service._build_messages(
+            user_message="Ciao",
+            history=[],
+            language_code="it",
+        )
+        system_msg = messages[0]
+        assert "Italian" in system_msg.content
+
+
+class TestChatServiceMergeDirectVerses:
+    """Tests for ChatService._merge_direct_verses()."""
+
+    def test_merge_new_verses(self):
+        service, _, _ = _make_chat_service()
+        context = SearchResults(
+            query="test",
+            verses=[
+                VerseResult(
+                    reference="John 3:16",
+                    text="For God so loved...",
+                    book="John",
+                    chapter=3,
+                    verse=16,
+                )
+            ],
+            passages=[],
+        )
+        direct_verses = [
+            VerseResult(
+                reference="Genesis 1:1",
+                text="In the beginning...",
+                book="Genesis",
+                chapter=1,
+                verse=1,
+            )
+        ]
+        service._merge_direct_verses(context, direct_verses)
+        assert len(context.verses) == 2
+        # Direct verse should be at the beginning
+        assert context.verses[0].reference == "Genesis 1:1"
+
+    def test_no_duplicates(self):
+        service, _, _ = _make_chat_service()
+        context = SearchResults(
+            query="test",
+            verses=[
+                VerseResult(
+                    reference="John 3:16",
+                    text="For God so loved...",
+                    book="John",
+                    chapter=3,
+                    verse=16,
+                )
+            ],
+            passages=[],
+        )
+        # Same verse as already in context
+        direct_verses = [
+            VerseResult(
+                reference="John 3:16",
+                text="For God so loved...",
+                book="John",
+                chapter=3,
+                verse=16,
+            )
+        ]
+        service._merge_direct_verses(context, direct_verses)
+        assert len(context.verses) == 1
+
+    def test_empty_direct_verses(self):
+        service, _, _ = _make_chat_service()
+        context = SearchResults(
+            query="test",
+            verses=[],
+            passages=[],
+        )
+        service._merge_direct_verses(context, [])
+        assert len(context.verses) == 0
+
+    def test_none_context(self):
+        service, _, _ = _make_chat_service()
+        # Should not raise
+        service._merge_direct_verses(
+            None,
+            [VerseResult(reference="Gen 1:1", text="test", book="Genesis", chapter=1, verse=1)],
+        )
+
+
+class TestChatServiceChat:
+    """Tests for ChatService.chat()."""
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.get_translation_info", return_value={"code": "kjv", "name": "KJV"})
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_basic(
+        self, mock_extract, mock_is_verse, mock_trans_info, mock_resolve, mock_detect
+    ):
+        service, llm, embedding = _make_chat_service()
+
+        # Mock search service
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+
+        # Mock LLM response
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(
+                content="God loves you!",
+                provider="test",
+                model="test-model",
+            )
+        )
+
+        request = ChatRequest(message="I need encouragement")
+        response = await service.chat(request)
+
+        assert isinstance(response, ChatResponse)
+        assert response.message == "God loves you!"
+        assert response.provider == "test"
+        assert response.model == "test-model"
+        assert response.message_id  # Should be a UUID string
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.get_translation_info", return_value=None)
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_llm_error(
+        self, mock_extract, mock_is_verse, mock_trans_info, mock_resolve, mock_detect
+    ):
+        service, llm, _ = _make_chat_service()
+
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+
+        llm.chat = AsyncMock(side_effect=Exception("LLM connection failed"))
+
+        request = ChatRequest(message="Help me")
+        with pytest.raises(Exception, match="LLM connection failed"):
+            await service.chat(request)
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.get_translation_info", return_value=None)
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_search_disabled(
+        self, mock_extract, mock_is_verse, mock_trans_info, mock_resolve, mock_detect
+    ):
+        service, llm, _ = _make_chat_service()
+
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="Response", provider="test", model="m")
+        )
+
+        request = ChatRequest(message="Hello", include_search=False)
+        response = await service.chat(request)
+
+        assert response.scripture_context is None
+
+
+class TestChatServiceSearchScripture:
+    """Tests for ChatService._search_scripture()."""
+
+    @pytest.mark.asyncio
+    async def test_search_disabled(self):
+        service, _, _ = _make_chat_service()
+        request = ChatRequest(message="Hello", include_search=False)
+        context, prompt = await service._search_scripture(request, "kjv", [], False)
+        assert context is None
+        assert prompt == ""
+
+    @pytest.mark.asyncio
+    async def test_search_with_results(self):
+        service, _, embedding = _make_chat_service()
+        service.search_service = AsyncMock()
+        search_result = SearchResults(
+            query="test",
+            verses=[
+                VerseResult(
+                    reference="John 3:16",
+                    text="For God so loved the world...",
+                    book="John",
+                    chapter=3,
+                    verse=16,
+                )
+            ],
+            passages=[],
+        )
+        service.search_service.search = AsyncMock(return_value=search_result)
+
+        request = ChatRequest(message="love")
+        context, prompt = await service._search_scripture(request, "kjv", [], False)
+        assert context is not None
+        assert len(context.verses) == 1
+        assert "Scripture Context" in prompt
+
+    @pytest.mark.asyncio
+    async def test_search_exception_returns_none(self):
+        service, _, embedding = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(side_effect=Exception("DB error"))
+
+        request = ChatRequest(message="test")
+        context, prompt = await service._search_scripture(request, "kjv", [], False)
+        assert context is None
+        assert prompt == ""
+
+
+class TestChatServiceLookupDirectVerses:
+    """Tests for ChatService._lookup_direct_verses()."""
+
+    @pytest.mark.asyncio
+    async def test_empty_refs(self):
+        service, _, _ = _make_chat_service()
+        result = await service._lookup_direct_verses([], "kjv")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_single_verse_ref(self):
+        service, _, _ = _make_chat_service()
+        ref = MagicMock()
+        ref.book = "John"
+        ref.chapter = 3
+        ref.verse_start = 16
+        ref.verse_end = None
+
+        verse = VerseResult(
+            reference="John 3:16",
+            text="For God so loved...",
+            book="John",
+            chapter=3,
+            verse=16,
+        )
+        service.search_service = AsyncMock()
+        service.search_service.get_verse = AsyncMock(return_value=verse)
+
+        result = await service._lookup_direct_verses([ref], "kjv")
+        assert len(result) == 1
+        assert result[0].reference == "John 3:16"
+
+    @pytest.mark.asyncio
+    async def test_verse_range_ref(self):
+        service, _, _ = _make_chat_service()
+        ref = MagicMock()
+        ref.book = "Genesis"
+        ref.chapter = 1
+        ref.verse_start = 1
+        ref.verse_end = 3
+
+        verses = [
+            VerseResult(
+                reference=f"Genesis 1:{i}", text=f"Verse {i}", book="Genesis", chapter=1, verse=i
+            )
+            for i in range(1, 4)
+        ]
+        service.search_service = AsyncMock()
+        service.search_service.get_verse_range = AsyncMock(return_value=verses)
+
+        result = await service._lookup_direct_verses([ref], "kjv")
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_verse_not_found(self):
+        service, _, _ = _make_chat_service()
+        ref = MagicMock()
+        ref.book = "NotABook"
+        ref.chapter = 1
+        ref.verse_start = 1
+        ref.verse_end = None
+
+        service.search_service = AsyncMock()
+        service.search_service.get_verse = AsyncMock(return_value=None)
+
+        result = await service._lookup_direct_verses([ref], "kjv")
+        assert result == []
+
+
+class TestChatServiceChatStream:
+    """Tests for ChatService.chat_stream()."""
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_stream_yields_chunks(
+        self, mock_extract, mock_is_verse, mock_resolve, mock_detect
+    ):
+        service, llm, _ = _make_chat_service()
+
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+
+        async def mock_stream(*args, **kwargs):
+            yield "Hello "
+            yield "world!"
+
+        llm.chat_stream = mock_stream
+
+        request = ChatRequest(message="Hi")
+        chunks = []
+        async for chunk in service.chat_stream(request):
+            chunks.append(chunk)
+
+        assert chunks == ["Hello ", "world!"]
+
+
+class TestChatServiceGetVerseContext:
+    """Tests for ChatService.get_verse_context()."""
+
+    @pytest.mark.asyncio
+    async def test_get_verse_context(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+
+        mock_verses = [
+            VerseResult(reference=f"John 3:{v}", text=f"Verse {v}", book="John", chapter=3, verse=v)
+            for v in range(14, 19)
+        ]
+        service.search_service.get_context = AsyncMock(return_value=mock_verses)
+
+        result = await service.get_verse_context("John", 3, 16)
+        assert result["target_verse"] == 16
+        assert len(result["verses"]) == 5
+
+
+class TestChatRequestModel:
+    """Tests for ChatRequest Pydantic model."""
+
+    def test_valid_request(self):
+        req = ChatRequest(message="Hello")
+        assert req.message == "Hello"
+        assert req.include_search is True
+        assert req.conversation_history == []
+
+    def test_message_strip(self):
+        req = ChatRequest(message="  Hello  ")
+        assert req.message == "Hello"
+
+    def test_empty_message_fails(self):
+        with pytest.raises(Exception):
+            ChatRequest(message="   ")
+
+    def test_with_history(self):
+        req = ChatRequest(
+            message="Hello",
+            conversation_history=[
+                ConversationMessage(role="user", content="First msg"),
+            ],
+        )
+        assert len(req.conversation_history) == 1
+
+    def test_with_session_id(self):
+        req = ChatRequest(message="Hello", session_id="abc-123")
+        assert req.session_id == "abc-123"
+
+    def test_invalid_session_id(self):
+        with pytest.raises(Exception):
+            ChatRequest(message="Hello", session_id="invalid id with spaces!!")
+
+    def test_with_preferred_translation(self):
+        req = ChatRequest(message="Hello", preferred_translation="kjv")
+        assert req.preferred_translation == "kjv"
+
+
+class TestConversationMessage:
+    """Tests for ConversationMessage Pydantic model."""
+
+    def test_user_message(self):
+        msg = ConversationMessage(role="user", content="Hello")
+        assert msg.role == "user"
+        assert msg.content == "Hello"
+
+    def test_assistant_message(self):
+        msg = ConversationMessage(role="assistant", content="Hi there")
+        assert msg.role == "assistant"

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -1,0 +1,1127 @@
+"""
+Tests for routes (chat, health, scripture, feedback) and main.py.
+
+Coverage targets:
+- routes/chat.py: chat, chat_stream, get_verse_context
+- routes/health.py: check_database_health, check_llm_health, check_embedding_health,
+  get_memory_info, health_check, liveness_probe, readiness_probe
+- routes/scripture.py: get_translations, get_books, get_verse, get_chapter,
+  get_verse_range, search_scripture, search_text, get_stats
+- routes/feedback.py: submit_feedback, submit_contact
+- main.py: lifespan, root, config, debug_embeddings, provider_error_handler, _get_cors_origins
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from providers import EmbeddingResponse, ProviderError
+
+# ==================== Health Route Tests ====================
+
+
+class TestCheckDatabaseHealth:
+    """Tests for check_database_health()."""
+
+    @pytest.mark.asyncio
+    @patch("routes.health.async_session_factory")
+    async def test_healthy(self, mock_factory):
+        from routes.health import check_database_health
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = 1
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_factory.return_value = mock_session
+
+        result = await check_database_health()
+        assert result.status == "healthy"
+        assert result.latency_ms is not None
+
+    @pytest.mark.asyncio
+    @patch("routes.health.async_session_factory")
+    async def test_timeout(self, mock_factory):
+        import asyncio
+
+        from routes.health import check_database_health
+
+        mock_session = AsyncMock()
+
+        async def slow_execute(*args, **kwargs):
+            await asyncio.sleep(100)
+
+        mock_session.execute = slow_execute
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_factory.return_value = mock_session
+
+        with patch("routes.health.settings") as mock_settings:
+            mock_settings.health_check_timeout = 0.001
+            result = await check_database_health()
+
+        assert result.status == "unhealthy"
+        assert "timed out" in result.error
+
+    @pytest.mark.asyncio
+    @patch("routes.health.async_session_factory")
+    async def test_exception(self, mock_factory):
+        from routes.health import check_database_health
+
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=ConnectionError("Connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_factory.return_value = mock_session
+
+        result = await check_database_health()
+        assert result.status == "unhealthy"
+        assert result.error is not None
+        assert result.latency_ms is not None
+
+
+class TestCheckLlmHealth:
+    """Tests for check_llm_health()."""
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_llm_provider")
+    async def test_healthy(self, mock_get_provider, mock_settings):
+        from routes.health import check_llm_health
+
+        mock_settings.health_check_timeout = 5.0
+        provider = AsyncMock()
+        provider.provider_name = "ollama"
+        provider.health_check = AsyncMock(return_value=True)
+        mock_get_provider.return_value = provider
+
+        result = await check_llm_health()
+        assert result.status == "healthy"
+        assert result.details["provider"] == "ollama"
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_llm_provider")
+    async def test_unhealthy(self, mock_get_provider, mock_settings):
+        from routes.health import check_llm_health
+
+        mock_settings.health_check_timeout = 5.0
+        provider = AsyncMock()
+        provider.provider_name = "ollama"
+        provider.health_check = AsyncMock(return_value=False)
+        mock_get_provider.return_value = provider
+
+        result = await check_llm_health()
+        assert result.status == "unhealthy"
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_llm_provider")
+    async def test_timeout(self, mock_get_provider, mock_settings):
+        import asyncio
+
+        from routes.health import check_llm_health
+
+        mock_settings.health_check_timeout = 0.001
+        mock_settings.llm_provider = "ollama"
+
+        async def slow_check():
+            await asyncio.sleep(100)
+            return True
+
+        provider = AsyncMock()
+        provider.health_check = slow_check
+        mock_get_provider.return_value = provider
+
+        result = await check_llm_health()
+        assert result.status == "unhealthy"
+        assert "timed out" in result.error
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_llm_provider")
+    async def test_provider_error(self, mock_get_provider, mock_settings):
+        from routes.health import check_llm_health
+
+        mock_settings.health_check_timeout = 5.0
+        mock_settings.llm_provider = "ollama"
+        provider = AsyncMock()
+        provider.health_check = AsyncMock(side_effect=ProviderError("Provider down"))
+        mock_get_provider.return_value = provider
+
+        result = await check_llm_health()
+        assert result.status == "unhealthy"
+        assert "Provider down" in result.error
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_llm_provider")
+    async def test_generic_exception(self, mock_get_provider, mock_settings):
+        from routes.health import check_llm_health
+
+        mock_settings.health_check_timeout = 5.0
+        mock_settings.llm_provider = "ollama"
+        provider = AsyncMock()
+        provider.health_check = AsyncMock(side_effect=RuntimeError("unexpected"))
+        mock_get_provider.return_value = provider
+
+        result = await check_llm_health()
+        assert result.status == "unhealthy"
+        assert "unexpected" in result.error
+
+
+class TestCheckEmbeddingHealth:
+    """Tests for check_embedding_health()."""
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_embedding_provider")
+    async def test_healthy(self, mock_get_provider, mock_settings):
+        from routes.health import check_embedding_health
+
+        mock_settings.health_check_timeout = 5.0
+        provider = AsyncMock()
+        provider.provider_name = "ollama"
+        provider.embed = AsyncMock(
+            return_value=EmbeddingResponse(embedding=[0.1] * 1024, provider="ollama", model="mxbai")
+        )
+        mock_get_provider.return_value = provider
+
+        result = await check_embedding_health()
+        assert result.status == "healthy"
+        assert result.details["dimensions"] == 1024
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_embedding_provider")
+    async def test_timeout(self, mock_get_provider, mock_settings):
+        import asyncio
+
+        from routes.health import check_embedding_health
+
+        mock_settings.health_check_timeout = 0.001
+        mock_settings.embedding_provider = "ollama"
+
+        async def slow_embed(text):
+            await asyncio.sleep(100)
+
+        provider = AsyncMock()
+        provider.embed = slow_embed
+        mock_get_provider.return_value = provider
+
+        result = await check_embedding_health()
+        assert result.status == "unhealthy"
+        assert "timed out" in result.error
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_embedding_provider")
+    async def test_provider_error(self, mock_get_provider, mock_settings):
+        from routes.health import check_embedding_health
+
+        mock_settings.health_check_timeout = 5.0
+        mock_settings.embedding_provider = "ollama"
+        provider = AsyncMock()
+        provider.embed = AsyncMock(side_effect=ProviderError("Embedding down"))
+        mock_get_provider.return_value = provider
+
+        result = await check_embedding_health()
+        assert result.status == "unhealthy"
+        assert "Embedding down" in result.error
+
+    @pytest.mark.asyncio
+    @patch("routes.health.settings")
+    @patch("routes.health.get_embedding_provider")
+    async def test_generic_exception(self, mock_get_provider, mock_settings):
+        from routes.health import check_embedding_health
+
+        mock_settings.health_check_timeout = 5.0
+        mock_settings.embedding_provider = "ollama"
+        provider = AsyncMock()
+        provider.embed = AsyncMock(side_effect=RuntimeError("unexpected"))
+        mock_get_provider.return_value = provider
+
+        result = await check_embedding_health()
+        assert result.status == "unhealthy"
+
+
+class TestGetMemoryInfo:
+    """Tests for get_memory_info()."""
+
+    def test_returns_dict(self):
+        from routes.health import get_memory_info
+
+        result = get_memory_info()
+        assert isinstance(result, dict)
+        # Should have memory info keys
+        assert "used_mb" in result or "error" in result
+
+    @patch("routes.health.resource")
+    def test_returns_memory_info(self, mock_resource):
+        from routes.health import get_memory_info
+
+        mock_usage = MagicMock()
+        mock_usage.ru_maxrss = 512 * 1024  # 512 MB in KB
+        mock_resource.getrusage.return_value = mock_usage
+        mock_resource.RUSAGE_SELF = 0
+
+        with patch("routes.health.settings") as mock_settings:
+            mock_settings.memory_warning_threshold_mb = 1024
+
+            result = get_memory_info()
+
+        assert result["used_mb"] == 512.0
+        assert result["limit_mb"] == 1024
+        assert result["warning"] is False
+
+    @patch("routes.health.resource")
+    def test_warning_when_over_threshold(self, mock_resource):
+        from routes.health import get_memory_info
+
+        mock_usage = MagicMock()
+        mock_usage.ru_maxrss = 2048 * 1024  # 2048 MB
+        mock_resource.getrusage.return_value = mock_usage
+        mock_resource.RUSAGE_SELF = 0
+
+        with patch("routes.health.settings") as mock_settings:
+            mock_settings.memory_warning_threshold_mb = 1024
+
+            result = get_memory_info()
+
+        assert result["warning"] is True
+
+    @patch("routes.health.resource")
+    def test_exception_returns_error(self, mock_resource):
+        from routes.health import get_memory_info
+
+        mock_resource.getrusage.side_effect = Exception("not supported")
+        mock_resource.RUSAGE_SELF = 0
+
+        result = get_memory_info()
+        assert "error" in result
+
+
+class TestLivenessProbe:
+    """Tests for liveness_probe endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_liveness(self):
+        from routes.health import liveness_probe
+
+        result = await liveness_probe()
+        assert result == {"status": "alive"}
+
+
+class TestReadinessProbe:
+    """Tests for readiness_probe endpoint."""
+
+    @pytest.mark.asyncio
+    @patch("routes.health.check_database_health")
+    async def test_ready(self, mock_db_health):
+        from routes.health import ComponentHealth, readiness_probe
+
+        mock_db_health.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
+        result = await readiness_probe()
+        assert result["status"] == "ready"
+        assert result["database_latency_ms"] == 5.0
+
+    @pytest.mark.asyncio
+    @patch("routes.health.check_database_health")
+    async def test_not_ready(self, mock_db_health):
+        from routes.health import ComponentHealth, readiness_probe
+
+        mock_db_health.return_value = ComponentHealth(
+            status="unhealthy", error="Connection refused"
+        )
+        result = await readiness_probe()
+        assert result.status_code == 503
+        body = result.body
+        assert b"not_ready" in body
+
+
+# ==================== Main App Tests ====================
+
+
+class TestMainApp:
+    """Tests for main.py app configuration."""
+
+    def test_root_endpoint(self):
+        with (
+            patch("main.init_db", new_callable=AsyncMock),
+            patch("main.close_db", new_callable=AsyncMock),
+        ):
+            from main import app
+
+            client = TestClient(app)
+            response = client.get("/")
+            assert response.status_code == 200
+            data = response.json()
+            assert "name" in data
+            assert "version" in data
+            assert "docs" in data
+            assert "health" in data
+
+    def test_config_endpoint(self):
+        with (
+            patch("main.init_db", new_callable=AsyncMock),
+            patch("main.close_db", new_callable=AsyncMock),
+        ):
+            from main import app
+
+            client = TestClient(app)
+            response = client.get("/config")
+            assert response.status_code == 200
+            data = response.json()
+            assert "llm" in data
+            assert "embedding" in data
+            assert "chat" in data
+            assert "provider" in data["llm"]
+            assert "model" in data["llm"]
+
+    def test_provider_error_handler(self):
+        with (
+            patch("main.init_db", new_callable=AsyncMock),
+            patch("main.close_db", new_callable=AsyncMock),
+        ):
+            from main import app
+
+            # Add a test route that raises ProviderError
+            @app.get("/test-provider-error")
+            async def trigger_error():
+                raise ProviderError("Test provider error")
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.get("/test-provider-error")
+            assert response.status_code == 503
+            data = response.json()
+            assert "error" in data
+            assert "LLM Provider Error" in data["error"]
+
+    def test_get_cors_origins(self):
+        from main import _get_cors_origins
+
+        origins = _get_cors_origins()
+        assert "http://localhost:3000" in origins
+        assert "http://127.0.0.1:3000" in origins
+
+    @patch("main.settings")
+    def test_get_cors_origins_with_custom(self, mock_settings):
+        from main import _get_cors_origins
+
+        mock_settings.cors_origins = "https://custom.example.com, https://other.example.com"
+        origins = _get_cors_origins()
+        assert "https://custom.example.com" in origins
+        assert "https://other.example.com" in origins
+
+    @patch("main.settings")
+    def test_get_cors_origins_empty_custom(self, mock_settings):
+        from main import _get_cors_origins
+
+        mock_settings.cors_origins = ""
+        origins = _get_cors_origins()
+        assert "http://localhost:3000" in origins
+
+
+class TestMainLifespan:
+    """Tests for the lifespan context manager."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_startup_and_shutdown(self):
+        from main import lifespan
+
+        mock_app = MagicMock()
+
+        with (
+            patch("main.init_db", new_callable=AsyncMock) as mock_init,
+            patch("main.close_db", new_callable=AsyncMock) as mock_close,
+        ):
+            async with lifespan(mock_app):
+                mock_init.assert_awaited_once()
+
+            mock_close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_db_init_failure(self):
+        from main import lifespan
+
+        mock_app = MagicMock()
+
+        with (
+            patch("main.init_db", new_callable=AsyncMock, side_effect=Exception("DB error")),
+            patch("main.close_db", new_callable=AsyncMock) as mock_close,
+        ):
+            # Should not raise - logs the error and continues
+            async with lifespan(mock_app):
+                pass
+
+            mock_close.assert_awaited_once()
+
+
+# ==================== Feedback Route Tests ====================
+
+
+class TestFeedbackRoutes:
+    """Tests for feedback route functions."""
+
+    @pytest.mark.asyncio
+    async def test_submit_feedback_success(self):
+        from datetime import UTC, datetime
+
+        from feedback.models import Feedback, FeedbackRequest
+        from routes.feedback import submit_feedback
+
+        mock_repo = AsyncMock()
+        mock_feedback = MagicMock(spec=Feedback)
+        mock_feedback.id = 1
+        mock_feedback.message_id = "550e8400-e29b-41d4-a716-446655440000"
+        mock_feedback.rating = "positive"
+        mock_feedback.created_at = datetime.now(UTC)
+        mock_repo.save_feedback = AsyncMock(return_value=mock_feedback)
+
+        request = FeedbackRequest(
+            message_id="550e8400-e29b-41d4-a716-446655440000",
+            rating="positive",
+            user_message="What does John 3:16 mean?",
+            assistant_response="John 3:16 tells us about God's love...",
+        )
+
+        result = await submit_feedback(request, mock_repo)
+        assert result.id == 1
+        assert result.rating == "positive"
+
+    @pytest.mark.asyncio
+    async def test_submit_feedback_negative_sends_email(self):
+        from datetime import UTC, datetime
+
+        from feedback.models import Feedback, FeedbackRequest
+        from routes.feedback import submit_feedback
+
+        mock_repo = AsyncMock()
+        mock_feedback = MagicMock(spec=Feedback)
+        mock_feedback.id = 2
+        mock_feedback.message_id = "550e8400-e29b-41d4-a716-446655440000"
+        mock_feedback.rating = "negative"
+        mock_feedback.created_at = datetime.now(UTC)
+        mock_repo.save_feedback = AsyncMock(return_value=mock_feedback)
+
+        request = FeedbackRequest(
+            message_id="550e8400-e29b-41d4-a716-446655440000",
+            rating="negative",
+            comment="Bad answer",
+            user_message="test",
+            assistant_response="response",
+        )
+
+        with patch("routes.feedback.email_service") as mock_email:
+            result = await submit_feedback(request, mock_repo)
+            mock_email.send_feedback_notification.assert_called_once()
+
+        assert result.rating == "negative"
+
+    @pytest.mark.asyncio
+    async def test_submit_feedback_value_error(self):
+        from fastapi import HTTPException
+
+        from feedback.models import FeedbackRequest
+        from routes.feedback import submit_feedback
+
+        mock_repo = AsyncMock()
+        mock_repo.save_feedback = AsyncMock(side_effect=ValueError("Invalid UUID"))
+
+        request = FeedbackRequest(
+            message_id="invalid",
+            rating="positive",
+            user_message="test",
+            assistant_response="response",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await submit_feedback(request, mock_repo)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_submit_feedback_generic_error(self):
+        from fastapi import HTTPException
+
+        from feedback.models import FeedbackRequest
+        from routes.feedback import submit_feedback
+
+        mock_repo = AsyncMock()
+        mock_repo.save_feedback = AsyncMock(side_effect=RuntimeError("DB down"))
+
+        request = FeedbackRequest(
+            message_id="550e8400-e29b-41d4-a716-446655440000",
+            rating="positive",
+            user_message="test",
+            assistant_response="response",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await submit_feedback(request, mock_repo)
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_submit_contact_success(self):
+        from datetime import UTC, datetime
+
+        from feedback.models import ContactRequest, ContactSubmission
+        from routes.feedback import submit_contact
+
+        mock_repo = AsyncMock()
+        mock_contact = MagicMock(spec=ContactSubmission)
+        mock_contact.id = 1
+        mock_contact.subject = "bug"
+        mock_contact.created_at = datetime.now(UTC)
+        mock_repo.save_contact = AsyncMock(return_value=mock_contact)
+
+        request = ContactRequest(
+            subject="bug",
+            message="Found a bug in the chat",
+            email="user@example.com",
+        )
+
+        with patch("routes.feedback.email_service") as mock_email:
+            mock_email.send_contact_notification.return_value = True
+            result = await submit_contact(request, mock_repo)
+
+        assert result.id == 1
+        assert result.subject == "bug"
+
+    @pytest.mark.asyncio
+    async def test_submit_contact_email_not_sent(self):
+        from datetime import UTC, datetime
+
+        from feedback.models import ContactRequest, ContactSubmission
+        from routes.feedback import submit_contact
+
+        mock_repo = AsyncMock()
+        mock_contact = MagicMock(spec=ContactSubmission)
+        mock_contact.id = 2
+        mock_contact.subject = "feedback"
+        mock_contact.created_at = datetime.now(UTC)
+        mock_repo.save_contact = AsyncMock(return_value=mock_contact)
+
+        request = ContactRequest(
+            subject="feedback",
+            message="Great app!",
+        )
+
+        with patch("routes.feedback.email_service") as mock_email:
+            mock_email.send_contact_notification.return_value = False
+            result = await submit_contact(request, mock_repo)
+
+        assert result.id == 2
+
+    @pytest.mark.asyncio
+    async def test_submit_contact_generic_error(self):
+        from fastapi import HTTPException
+
+        from feedback.models import ContactRequest
+        from routes.feedback import submit_contact
+
+        mock_repo = AsyncMock()
+        mock_repo.save_contact = AsyncMock(side_effect=RuntimeError("DB down"))
+
+        request = ContactRequest(
+            subject="bug",
+            message="Test message",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await submit_contact(request, mock_repo)
+        assert exc_info.value.status_code == 500
+
+
+# ==================== Chat Route Tests ====================
+
+
+class TestChatRoutes:
+    """Tests for chat route functions."""
+
+    @pytest.mark.asyncio
+    async def test_chat_success(self):
+        from chat.service import ChatRequest, ChatResponse
+        from routes.chat import chat
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        request = ChatRequest(message="I need encouragement")
+
+        expected_response = ChatResponse(
+            message_id="test-id",
+            message="God loves you!",
+            provider="test",
+            model="test-model",
+        )
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.chat = AsyncMock(return_value=expected_response)
+            mock_service_cls.return_value = mock_service
+
+            result = await chat(request, mock_db, mock_llm, mock_embedding)
+
+        assert result.message == "God loves you!"
+
+    @pytest.mark.asyncio
+    async def test_chat_rate_limit_error(self):
+        from fastapi import HTTPException
+
+        from chat.service import ChatRequest
+        from routes.chat import chat
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        request = ChatRequest(message="Hello")
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.chat = AsyncMock(
+                side_effect=RuntimeError("All models rate limited or failed")
+            )
+            mock_service_cls.return_value = mock_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await chat(request, mock_db, mock_llm, mock_embedding)
+
+            assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_chat_runtime_error(self):
+        from fastapi import HTTPException
+
+        from chat.service import ChatRequest
+        from routes.chat import chat
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        request = ChatRequest(message="Hello")
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.chat = AsyncMock(side_effect=RuntimeError("Some other runtime error"))
+            mock_service_cls.return_value = mock_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await chat(request, mock_db, mock_llm, mock_embedding)
+
+            assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_chat_generic_error(self):
+        from fastapi import HTTPException
+
+        from chat.service import ChatRequest
+        from routes.chat import chat
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        request = ChatRequest(message="Hello")
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.chat = AsyncMock(side_effect=ValueError("bad input"))
+            mock_service_cls.return_value = mock_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await chat(request, mock_db, mock_llm, mock_embedding)
+
+            assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_get_verse_context_success(self):
+        from routes.chat import get_verse_context
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        expected = {"target_verse": 16, "verses": []}
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.get_verse_context = AsyncMock(return_value=expected)
+            mock_service_cls.return_value = mock_service
+
+            result = await get_verse_context("John", 3, 16, mock_db, mock_llm, mock_embedding)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_get_verse_context_error(self):
+        from fastapi import HTTPException
+
+        from routes.chat import get_verse_context
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.get_verse_context = AsyncMock(side_effect=Exception("DB error"))
+            mock_service_cls.return_value = mock_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_verse_context("John", 3, 16, mock_db, mock_llm, mock_embedding)
+
+            assert exc_info.value.status_code == 500
+
+
+class TestChatStreamRoute:
+    """Tests for chat_stream route function."""
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_returns_streaming_response(self):
+        from chat.service import ChatRequest
+        from routes.chat import chat_stream
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        request = ChatRequest(message="Hello")
+
+        async def mock_gen(req):
+            yield "Hello "
+            yield "world!"
+
+        with patch("routes.chat.ChatService") as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service.chat_stream = mock_gen
+            mock_service_cls.return_value = mock_service
+
+            response = await chat_stream(request, mock_db, mock_llm, mock_embedding)
+
+        # Should be a StreamingResponse
+        assert response.media_type == "text/event-stream"
+
+
+# ==================== Scripture Route Tests ====================
+
+
+class TestScriptureRoutes:
+    """Tests for scripture route functions."""
+
+    @pytest.mark.asyncio
+    async def test_get_translations(self):
+        from routes.scripture import get_translations
+
+        with patch("routes.scripture.get_all_translations") as mock_get:
+            mock_get.return_value = [
+                {"code": "kjv", "name": "King James Version"},
+                {"code": "ita1927", "name": "Italian Riveduta"},
+            ]
+            result = await get_translations()
+
+        assert "translations" in result
+        assert len(result["translations"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_books(self):
+        from routes.scripture import get_books
+
+        mock_db = AsyncMock()
+
+        mock_book = MagicMock()
+        mock_book.id = 1
+        mock_book.name = "Genesis"
+        mock_book.abbreviation = "Gen"
+        mock_book.testament = "OT"
+        mock_book.position = 1
+
+        with patch("routes.scripture.ScriptureRepository") as mock_repo_cls:
+            mock_repo = AsyncMock()
+            mock_repo.get_all_books = AsyncMock(return_value=[mock_book])
+            mock_repo_cls.return_value = mock_repo
+
+            result = await get_books(mock_db)
+
+        assert len(result.books) == 1
+        assert result.books[0]["name"] == "Genesis"
+
+    @pytest.mark.asyncio
+    async def test_get_verse_found(self):
+        from routes.scripture import get_verse
+
+        mock_db = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        mock_verse = MagicMock()
+        mock_verse.reference = "John 3:16"
+        mock_verse.text = "For God so loved the world..."
+        mock_verse.book.name = "John"
+        mock_verse.chapter_number = 3
+        mock_verse.verse_number = 16
+        mock_verse.translation = "kjv"
+
+        with patch("routes.scripture.ScriptureRepository") as mock_repo_cls:
+            mock_repo = AsyncMock()
+            mock_repo.get_verse = AsyncMock(return_value=mock_verse)
+            mock_repo_cls.return_value = mock_repo
+
+            with patch("routes.scripture.get_localized_book_name", return_value="John"):
+                result = await get_verse("John", 3, 16, mock_db, mock_embedding, None)
+
+        assert result["reference"] == "John 3:16"
+
+    @pytest.mark.asyncio
+    async def test_get_verse_not_found(self):
+        from fastapi import HTTPException
+
+        from routes.scripture import get_verse
+
+        mock_db = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        with patch("routes.scripture.ScriptureRepository") as mock_repo_cls:
+            mock_repo = AsyncMock()
+            mock_repo.get_verse = AsyncMock(return_value=None)
+            mock_repo_cls.return_value = mock_repo
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_verse("NotABook", 1, 1, mock_db, mock_embedding, None)
+
+            assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_chapter_found(self):
+        from routes.scripture import get_chapter
+
+        mock_db = AsyncMock()
+
+        mock_verse = MagicMock()
+        mock_verse.reference = "Genesis 1:1"
+        mock_verse.text = "In the beginning..."
+        mock_verse.book.name = "Genesis"
+        mock_verse.chapter_number = 1
+        mock_verse.verse_number = 1
+        mock_verse.translation = "kjv"
+
+        with (
+            patch("routes.scripture.ScriptureRepository") as mock_repo_cls,
+            patch("routes.scripture.get_localized_book_name", return_value="Genesis"),
+            patch(
+                "routes.scripture.get_translation_info", return_value={"name": "King James Version"}
+            ),
+        ):
+            mock_repo = AsyncMock()
+            mock_repo.get_chapter_verses = AsyncMock(return_value=[mock_verse])
+            mock_repo_cls.return_value = mock_repo
+
+            result = await get_chapter("Genesis", 1, mock_db, None)
+
+        assert result.book == "Genesis"
+        assert result.chapter == 1
+        assert len(result.verses) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_chapter_not_found(self):
+        from fastapi import HTTPException
+
+        from routes.scripture import get_chapter
+
+        mock_db = AsyncMock()
+
+        with patch("routes.scripture.ScriptureRepository") as mock_repo_cls:
+            mock_repo = AsyncMock()
+            mock_repo.get_chapter_verses = AsyncMock(return_value=[])
+            mock_repo_cls.return_value = mock_repo
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_chapter("NotABook", 1, mock_db, None)
+
+            assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_verse_range_found(self):
+        from routes.scripture import get_verse_range
+        from scripture.search import VerseResult
+
+        mock_db = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        mock_verses = [
+            VerseResult(reference="John 3:16", text="Verse 16", book="John", chapter=3, verse=16),
+            VerseResult(reference="John 3:17", text="Verse 17", book="John", chapter=3, verse=17),
+        ]
+
+        with patch("routes.scripture.ScriptureSearchService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.get_verse_range = AsyncMock(return_value=mock_verses)
+            mock_service_cls.return_value = mock_service
+
+            result = await get_verse_range("John", 3, 16, 17, mock_db, mock_embedding)
+
+        assert len(result["verses"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_verse_range_not_found(self):
+        from fastapi import HTTPException
+
+        from routes.scripture import get_verse_range
+
+        mock_db = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        with patch("routes.scripture.ScriptureSearchService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.get_verse_range = AsyncMock(return_value=[])
+            mock_service_cls.return_value = mock_service
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_verse_range("NotABook", 1, 1, 5, mock_db, mock_embedding)
+
+            assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_search_scripture(self):
+        from routes.scripture import search_scripture
+        from scripture.search import SearchResults
+
+        mock_db = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        expected = SearchResults(query="love", verses=[], passages=[])
+
+        with patch("routes.scripture.ScriptureSearchService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.search = AsyncMock(return_value=expected)
+            mock_service_cls.return_value = mock_service
+
+            result = await search_scripture("love", 5, 2, None, mock_db, mock_embedding)
+
+        assert result.query == "love"
+
+    @pytest.mark.asyncio
+    async def test_search_text(self):
+        from routes.scripture import search_text
+
+        mock_db = AsyncMock()
+        mock_embedding = AsyncMock()
+
+        with patch("routes.scripture.ScriptureSearchService") as mock_service_cls:
+            mock_service = AsyncMock()
+            mock_service.text_search = AsyncMock(return_value=[])
+            mock_service_cls.return_value = mock_service
+
+            result = await search_text("love", 20, mock_db, mock_embedding)
+
+        assert result["query"] == "love"
+        assert result["verses"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_stats(self):
+        from routes.scripture import get_stats
+
+        mock_db = AsyncMock()
+        expected_stats = {"total_verses": 31102, "total_books": 66}
+
+        with patch("routes.scripture.ScriptureRepository") as mock_repo_cls:
+            mock_repo = AsyncMock()
+            mock_repo.get_stats = AsyncMock(return_value=expected_stats)
+            mock_repo_cls.return_value = mock_repo
+
+            result = await get_stats(mock_db)
+
+        assert result == expected_stats
+
+
+# ==================== Health Check Endpoint Integration ====================
+
+
+class TestHealthCheckEndpoint:
+    """Tests for the health_check endpoint (integration of check functions)."""
+
+    @pytest.mark.asyncio
+    @patch("routes.health.get_memory_info")
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
+    @patch("routes.health.check_database_health")
+    async def test_all_healthy(self, mock_db, mock_llm, mock_emb, mock_mem):
+        from routes.health import ComponentHealth, health_check
+
+        mock_db.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
+        mock_llm.return_value = ComponentHealth(
+            status="healthy", latency_ms=10.0, details={"provider": "ollama"}
+        )
+        mock_emb.return_value = ComponentHealth(
+            status="healthy", latency_ms=20.0, details={"provider": "ollama", "dimensions": 1024}
+        )
+        mock_mem.return_value = {"used_mb": 100, "limit_mb": 1024, "percent": 9.8, "warning": False}
+
+        result = await health_check()
+        assert result.status == "healthy"
+
+    @pytest.mark.asyncio
+    @patch("routes.health.get_memory_info")
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
+    @patch("routes.health.check_database_health")
+    async def test_db_unhealthy_returns_503(self, mock_db, mock_llm, mock_emb, mock_mem):
+        from routes.health import ComponentHealth, health_check
+
+        mock_db.return_value = ComponentHealth(status="unhealthy", error="Connection refused")
+        mock_llm.return_value = ComponentHealth(
+            status="healthy", latency_ms=10.0, details={"provider": "ollama"}
+        )
+        mock_emb.return_value = ComponentHealth(
+            status="healthy", latency_ms=20.0, details={"provider": "ollama", "dimensions": 1024}
+        )
+        mock_mem.return_value = {"used_mb": 100, "limit_mb": 1024, "percent": 9.8, "warning": False}
+
+        result = await health_check()
+        # When DB is unhealthy, it returns a JSONResponse with 503
+        assert result.status_code == 503
+
+    @pytest.mark.asyncio
+    @patch("routes.health.get_memory_info")
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
+    @patch("routes.health.check_database_health")
+    async def test_llm_unhealthy_returns_degraded(self, mock_db, mock_llm, mock_emb, mock_mem):
+        from routes.health import ComponentHealth, health_check
+
+        mock_db.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
+        mock_llm.return_value = ComponentHealth(
+            status="unhealthy", error="LLM down", details={"provider": "ollama"}
+        )
+        mock_emb.return_value = ComponentHealth(
+            status="healthy", latency_ms=20.0, details={"provider": "ollama", "dimensions": 1024}
+        )
+        mock_mem.return_value = {"used_mb": 100, "limit_mb": 1024, "percent": 9.8, "warning": False}
+
+        result = await health_check()
+        assert result.status == "degraded"
+
+    @pytest.mark.asyncio
+    @patch("routes.health.get_memory_info")
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
+    @patch("routes.health.check_database_health")
+    async def test_embedding_unhealthy_returns_degraded(
+        self, mock_db, mock_llm, mock_emb, mock_mem
+    ):
+        from routes.health import ComponentHealth, health_check
+
+        mock_db.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
+        mock_llm.return_value = ComponentHealth(
+            status="healthy", latency_ms=10.0, details={"provider": "ollama"}
+        )
+        mock_emb.return_value = ComponentHealth(
+            status="unhealthy", error="Emb down", details={"provider": "ollama"}
+        )
+        mock_mem.return_value = {"used_mb": 100, "limit_mb": 1024, "percent": 9.8, "warning": False}
+
+        result = await health_check()
+        assert result.status == "degraded"


### PR DESCRIPTION
## Summary
- Add 125 new tests across two test files for chat service/prompts, all routes (health, scripture, feedback, chat), and main.py
- This is the second PR in the coverage increase series (PR #1 was #103)

### Coverage improvements per module:
| Module | Before | After |
|---|---|---|
| `chat/prompts.py` | 31% | **100%** |
| `chat/service.py` | 33% | **99%** |
| `routes/health.py` | 47% | **100%** |
| `routes/scripture.py` | 51% | **100%** |
| `routes/feedback.py` | 75% | **98%** |
| `routes/chat.py` | 33% | **75%** |
| `main.py` | 42% | **61%** |

### New test files:
- `api/tests/test_chat_coverage.py` - 69 tests for prompts and ChatService
- `api/tests/test_routes_main_coverage.py` - 56 tests for routes and main

## Test plan
- [x] All 125 new tests pass
- [x] Pre-commit hooks (black, ruff, mypy, bandit) pass
- [x] No pre-existing tests broken by changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)