### PR TITLE
feat: Add golden set report generation and comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,20 @@ golden-review: install-deps ## Review golden set results (interactive human scor
 	@cd api && $(CURDIR)/$(PYTHON) -m golden_set.reviewer
 	@echo "$(GREEN)✓ Review session complete$(NC)"
 
+golden-report: install-deps ## Generate golden set markdown report from latest run
+	@echo "$(BLUE)Generating golden set report...$(NC)"
+	@cd api && $(CURDIR)/$(PYTHON) -c "\
+from golden_set.runner import get_latest_run; \
+from golden_set.report import generate_report, save_report; \
+from pathlib import Path; \
+run = get_latest_run(); \
+assert run, 'No saved runs found. Run golden-test-live first.'; \
+report = generate_report(run); \
+path = save_report(report, Path('golden_set/results') / f'{run.run_id}_report.md'); \
+print(report); \
+print(f'\nReport saved to: {path}')"
+	@echo "$(GREEN)✓ Report generated$(NC)"
+
 check-all: lint type-check security test validate-env ## Run all checks (pre-push validation)
 	@echo "$(GREEN)✓ All checks passed!$(NC)"
 

--- a/api/golden_set/report.py
+++ b/api/golden_set/report.py
@@ -1,0 +1,232 @@
+"""Markdown report generation for golden set evaluation runs.
+
+Generates single-run summaries and multi-run comparison reports.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from golden_set.models import EvalRun
+
+
+def generate_report(run: EvalRun) -> str:
+    """Generate a markdown report for a single evaluation run.
+
+    Args:
+        run: The evaluation run to report on.
+
+    Returns:
+        Markdown-formatted report string.
+    """
+    total = len(run.results)
+    passed = sum(1 for r in run.results if r.automated_score.passed)
+    failed = total - passed
+
+    scored = [r for r in run.results if r.human_score is not None]
+    avg_overall = sum(r.human_score.overall for r in scored) / len(scored) if scored else 0
+
+    timed = [r for r in run.results if r.response_time_ms > 0]
+    avg_time = sum(r.response_time_ms for r in timed) / len(timed) if timed else 0
+
+    lines: list[str] = []
+    lines.append(f"# Golden Set Report: {run.run_id}")
+    lines.append("")
+    lines.append(
+        f"**Provider:** {run.provider} | **Model:** {run.model} | "
+        f"**Mode:** {run.mode} | **Date:** {run.timestamp.strftime('%Y-%m-%d %H:%M')}"
+    )
+    lines.append("")
+
+    # Summary table
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Total Cases | {total} |")
+    if total > 0:
+        lines.append(f"| Auto-Pass | {passed}/{total} ({passed / total * 100:.1f}%) |")
+        lines.append(f"| Auto-Fail | {failed} |")
+    else:
+        lines.append("| Auto-Pass | 0 |")
+        lines.append("| Auto-Fail | 0 |")
+    lines.append(f"| Human Reviewed | {len(scored)} |")
+    if scored:
+        lines.append(f"| Avg Human Overall | {avg_overall:.1f}/5 |")
+    if timed:
+        lines.append(f"| Avg Response Time | {avg_time:.0f}ms |")
+    lines.append("")
+
+    # By category
+    categories: dict[str, list] = defaultdict(list)
+    for r in run.results:
+        cat = r.case_id.rsplit("-", 1)[0] if "-" in r.case_id else "unknown"
+        categories[cat].append(r)
+
+    lines.append("## By Category")
+    lines.append("")
+    lines.append("| Category | Cases | Auto-Pass | Human Avg |")
+    lines.append("|---|---|---|---|")
+    for cat in sorted(categories):
+        cat_results = categories[cat]
+        cat_total = len(cat_results)
+        cat_passed = sum(1 for r in cat_results if r.automated_score.passed)
+        cat_scored = [r for r in cat_results if r.human_score is not None]
+        cat_avg = (
+            f"{sum(r.human_score.overall for r in cat_scored) / len(cat_scored):.1f}"
+            if cat_scored
+            else "-"
+        )
+        rate = f"{cat_passed / cat_total * 100:.0f}%" if cat_total > 0 else "0%"
+        lines.append(f"| {cat} | {cat_total} | {cat_passed}/{cat_total} ({rate}) | {cat_avg} |")
+    lines.append("")
+
+    # Failed cases
+    failed_results = [r for r in run.results if not r.automated_score.passed]
+    if failed_results:
+        lines.append("## Failed Cases")
+        lines.append("")
+        for r in failed_results:
+            lines.append(f"### {r.case_id}")
+            lines.append("")
+            lines.append(f"**Input:** {r.input_message}")
+            lines.append("")
+            lines.append(f"**Failed checks:** {', '.join(r.automated_score.failed_checks)}")
+            lines.append("")
+            for check in r.automated_score.failed_checks:
+                detail = r.automated_score.details.get(check, "")
+                if detail:
+                    lines.append(f"- **{check}:** {detail}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def _get_category(case_id: str) -> str:
+    """Extract category from a case ID (e.g., 'enc-001' -> 'enc')."""
+    return case_id.rsplit("-", 1)[0] if "-" in case_id else "unknown"
+
+
+def _run_auto_pass_rate(run: EvalRun) -> str:
+    """Get auto-pass rate string for a run."""
+    total = len(run.results)
+    if total > 0:
+        passed = sum(1 for res in run.results if res.automated_score.passed)
+        return f"{passed / total * 100:.1f}%"
+    return "-"
+
+
+def _run_human_score(run: EvalRun) -> str:
+    """Get average human overall score string for a run."""
+    scored = [res for res in run.results if res.human_score is not None]
+    if scored:
+        avg = sum(res.human_score.overall for res in scored) / len(scored)
+        return f"{avg:.1f}/5"
+    return "-"
+
+
+def _run_avg_time(run: EvalRun) -> str:
+    """Get average response time string for a run."""
+    timed = [res for res in run.results if res.response_time_ms > 0]
+    if timed:
+        avg_t = sum(res.response_time_ms for res in timed) / len(timed)
+        return f"{avg_t:.0f}ms"
+    return "-"
+
+
+def _category_stats(run: EvalRun, cat: str) -> tuple[str, str]:
+    """Get auto-pass and human avg strings for a category within a run."""
+    cat_results = [res for res in run.results if _get_category(res.case_id) == cat]
+    if cat_results:
+        p = sum(1 for res in cat_results if res.automated_score.passed)
+        pass_str = f"{p}/{len(cat_results)}"
+    else:
+        pass_str = "-"
+
+    scored = [res for res in cat_results if res.human_score is not None]
+    if scored:
+        avg = sum(res.human_score.overall for res in scored) / len(scored)
+        human_str = f"{avg:.1f}"
+    else:
+        human_str = "-"
+
+    return pass_str, human_str
+
+
+def generate_comparison(runs: list[EvalRun]) -> str:
+    """Generate a comparison report across multiple evaluation runs.
+
+    Args:
+        runs: List of evaluation runs to compare.
+
+    Returns:
+        Markdown-formatted comparison report.
+    """
+    if not runs:
+        return "# Golden Set Comparison\n\nNo runs to compare.\n"
+
+    lines: list[str] = []
+    lines.append("# Golden Set Comparison")
+    lines.append("")
+
+    labels = [f"{r.provider}/{r.model}" for r in runs]
+    header = "| Metric | " + " | ".join(labels) + " |"
+    sep = "|---|" + "|".join(["---"] * len(runs)) + "|"
+    lines.append(header)
+    lines.append(sep)
+
+    lines.append("| Auto-Pass Rate | " + " | ".join(_run_auto_pass_rate(r) for r in runs) + " |")
+    lines.append("| Total Cases | " + " | ".join(str(len(r.results)) for r in runs) + " |")
+    lines.append("| Avg Human Score | " + " | ".join(_run_human_score(r) for r in runs) + " |")
+    lines.append("| Avg Response Time | " + " | ".join(_run_avg_time(r) for r in runs) + " |")
+    lines.append("")
+
+    # Per-category comparison
+    all_categories: set[str] = set()
+    for r in runs:
+        for res in r.results:
+            all_categories.add(_get_category(res.case_id))
+
+    lines.append("## By Category")
+    lines.append("")
+
+    for cat in sorted(all_categories):
+        lines.append(f"### {cat}")
+        lines.append("")
+        lines.append(header)
+        lines.append(sep)
+
+        stats = [_category_stats(r, cat) for r in runs]
+        lines.append("| Auto-Pass | " + " | ".join(s[0] for s in stats) + " |")
+        lines.append("| Human Avg | " + " | ".join(s[1] for s in stats) + " |")
+        lines.append("")
+
+    # Run metadata
+    lines.append("## Run Details")
+    lines.append("")
+    lines.append("| Field | " + " | ".join(labels) + " |")
+    lines.append(sep)
+    lines.append("| Run ID | " + " | ".join(r.run_id for r in runs) + " |")
+    lines.append("| Mode | " + " | ".join(r.mode for r in runs) + " |")
+    lines.append(
+        "| Date | " + " | ".join(r.timestamp.strftime("%Y-%m-%d %H:%M") for r in runs) + " |"
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def save_report(content: str, file_path: Path) -> Path:
+    """Save a report to a markdown file.
+
+    Args:
+        content: Markdown report content.
+        file_path: Path to save the report.
+
+    Returns:
+        Path to the saved file.
+    """
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content)
+    return file_path

--- a/api/tests/test_golden_set.py
+++ b/api/tests/test_golden_set.py
@@ -717,3 +717,251 @@ class TestReviewer:
         with patch("golden_set.reviewer.list_runs", return_value=[]):
             result = select_run()
         assert result is None
+
+
+# ==================== Report Tests ====================
+
+
+@pytest.mark.golden_set
+class TestSingleRunReport:
+    """Test single run markdown report generation."""
+
+    @pytest.mark.asyncio
+    async def test_report_contains_header(self):
+        from golden_set.report import generate_report
+        from golden_set.runner import run_mock
+
+        run = await run_mock()
+        report = generate_report(run)
+        assert "# Golden Set Report:" in report
+        assert run.run_id in report
+
+    @pytest.mark.asyncio
+    async def test_report_contains_summary_table(self):
+        from golden_set.report import generate_report
+        from golden_set.runner import run_mock
+
+        run = await run_mock()
+        report = generate_report(run)
+        assert "## Summary" in report
+        assert "| Total Cases |" in report
+        assert "| Auto-Pass |" in report
+
+    @pytest.mark.asyncio
+    async def test_report_contains_category_breakdown(self):
+        from golden_set.report import generate_report
+        from golden_set.runner import run_mock
+
+        run = await run_mock()
+        report = generate_report(run)
+        assert "## By Category" in report
+        assert "| Category |" in report
+
+    @pytest.mark.asyncio
+    async def test_report_shows_failed_cases(self):
+        from datetime import datetime, timezone
+
+        from golden_set.models import AutomatedScore, CaseResult, EvalRun
+        from golden_set.report import generate_report
+
+        run = EvalRun(
+            run_id="fail-test",
+            timestamp=datetime.now(timezone.utc),
+            provider="test",
+            model="test-v1",
+            mode="mock",
+            results=[
+                CaseResult(
+                    run_id="fail-test",
+                    case_id="enc-001",
+                    timestamp=datetime.now(timezone.utc),
+                    provider="test",
+                    model="test-v1",
+                    input_message="test input",
+                    actual_response="no scripture here",
+                    automated_score=AutomatedScore(
+                        passed=False,
+                        total_checks=7,
+                        passed_checks=5,
+                        failed_checks=["scripture_presence", "forbidden_content"],
+                        details={
+                            "scripture_presence": "No verse references found",
+                            "forbidden_content": "Found: bad phrase",
+                        },
+                    ),
+                )
+            ],
+        )
+        report = generate_report(run)
+        assert "## Failed Cases" in report
+        assert "enc-001" in report
+        assert "scripture_presence" in report
+
+    @pytest.mark.asyncio
+    async def test_report_no_failed_cases(self):
+        """Report without failed cases omits Failed Cases section."""
+        from datetime import datetime, timezone
+
+        from golden_set.models import AutomatedScore, CaseResult, EvalRun
+        from golden_set.report import generate_report
+
+        run = EvalRun(
+            run_id="pass-test",
+            timestamp=datetime.now(timezone.utc),
+            provider="test",
+            model="test-v1",
+            mode="mock",
+            results=[
+                CaseResult(
+                    run_id="pass-test",
+                    case_id="enc-001",
+                    timestamp=datetime.now(timezone.utc),
+                    provider="test",
+                    model="test-v1",
+                    input_message="test",
+                    actual_response="test",
+                    automated_score=AutomatedScore(passed=True, total_checks=7, passed_checks=7),
+                )
+            ],
+        )
+        report = generate_report(run)
+        assert "## Failed Cases" not in report
+
+    @pytest.mark.asyncio
+    async def test_report_with_human_scores(self):
+        from datetime import datetime, timezone
+
+        from golden_set.models import (
+            AutomatedScore,
+            CaseResult,
+            EvalRun,
+            HumanScore,
+        )
+        from golden_set.report import generate_report
+
+        run = EvalRun(
+            run_id="human-test",
+            timestamp=datetime.now(timezone.utc),
+            provider="test",
+            model="test-v1",
+            mode="live",
+            results=[
+                CaseResult(
+                    run_id="human-test",
+                    case_id="enc-001",
+                    timestamp=datetime.now(timezone.utc),
+                    provider="test",
+                    model="test-v1",
+                    input_message="test",
+                    actual_response="test response",
+                    automated_score=AutomatedScore(passed=True, total_checks=7, passed_checks=7),
+                    human_score=HumanScore(
+                        relevance=4,
+                        scripture_accuracy=5,
+                        tone_quality=4,
+                        source_attribution=3,
+                        overall=4,
+                    ),
+                    response_time_ms=1200,
+                )
+            ],
+        )
+        report = generate_report(run)
+        assert "Avg Human Overall" in report
+        assert "4.0/5" in report
+        assert "1200ms" in report
+
+    @pytest.mark.asyncio
+    async def test_report_empty_results(self):
+        from datetime import datetime, timezone
+
+        from golden_set.models import EvalRun
+        from golden_set.report import generate_report
+
+        run = EvalRun(
+            run_id="empty",
+            timestamp=datetime.now(timezone.utc),
+            provider="test",
+            model="test-v1",
+            mode="mock",
+            results=[],
+        )
+        report = generate_report(run)
+        assert "# Golden Set Report:" in report
+        assert "| Total Cases | 0 |" in report
+
+
+@pytest.mark.golden_set
+class TestComparisonReport:
+    """Test multi-run comparison report generation."""
+
+    @pytest.mark.asyncio
+    async def test_comparison_two_runs(self):
+        from golden_set.report import generate_comparison
+        from golden_set.runner import run_mock
+
+        run1 = await run_mock()
+        run2 = await run_mock()
+        run2.provider = "other"
+        run2.model = "other-v1"
+
+        report = generate_comparison([run1, run2])
+        assert "# Golden Set Comparison" in report
+        assert "mock/mock-v1" in report
+        assert "other/other-v1" in report
+        assert "Auto-Pass Rate" in report
+
+    def test_comparison_empty_runs(self):
+        from golden_set.report import generate_comparison
+
+        report = generate_comparison([])
+        assert "No runs to compare" in report
+
+    @pytest.mark.asyncio
+    async def test_comparison_contains_category_breakdown(self):
+        from golden_set.report import generate_comparison
+        from golden_set.runner import run_mock
+
+        run1 = await run_mock()
+        run2 = await run_mock()
+        run2.provider = "provider2"
+        run2.model = "model2"
+
+        report = generate_comparison([run1, run2])
+        assert "## By Category" in report
+
+    @pytest.mark.asyncio
+    async def test_comparison_contains_run_details(self):
+        from golden_set.report import generate_comparison
+        from golden_set.runner import run_mock
+
+        run1 = await run_mock()
+        run2 = await run_mock()
+        run2.provider = "provider2"
+        run2.model = "model2"
+
+        report = generate_comparison([run1, run2])
+        assert "## Run Details" in report
+        assert run1.run_id in report
+        assert run2.run_id in report
+
+
+@pytest.mark.golden_set
+class TestSaveReport:
+    """Test report file saving."""
+
+    def test_save_report_creates_file(self, tmp_path):
+        from golden_set.report import save_report
+
+        content = "# Test Report\n\nSome content."
+        file_path = tmp_path / "reports" / "test.md"
+        result = save_report(content, file_path)
+        assert result.exists()
+        assert result.read_text() == content
+
+    def test_save_report_creates_directories(self, tmp_path):
+        from golden_set.report import save_report
+
+        file_path = tmp_path / "deep" / "nested" / "report.md"
+        save_report("content", file_path)
+        assert file_path.exists()


### PR DESCRIPTION
## Summary

- Add `golden_set/report.py` with markdown report generation:
  - **Single-run report**: Summary table, per-category auto-pass/human-score breakdown, failed case details with check-level diagnostics
  - **Multi-run comparison**: Side-by-side auto-pass rate, human scores, response times across providers/models, per-category drill-down
  - `save_report()` for persisting reports to disk
- Add `golden-report` Makefile target that loads the latest run and generates a markdown report
- Add 13 new tests covering report generation, comparison, edge cases (84 total)

## Test plan

- [x] All 84 golden set tests pass
- [x] All pre-commit hooks pass (black, ruff C901 complexity resolved, mypy, bandit)
- [ ] After merging PRs #106 and #107, run `make golden-test` and `make golden-report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)