### PR TITLE
fix(ci): Resolve HEAD~1 to SHA for dorny/paths-filter

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -103,10 +103,13 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}
           fetch-depth: 2
+      - name: Resolve base commit
+        id: base
+        run: echo "sha=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          base: HEAD~1
+          base: ${{ steps.base.outputs.sha }}
           filters: |
             backend:
               - 'api/**'


### PR DESCRIPTION
## Summary

- Fix `dorny/paths-filter` failing with exit code 128 in `workflow_run` context
- The `base` parameter is treated as a git refspec — `HEAD~1` can't be fetched
- Resolve it to an actual commit SHA via `git rev-parse HEAD~1` in a prior step

Fixes the failure in deploy run #192 introduced by #111.

## Test plan

- [ ] Merge to main and verify the deploy workflow's `changes` job succeeds
- [ ] Verify `dorny/paths-filter` correctly detects changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)