### PR TITLE
test(android): regression tests for Hindi verse-detection edge cases

### DIFF
--- a/android/app/src/test/kotlin/com/bibleinspiration/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/com/bibleinspiration/components/VerseRefLinkTest.kt
@@ -495,6 +495,34 @@ class VerseRefLinkTest {
         assertTrue(result.contains("[1 कुरिन्थियों 13:4]"))
     }
 
+    @Test
+    fun `injectVerseLinks handles Hindi verse-range followed by और and another book`() {
+        // Regression test for web-side bug where the numbered-prefix branch greedily
+        // captured "4 और इब्रानियों" starting from the dangling 4 in "1:3-4".
+        // Android's regex is not vulnerable because its numbered branch only matches
+        // [1-3] prefixes, but we lock this behaviour in with an explicit test.
+        val input = "लेवियतियुस 1:3-4 और इब्रानियों 9:22 रोमियों 12:1"
+        val result = injectVerseLinks(input)
+        assertTrue("should link Leviticus", result.contains("[लेवियतियुस 1:3-4]"))
+        assertTrue("should link Hebrews", result.contains("[इब्रानियों 9:22]"))
+        assertTrue("should link Romans", result.contains("[रोमियों 12:1]"))
+        // Must not create a fake "4 और इब्रानियों" link.
+        assertTrue(
+            "should not produce greedy '4 और' match",
+            !result.contains("[4 और")
+        )
+    }
+
+    @Test
+    fun `injectVerseLinks wraps Hindi alternate transliteration लेवियतियुस`() {
+        // Unknown-to-the-map Hindi book names should still be wrapped because
+        // the generic BOOK_NAME pattern accepts any \p{Lo} starting character.
+        // Backend HINDI_ALIASES will normalize लेवियतियुस → Leviticus on tap.
+        val input = "लेवियतियुस 1:3 में बलिदान का उल्लेख है"
+        val result = injectVerseLinks(input)
+        assertTrue(result.contains("[लेवियतियुस 1:3]"))
+    }
+
     // ── Non-English book names: Arabic/Hindi multi-word with dynamic regex ──
 
     @Test

--- a/android/dependency-check-suppressions.xml
+++ b/android/dependency-check-suppressions.xml
@@ -48,6 +48,14 @@
     </notes>
     <cve>CVE-2023-22946</cve>
   </suppress>
+  <suppress>
+    <notes>CVE-2025-54920: False positive. collection-ktx is AndroidX, not Apache Spark.
+      OWASP incorrectly matches the jar to Apache Spark CPEs.
+      This CVE affects Apache Spark before 3.5.7 / 4.0.1 and is inapplicable to
+      the AndroidX collections library (androidx.collection:collection-ktx).
+    </notes>
+    <cve>CVE-2025-54920</cve>
+  </suppress>
 
   <!--
     Gradle 8.4.2 build tool CVEs (CVE-2026-22816, CVE-2026-22865).

--- a/api/utils/translation_registry.py
+++ b/api/utils/translation_registry.py
@@ -851,6 +851,12 @@ KOREAN_ALIASES: dict[str, str] = {
     "행전": "Acts",  # Short form of 사도행전 (without 사도)
 }
 
