### PR TITLE
ci: Gate deploy on test success via workflow_run

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -23,13 +23,10 @@ name: Build and Deploy to Azure
 
 # yamllint disable-line rule:truthy
 on:
-  push:
+  workflow_run:
+    workflows: ["CI/CD - Test Application"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "api/**"
-      - "frontend/**"
-      - "scripts/**"
-      - ".github/workflows/azure-deploy.yml"
   pull_request:
     branches: [main]
     paths:
@@ -77,6 +74,12 @@ on:
         type: boolean
 
 env:
+  # Normalize commit SHA: workflow_run events use the triggering commit,
+  # not the latest default-branch commit
+  DEPLOY_SHA: >-
+    ${{ github.event_name == 'workflow_run'
+        && github.event.workflow_run.head_sha
+        || github.sha }}
   BACKEND_APP_NAME: bible-app-backend
   FRONTEND_APP_NAME: bible-app-frontend
   ACR_NAME: bibleappacrmb0172
@@ -87,6 +90,9 @@ jobs:
   # Detect Changes
   # ---------------------------------------------------------------------------
   changes:
+    # Skip entirely when the test workflow failed (gates deploy on test success)
+    if: >-
+      github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -94,9 +100,13 @@ jobs:
       scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+          fetch-depth: 2
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: HEAD~1
           filters: |
             backend:
               - 'api/**'
@@ -125,6 +135,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -185,6 +197,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -271,7 +285,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           echo "Verifying NEXT_PUBLIC_API_URL is correctly baked into the image..."
-          IMAGE="${{ env.ACR_NAME }}.azurecr.io/bible-frontend:${{ github.sha }}"
+          IMAGE="${{ env.ACR_NAME }}.azurecr.io/bible-frontend:${{ env.DEPLOY_SHA }}"
           EXPECTED_URL="${{ steps.backend-url.outputs.url }}"
 
           docker pull "$IMAGE"
@@ -331,6 +345,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Login to Azure
         uses: azure/login@v1
@@ -404,7 +420,7 @@ jobs:
           else
             # Normal build: use new images for built components, current for others
             echo "Mode: normal build"
-            IMAGE_TAG="${{ github.sha }}"
+            IMAGE_TAG="${{ env.DEPLOY_SHA }}"
             BACKEND_BUILT="${{ needs.build-backend.result == 'success' }}"
             FRONTEND_BUILT="${{ needs.build-frontend.result == 'success' }}"
             DEPLOY_COMPONENT="${{ inputs.deploy_component }}"
@@ -565,6 +581,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -440,4 +440,3 @@ jobs:
         run: |
           cd frontend
           npm audit --audit-level=high
-        continue-on-error: true


### PR DESCRIPTION
## Summary

- Replace the `push` trigger in `azure-deploy.yml` with a `workflow_run` trigger that fires only after the test workflow (`CI/CD - Test Application`) completes successfully on `main`
- Add `DEPLOY_SHA` env var to correctly resolve the commit SHA across `workflow_run`, `pull_request`, and `workflow_dispatch` event types
- Gate the `changes` job (and all downstream jobs) on `workflow_run.conclusion == 'success'` so a failed test run skips the entire deploy
- Fix `dorny/paths-filter` to work in `workflow_run` context (`fetch-depth: 2`, `base: HEAD~1`)
- Remove `continue-on-error: true` from npm audit in `test_update.yml` so high/critical vulnerabilities fail the build and block deploys

## Why

Previously, `test_update.yml` and `azure-deploy.yml` ran in parallel on pushes to `main`. A broken commit could be deployed before tests caught the failure.

## Test plan

- [ ] Push a commit to a PR branch — verify `azure-deploy.yml` triggers with `pull_request` event (builds run, no deploy)
- [ ] Merge to main — verify `test_update.yml` runs first, then `azure-deploy.yml` triggers via `workflow_run` only after tests complete
- [ ] If tests fail on main, verify deploy workflow is skipped entirely
- [ ] Check that `DEPLOY_SHA` matches the merge commit SHA in build logs
- [ ] Verify `dorny/paths-filter` correctly detects changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)