### PR TITLE
fix(verse-detection): Hindi edge cases — alt spelling + greedy numbered-prefix

### DIFF
--- a/api/utils/translation_registry.py
+++ b/api/utils/translation_registry.py
@@ -851,6 +851,12 @@ KOREAN_ALIASES: dict[str, str] = {
     "행전": "Acts",  # Short form of 사도행전 (without 사도)
 }
 
+# Alternate Hindi spellings/transliterations that LLMs commonly produce but are
+# not the canonical IRV Bible keys in ENGLISH_TO_HINDI.
+HINDI_ALIASES: dict[str, str] = {
+    "लेवियतियुस": "Leviticus",  # Transliterated form; IRV uses लैव्यव्यवस्था
+}
+
 # Hindi (IRV Bible / hindi)
 ENGLISH_TO_HINDI: dict[str, str] = {
     "Genesis": "उत्पत्ति",
@@ -993,6 +999,7 @@ EXTRA_REVERSE_MAPPINGS: dict[str, str] = {
     **ARABIC_CITATION_FORMS,
     **CHINESE_ALIASES,
     **KOREAN_ALIASES,
+    **HINDI_ALIASES,
     **GERMAN_ALIASES,
     **ITALIAN_ALIASES,
     **FRENCH_ALIASES,

--- a/frontend/src/lib/verseExtraction.test.ts
+++ b/frontend/src/lib/verseExtraction.test.ts
@@ -1581,6 +1581,27 @@ describe("extractVerseReferences — Hindi", () => {
 
 // ── Hindi: no-space and Devanagari numeral improvements ─────────────────────────
 
+describe("extractVerseReferences — Hindi edge cases (verse range + conjunction, alt spelling)", () => {
+  it("should detect all three refs in a verse-range + 'और' context (no '4 और इब्रानियों' garbage)", () => {
+    const text =
+      "यह बाइबिल से है, विशेष रूप से लेवियतियुस 1:3-4 और इब्रानियों 9:22। रोमियों 12:1 में कहा गया है।";
+    const refs = extractVerseReferences(text);
+    expect(refs.has("leviticus 1:3")).toBe(true);
+    expect(refs.has("hebrews 9:22")).toBe(true);
+    expect(refs.has("romans 12:1")).toBe(true);
+    // Must not produce the greedy '4 और इब्रानियों' garbage match.
+    for (const r of refs) {
+      expect(r.startsWith("4 ")).toBe(false);
+      expect(r).not.toContain("और");
+    }
+  });
+
+  it("should detect alternate transliteration लेवियतियुस → leviticus", () => {
+    const refs = extractVerseReferences("लेवियतियुस 1:3");
+    expect(refs.has("leviticus 1:3")).toBe(true);
+  });
+});
+
 describe("extractVerseReferences — Hindi no-space and Devanagari numerals", () => {
   describe("no-space references", () => {
     it("should detect यूहन्ना3:16 (no space) → john 3:16", () => {

--- a/frontend/src/lib/verseExtraction.ts
+++ b/frontend/src/lib/verseExtraction.ts
@@ -444,6 +444,7 @@ export const LOCALIZED_BOOK_TO_ENGLISH: Record<string, string> = {
   उत्पत्ति: "genesis",
   निर्गमन: "exodus",
   लैव्यव्यवस्था: "leviticus",
+  लेवियतियुस: "leviticus", // alternate transliteration used by some LLMs
   गिनती: "numbers",
   व्यवस्थाविवरण: "deuteronomy",
   यहोशू: "joshua",

--- a/frontend/src/lib/versePatterns.test.ts
+++ b/frontend/src/lib/versePatterns.test.ts
@@ -59,12 +59,17 @@ describe("getMultiWordAlternation", () => {
     }
   });
 
-  it("should NOT include number-prefixed book names", () => {
-    // "1 царств", "2 samuel", etc. are handled by the \\d+ branch — must not appear
-    // as a multi-word alternate.
+  it("should NOT include number-prefixed Latin/Cyrillic/Arabic book names", () => {
+    // "1 царств", "2 samuel", "1 أخبار الأيام", etc. are handled by the \\d+ branch
+    // and must not appear as multi-word alternates.
+    // EXCEPTION: number-prefixed non-Latin (Han/Hangul/Devanagari) books must be
+    // listed explicitly because the numbered-prefix branch excludes those scripts.
+    const NON_LATIN = /[\p{Script=Han}\p{Script=Hangul}\p{Script=Devanagari}]/u;
     const parts = getMultiWordAlternation().split("|");
     for (const part of parts) {
-      expect(part).not.toMatch(/^\d/);
+      if (part.match(/^\d/)) {
+        expect(part).toMatch(NON_LATIN);
+      }
     }
   });
 

--- a/frontend/src/lib/versePatterns.ts
+++ b/frontend/src/lib/versePatterns.ts
@@ -90,9 +90,18 @@ export function getMultiWordAlternation(): string {
   } else {
     // Collect all multi-word localized book names.
     // A "multi-word" key is one that contains a space AND is NOT number-prefixed.
-    multiWordNames = Object.keys(LOCALIZED_BOOK_TO_ENGLISH).filter(
-      (key) => key.includes(" ") && !isNumberPrefixed(key),
-    );
+    // Number-prefixed Latin/Cyrillic/Arabic books (e.g. "1 samuel", "1 царств",
+    // "1 أخبار الأيام") are handled by the numbered-prefix \d+ branch in the regex.
+    // BUT number-prefixed Han/Hangul/Devanagari books (e.g. "1 शमूएल", "1 요한") must
+    // be listed explicitly here, because the numbered-prefix branch excludes those
+    // scripts to prevent greedy over-matching of surrounding non-Latin context text.
+    const NON_LATIN_SCRIPT_RE =
+      /[\p{Script=Han}\p{Script=Hangul}\p{Script=Devanagari}]/u;
+    multiWordNames = Object.keys(LOCALIZED_BOOK_TO_ENGLISH).filter((key) => {
+      if (!key.includes(" ")) return false;
+      if (isNumberPrefixed(key)) return NON_LATIN_SCRIPT_RE.test(key);
+      return true;
+    });
 
     // Sort longest-first so that longer alternates (e.g. "деяния апостолов")
     // are tried before shorter ones (e.g. "деяния") — prevents partial matches.
@@ -207,6 +216,8 @@ function getDevanagariAlternation(): string {
  *     (e.g. Russian: Плач Иеремии, Песня Песней; plus any names loaded via API)
  *  2. Multi-word books joined by a connector word (Song of Solomon, Cantique des Cantiques…)
  *  3. Numbered-prefix books (1 John, 2 Kings, 1. Mose, 2. Könige, 1 أخبار الأيام…)
+ *     Han/Hangul/Devanagari characters are excluded from this branch — all legitimate
+ *     CJK/Korean/Hindi numbered books are already covered by branches 1, 4, and 5.
  *  4. Chinese/CJK book names — explicit alternation of known names from the map.
  *     Unlike the generic [\p{Script=Han}]{2,} that was used before, an explicit
  *     alternation prevents greedy over-matching of surrounding CJK context text.
@@ -256,7 +267,7 @@ function buildPatternSource(): string {
   _cachedPatternSource =
     `(?:(?<!\\p{L})|(?<=\\p{Script=Han})|(?<=\\p{Script=Hangul})|(?<=\\p{Script=Devanagari})|(?<=[\u300A\u300C\u300E]))(${multiWordPart}` +
     `[\\p{L}\\p{M}]{2,}(?:\\s+(?:of|dei|des|der|van|de|af|dos|da|del|के|ال)\\s+[\\p{L}\\p{M}]+)+` +
-    `|\\d+(?:\\.|-[\\p{L}\\p{M}]{1,2})?\\s*[\\p{L}\\p{M}]{2,}(?:\\s+[\\p{L}\\p{M}]+)*` +
+    `|\\d+(?:\\.|-(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}]{1,2})?\\s*(?:(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}]){2,}(?:\\s+(?:(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}])+)*` +
     `|${cjkPart}` +
     `${hangulPart}` +
     `${devanagariPart}` +


### PR DESCRIPTION
## Summary
Fixes two Hindi verse-detection bugs reported against LLM output like:
`लेवियतियुस 1:3-4 और इब्रानियों 9:22। रोमियों 12:1`

1. **Alternate transliteration unmatched.** LLM emitted `लेवियतियुस` (transliterated Leviticus) but the IRV map only contains `लैव्यव्यवस्था`. The generic regex fallback already excludes Devanagari, so unknown Hindi spellings were silently dropped. Added the alias in the frontend map and a new `HINDI_ALIASES` dict in the backend registry.

2. **Greedy numbered-prefix branch.** The `\d+...[\p{L}\p{M}]+` branch latched onto the dangling `4` from verse range `1:3-4` and captured `4 और इब्रानियों 9:22` as a fake "numbered book", shadowing the real `इब्रानियों 9:22`. Fixed by excluding Han/Hangul/Devanagari from letter classes inside that branch — legitimate non-Latin numbered books (`1 शमूएल`, `2 राजाओं`, etc.) are now kept in the explicit multi-word alternation instead.

## Test plan
- [x] `cd frontend && npx vitest run src/lib/verseExtraction.test.ts src/lib/versePatterns.test.ts` — 284/284 passing (added 2 new Hindi edge-case tests)
- [x] Backend `pytest api/tests/test_verse_parser.py api/tests/test_translations.py` — 256/256 non-network tests passing
- [x] Manual repro on the full Hindi bug text now extracts `leviticus 1:3`, `hebrews 9:22`, `romans 12:1` with no garbage

Android not modified in this PR — will be handled in a follow-up.

https://claude.ai/code/session_01G9YnnrDxpy1NEbyK7hSxdK