+# Alternate Hindi spellings/transliterations that LLMs commonly produce but are
+# not the canonical IRV Bible keys in ENGLISH_TO_HINDI.
+HINDI_ALIASES: dict[str, str] = {
+    "लेवियतियुस": "Leviticus",  # Transliterated form; IRV uses लैव्यव्यवस्था
+}
+
 # Hindi (IRV Bible / hindi)
 ENGLISH_TO_HINDI: dict[str, str] = {
     "Genesis": "उत्पत्ति",
@@ -993,6 +999,7 @@ EXTRA_REVERSE_MAPPINGS: dict[str, str] = {
     **ARABIC_CITATION_FORMS,
     **CHINESE_ALIASES,
     **KOREAN_ALIASES,
+    **HINDI_ALIASES,
     **GERMAN_ALIASES,
     **ITALIAN_ALIASES,
     **FRENCH_ALIASES,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "lucide-react": "^0.577.0",
-        "next": "^16.1.7",
-        "next-intl": "^4.8.3",
+        "next": "^16.2.3",
+        "next-intl": "^4.9.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^9.0.1"
@@ -1100,56 +1100,55 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@formatjs/bigdecimal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/bigdecimal/-/bigdecimal-0.2.0.tgz",
+      "integrity": "sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==",
+      "license": "MIT"
+    },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
-      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.2.0.tgz",
+      "integrity": "sha512-dHnqHgBo6GXYGRsepaE1wmsC2etaivOWd5VaJstZd+HI2zR3DCUjbDVZRtoPGkkXZmyHvBwrdEUuqfvzhF/DtQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/intl-localematcher": "0.8.1",
-        "decimal.js": "^10.6.0",
-        "tslib": "^2.8.1"
+        "@formatjs/bigdecimal": "0.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/intl-localematcher": "0.8.2"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
-      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.1.tgz",
+      "integrity": "sha512-CbNbf+tlJn1baRnPkNePnBqTLxGliG6DDgNa/UtV66abwIjwsliPMOt0172tzxABYzSuxZBZfcp//qI8AvBWPg==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
-      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.3.tgz",
+      "integrity": "sha512-HJWZ9S6JWey6iY5+YXE3Kd0ofWU1sC2KTTp56e1168g/xxWvVvr8k9G4fexIgwYV9wbtjY7kGYK5FjoWB3B2OQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/icu-skeleton-parser": "2.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/icu-skeleton-parser": "2.1.3"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
-      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.3.tgz",
+      "integrity": "sha512-9mFp8TJ166ZM2pcjKwsBWXrDnOJGT7vMEScVgLygUODPOsE8S6f/FHoacvrlHK1B4dYZk8vSCNruyPU64AfgJQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "3.2.0"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
-      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.2.tgz",
+      "integrity": "sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.0",
-        "tslib": "^2.8.1"
+        "@formatjs/fast-memoize": "3.1.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1734,9 +1733,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
-      "integrity": "sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1750,9 +1749,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.7.tgz",
-      "integrity": "sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
       "cpu": [
         "arm64"
       ],
@@ -1766,9 +1765,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
-      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
       "cpu": [
         "x64"
       ],
@@ -1782,9 +1781,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
-      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
       "cpu": [
         "arm64"
       ],
@@ -1798,9 +1797,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
-      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
       ],
@@ -1814,9 +1813,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
-      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
       "cpu": [
         "x64"
       ],
@@ -1830,9 +1829,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
-      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
       ],
@@ -1846,9 +1845,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
-      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
       "cpu": [
         "arm64"
       ],
@@ -1862,9 +1861,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
-      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
       "cpu": [
         "x64"
       ],
@@ -4654,6 +4653,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -6119,9 +6119,9 @@
       }
     },
     "node_modules/icu-minify": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.8.3.tgz",
-      "integrity": "sha512-65Av7FLosNk7bPbmQx5z5XG2Y3T2GFppcjiXh4z1idHeVgQxlDpAmkGoYI0eFzAvrOnjpWTL5FmPDhsdfRMPEA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.9.1.tgz",
+      "integrity": "sha512-6NkfF9GHHFouqnz+wuiLjCWQiyxoEyJ5liUv4Jxxo/8wyhV7MY0L0iTEGDAVEa4aAD58WqTxFMa20S5nyMjwNw==",
       "funding": [
         {
           "type": "individual",
@@ -6202,15 +6202,14 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.2.tgz",
-      "integrity": "sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.0.tgz",
+      "integrity": "sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.1.1",
-        "@formatjs/fast-memoize": "3.1.0",
-        "@formatjs/icu-messageformat-parser": "3.5.1",
-        "tslib": "^2.8.1"
+        "@formatjs/ecma402-abstract": "3.2.0",
+        "@formatjs/fast-memoize": "3.1.1",
+        "@formatjs/icu-messageformat-parser": "3.5.3"
       }
     },
     "node_modules/is-alphabetical": {
@@ -7781,12 +7780,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.7.tgz",
-      "integrity": "sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.7",
+        "@next/env": "16.2.3",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -7800,15 +7799,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.7",
-        "@next/swc-darwin-x64": "16.1.7",
-        "@next/swc-linux-arm64-gnu": "16.1.7",
-        "@next/swc-linux-arm64-musl": "16.1.7",
-        "@next/swc-linux-x64-gnu": "16.1.7",
-        "@next/swc-linux-x64-musl": "16.1.7",
-        "@next/swc-win32-arm64-msvc": "16.1.7",
-        "@next/swc-win32-x64-msvc": "16.1.7",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7834,9 +7833,9 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.3.tgz",
-      "integrity": "sha512-PvdBDWg+Leh7BR7GJUQbCDVVaBRn37GwDBWc9sv0rVQOJDQ5JU1rVzx9EEGuOGYo0DHAl70++9LQ7HxTawdL7w==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.9.1.tgz",
+      "integrity": "sha512-N7ga0CjtYcdxNvaKNIi6eJ2mmatlHK5hp8rt0YO2Omoc1m0gean242/Ukdj6+gJNiReBVcYIjK0HZeNx7CV1ug==",
       "funding": [
         {
           "type": "individual",
@@ -7848,16 +7847,15 @@
         "@formatjs/intl-localematcher": "^0.8.1",
         "@parcel/watcher": "^2.4.1",
         "@swc/core": "^1.15.2",
-        "icu-minify": "^4.8.3",
+        "icu-minify": "^4.9.1",
         "negotiator": "^1.0.0",
-        "next-intl-swc-plugin-extractor": "^4.8.3",
+        "next-intl-swc-plugin-extractor": "^4.9.1",
         "po-parser": "^2.1.1",
-        "use-intl": "^4.8.3"
+        "use-intl": "^4.9.1"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
-        "typescript": "^5.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -7866,9 +7864,9 @@
       }
     },
     "node_modules/next-intl-swc-plugin-extractor": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.8.3.tgz",
-      "integrity": "sha512-YcaT+R9z69XkGhpDarVFWUprrCMbxgIQYPUaXoE6LGVnLjGdo8hu3gL6bramDVjNKViYY8a/pXPy7Bna0mXORg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.9.1.tgz",
+      "integrity": "sha512-8whJJ6oxJz8JqkHarggmmuEDyXgC7nEnaPhZD91CJwEWW4xp0AST3Mw17YxvHyP2vAF3taWfFbs1maD+WWtz3w==",
       "license": "MIT"
     },
     "node_modules/next-intl/node_modules/@swc/core": {
@@ -10012,7 +10010,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10212,9 +10210,9 @@
       }
     },
     "node_modules/use-intl": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.8.3.tgz",
-      "integrity": "sha512-nLxlC/RH+le6g3amA508Itnn/00mE+J22ui21QhOWo5V9hCEC43+WtnRAITbJW0ztVZphev5X9gvOf2/Dk9PLA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.9.1.tgz",
+      "integrity": "sha512-iGVV/xFYlhe3btafRlL8RPLD2Jsuet4yqn9DR6LWWbMhULsJnXgLonDkzDmsAIBIwFtk02oJuX/Ox2vwHKF+UQ==",
       "funding": [
         {
           "type": "individual",
@@ -10225,7 +10223,7 @@
       "dependencies": {
         "@formatjs/fast-memoize": "^3.1.0",
         "@schummar/icu-type-parser": "1.21.5",
-        "icu-minify": "^4.8.3",
+        "icu-minify": "^4.9.1",
         "intl-messageformat": "^11.1.0"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "lucide-react": "^0.577.0",
-    "next": "^16.1.7",
-    "next-intl": "^4.8.3",
+    "next": "^16.2.3",
+    "next-intl": "^4.9.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.1"

--- a/frontend/src/lib/verseExtraction.test.ts
+++ b/frontend/src/lib/verseExtraction.test.ts
@@ -1581,6 +1581,27 @@ describe("extractVerseReferences — Hindi", () => {
 
 // ── Hindi: no-space and Devanagari numeral improvements ─────────────────────────
 
+describe("extractVerseReferences — Hindi edge cases (verse range + conjunction, alt spelling)", () => {
+  it("should detect all three refs in a verse-range + 'और' context (no '4 और इब्रानियों' garbage)", () => {
+    const text =
+      "यह बाइबिल से है, विशेष रूप से लेवियतियुस 1:3-4 और इब्रानियों 9:22। रोमियों 12:1 में कहा गया है।";
+    const refs = extractVerseReferences(text);
+    expect(refs.has("leviticus 1:3")).toBe(true);
+    expect(refs.has("hebrews 9:22")).toBe(true);
+    expect(refs.has("romans 12:1")).toBe(true);
+    // Must not produce the greedy '4 और इब्रानियों' garbage match.
+    for (const r of refs) {
+      expect(r.startsWith("4 ")).toBe(false);
+      expect(r).not.toContain("और");
+    }
+  });
+
+  it("should detect alternate transliteration लेवियतियुस → leviticus", () => {
+    const refs = extractVerseReferences("लेवियतियुस 1:3");
+    expect(refs.has("leviticus 1:3")).toBe(true);
+  });
+});
+
 describe("extractVerseReferences — Hindi no-space and Devanagari numerals", () => {
   describe("no-space references", () => {
     it("should detect यूहन्ना3:16 (no space) → john 3:16", () => {

--- a/frontend/src/lib/verseExtraction.ts
+++ b/frontend/src/lib/verseExtraction.ts
@@ -444,6 +444,7 @@ export const LOCALIZED_BOOK_TO_ENGLISH: Record<string, string> = {
   उत्पत्ति: "genesis",
   निर्गमन: "exodus",
   लैव्यव्यवस्था: "leviticus",
+  लेवियतियुस: "leviticus", // alternate transliteration used by some LLMs
   गिनती: "numbers",
   व्यवस्थाविवरण: "deuteronomy",
   यहोशू: "joshua",

--- a/frontend/src/lib/versePatterns.test.ts
+++ b/frontend/src/lib/versePatterns.test.ts
@@ -59,12 +59,17 @@ describe("getMultiWordAlternation", () => {
     }
   });
 
-  it("should NOT include number-prefixed book names", () => {
-    // "1 царств", "2 samuel", etc. are handled by the \\d+ branch — must not appear
-    // as a multi-word alternate.
+  it("should NOT include number-prefixed Latin/Cyrillic/Arabic book names", () => {
+    // "1 царств", "2 samuel", "1 أخبار الأيام", etc. are handled by the \\d+ branch
+    // and must not appear as multi-word alternates.
+    // EXCEPTION: number-prefixed non-Latin (Han/Hangul/Devanagari) books must be
+    // listed explicitly because the numbered-prefix branch excludes those scripts.
+    const NON_LATIN = /[\p{Script=Han}\p{Script=Hangul}\p{Script=Devanagari}]/u;
     const parts = getMultiWordAlternation().split("|");
     for (const part of parts) {
-      expect(part).not.toMatch(/^\d/);
+      if (part.match(/^\d/)) {
+        expect(part).toMatch(NON_LATIN);
+      }
     }
   });
 

--- a/frontend/src/lib/versePatterns.ts
+++ b/frontend/src/lib/versePatterns.ts
@@ -90,9 +90,18 @@ export function getMultiWordAlternation(): string {
   } else {
     // Collect all multi-word localized book names.
     // A "multi-word" key is one that contains a space AND is NOT number-prefixed.
-    multiWordNames = Object.keys(LOCALIZED_BOOK_TO_ENGLISH).filter(
-      (key) => key.includes(" ") && !isNumberPrefixed(key),
-    );
+    // Number-prefixed Latin/Cyrillic/Arabic books (e.g. "1 samuel", "1 царств",
+    // "1 أخبار الأيام") are handled by the numbered-prefix \d+ branch in the regex.
+    // BUT number-prefixed Han/Hangul/Devanagari books (e.g. "1 शमूएल", "1 요한") must
+    // be listed explicitly here, because the numbered-prefix branch excludes those
+    // scripts to prevent greedy over-matching of surrounding non-Latin context text.
+    const NON_LATIN_SCRIPT_RE =
+      /[\p{Script=Han}\p{Script=Hangul}\p{Script=Devanagari}]/u;
+    multiWordNames = Object.keys(LOCALIZED_BOOK_TO_ENGLISH).filter((key) => {
+      if (!key.includes(" ")) return false;
+      if (isNumberPrefixed(key)) return NON_LATIN_SCRIPT_RE.test(key);
+      return true;
+    });
 
     // Sort longest-first so that longer alternates (e.g. "деяния апостолов")
     // are tried before shorter ones (e.g. "деяния") — prevents partial matches.
@@ -207,6 +216,8 @@ function getDevanagariAlternation(): string {
  *     (e.g. Russian: Плач Иеремии, Песня Песней; plus any names loaded via API)
  *  2. Multi-word books joined by a connector word (Song of Solomon, Cantique des Cantiques…)
  *  3. Numbered-prefix books (1 John, 2 Kings, 1. Mose, 2. Könige, 1 أخبار الأيام…)
+ *     Han/Hangul/Devanagari characters are excluded from this branch — all legitimate
+ *     CJK/Korean/Hindi numbered books are already covered by branches 1, 4, and 5.
  *  4. Chinese/CJK book names — explicit alternation of known names from the map.
  *     Unlike the generic [\p{Script=Han}]{2,} that was used before, an explicit
  *     alternation prevents greedy over-matching of surrounding CJK context text.
@@ -256,7 +267,7 @@ function buildPatternSource(): string {
   _cachedPatternSource =
     `(?:(?<!\\p{L})|(?<=\\p{Script=Han})|(?<=\\p{Script=Hangul})|(?<=\\p{Script=Devanagari})|(?<=[\u300A\u300C\u300E]))(${multiWordPart}` +
     `[\\p{L}\\p{M}]{2,}(?:\\s+(?:of|dei|des|der|van|de|af|dos|da|del|के|ال)\\s+[\\p{L}\\p{M}]+)+` +
-    `|\\d+(?:\\.|-[\\p{L}\\p{M}]{1,2})?\\s*[\\p{L}\\p{M}]{2,}(?:\\s+[\\p{L}\\p{M}]+)*` +
+    `|\\d+(?:\\.|-(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}]{1,2})?\\s*(?:(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}]){2,}(?:\\s+(?:(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}])+)*` +
     `|${cjkPart}` +
     `${hangulPart}` +
     `${devanagariPart}` +


### PR DESCRIPTION
## Summary
Companion to #403 (Hindi web edge cases). After verifying with a standalone Java repro that Android's existing regex correctly handles both Hindi edge-case scenarios, this PR adds regression tests to lock in the current behaviour.

**Why Android is not vulnerable to the two web-side bugs:**

1. **Greedy numbered-prefix match** — Android's numbered branch is `[1-3](?:[\s.][\s]?|-...)`. It can only start with `1`, `2`, or `3`, so the dangling `4` from a verse range like `1:3-4` cannot trigger a false match that would swallow `4 और इब्रानियों`.

2. **Unknown Devanagari spellings** — Android's generic `BOOK_NAME = [\p{Lu}\p{Lo}][\p{L}\p{M}\d]*` already accepts any Devanagari starting character (`फ`, `ल`, etc. are in `\p{Lo}`). Unknown spellings like `लेवियतियुस` are matched and wrapped in a `verse://` link. Backend `HINDI_ALIASES` (from #403) handles resolving the alternate spelling to Leviticus on tap.

## Test plan
- [x] Added test `injectVerseLinks handles Hindi verse-range followed by और and another book` — asserts all three of Leviticus/Hebrews/Romans are wrapped and no `[4 और` garbage link is produced.
- [x] Added test `injectVerseLinks wraps Hindi alternate transliteration लेवियतियुस` — asserts the unknown spelling is still wrapped.
- [x] Standalone Java regex repro confirmed both tests match against the current production regex.

https://claude.ai/code/session_01G9YnnrDxpy1NEbyK7hSxdK