### PR TITLE
fix: harden infrastructure to surface errors instead of hiding them

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -249,7 +249,8 @@ jobs:
       - name: Compile Kotlin sources (release)
         run: |
           ./gradlew compileReleaseKotlin --no-daemon \
-            -PbaseUrl=${{ vars.BACKEND_API_URL || 'https://api.voxquieta.org/' }}
+            -PbaseUrl=${{ vars.BACKEND_API_URL || 'https://api.voxquieta.org/' }} \
+            -PfrontendUrl=${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
         working-directory: android
 
   # ---------------------------------------------------------------------------
@@ -397,7 +398,8 @@ jobs:
       - name: Build prod APK (debuggable, points to production backend)
         run: |
           ./gradlew assembleDebug --no-daemon \
-            -PbaseUrl=${{ vars.BACKEND_API_URL || 'https://api.voxquieta.org/' }}
+            -PbaseUrl=${{ vars.BACKEND_API_URL || 'https://api.voxquieta.org/' }} \
+            -PfrontendUrl=${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
         working-directory: android
 
       - name: Upload prod APK
@@ -493,7 +495,8 @@ jobs:
       - name: Build prod APK (debuggable, points to production backend)
         run: |
           ./gradlew assembleDebug --no-daemon \
-            -PbaseUrl=${{ vars.BACKEND_API_URL || 'https://api.voxquieta.org/' }}
+            -PbaseUrl=${{ vars.BACKEND_API_URL || 'https://api.voxquieta.org/' }} \
+            -PfrontendUrl=${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
         working-directory: android
 
       - name: Check AndroidManifest security flags

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -524,7 +524,8 @@ jobs:
             echo "cert_decoded=false" >> $GITHUB_ENV
           else
             echo "$CERT_B64" | base64 -d > ${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx
-            echo "TF_VAR_cloudflare_origin_cert_frontend=${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx" >> $GITHUB_ENV
+            # Path relative to TF working dir so filemd5() and az CLI resolve correctly
+            echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
             echo "cert_decoded=true" >> $GITHUB_ENV
           fi
 
@@ -816,7 +817,8 @@ jobs:
             echo "cert_decoded=false" >> $GITHUB_ENV
           else
             echo "$CERT_B64" | base64 -d > deployment/cloudflare-origin.pfx
-            echo "TF_VAR_cloudflare_origin_cert_frontend=deployment/cloudflare-origin.pfx" >> $GITHUB_ENV
+            # Path relative to TF working dir so filemd5() and az CLI resolve correctly
+            echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
             echo "cert_decoded=true" >> $GITHUB_ENV
           fi
 
@@ -911,7 +913,8 @@ jobs:
           FAILED=0
           for DOMAIN in "${DOMAINS[@]}"; do
             echo "Checking https://$DOMAIN ..."
-            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://$DOMAIN/health" 2>/dev/null || echo "000")
+            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+              --max-time 15 "https://$DOMAIN/health" 2>/dev/null || echo "000")
             CF_RAY=$(curl -sI --max-time 15 "https://$DOMAIN/health" 2>/dev/null | grep -i 'cf-ray' || echo "")
 
             if [ "$HTTP_CODE" = "526" ]; then
@@ -1056,7 +1059,8 @@ jobs:
             echo "cert_decoded=false" >> $GITHUB_ENV
           else
             echo "$CERT_B64" | base64 -d > ${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx
-            echo "TF_VAR_cloudflare_origin_cert_frontend=${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx" >> $GITHUB_ENV
+            # Path relative to TF working dir so filemd5() and az CLI resolve correctly
+            echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
             echo "cert_decoded=true" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -903,6 +903,33 @@ jobs:
             echo "Frontend URL: https://$FRONTEND_FQDN"
           fi
 
+      - name: Verify Custom Domain HTTPS
+        if: env.cert_decoded == 'true'
+        run: |
+          set -euo pipefail
+          DOMAINS=("voxquieta.org" "api.voxquieta.org")
+          FAILED=0
+          for DOMAIN in "${DOMAINS[@]}"; do
+            echo "Checking https://$DOMAIN ..."
+            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://$DOMAIN/health" 2>/dev/null || echo "000")
+            CF_RAY=$(curl -sI --max-time 15 "https://$DOMAIN/health" 2>/dev/null | grep -i 'cf-ray' || echo "")
+
+            if [ "$HTTP_CODE" = "526" ]; then
+              echo "::error::$DOMAIN returned HTTP 526 (Invalid SSL Certificate) — cert binding is wrong"
+              FAILED=1
+            elif [ "$HTTP_CODE" = "000" ]; then
+              echo "::warning::$DOMAIN is unreachable (DNS may not be propagated yet)"
+            elif [ -z "$CF_RAY" ]; then
+              echo "::warning::$DOMAIN responded HTTP $HTTP_CODE but no cf-ray header (not going through Cloudflare)"
+            else
+              echo "$DOMAIN OK — HTTP $HTTP_CODE, $CF_RAY"
+            fi
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::One or more domains have SSL certificate issues"
+            exit 1
+          fi
+
       - name: Post Deployment Summary
         run: |
           echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -518,10 +518,15 @@ jobs:
       - name: Decode Cloudflare Origin Certificate
         env:
           CERT_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_B64 }}
-        if: env.CERT_B64 != ''
         run: |
-          echo "$CERT_B64" | base64 -d > ${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx
-          echo "TF_VAR_cloudflare_origin_cert_frontend=${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx" >> $GITHUB_ENV
+          if [ -z "$CERT_B64" ]; then
+            echo "::warning::CLOUDFLARE_ORIGIN_CERT_B64 secret is not set — custom domain SSL will not be configured"
+            echo "cert_decoded=false" >> $GITHUB_ENV
+          else
+            echo "$CERT_B64" | base64 -d > ${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx
+            echo "TF_VAR_cloudflare_origin_cert_frontend=${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx" >> $GITHUB_ENV
+            echo "cert_decoded=true" >> $GITHUB_ENV
+          fi
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
@@ -805,10 +810,15 @@ jobs:
       - name: Decode Cloudflare Origin Certificate
         env:
           CERT_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_B64 }}
-        if: env.CERT_B64 != ''
         run: |
-          echo "$CERT_B64" | base64 -d > deployment/cloudflare-origin.pfx
-          echo "TF_VAR_cloudflare_origin_cert_frontend=deployment/cloudflare-origin.pfx" >> $GITHUB_ENV
+          if [ -z "$CERT_B64" ]; then
+            echo "::warning::CLOUDFLARE_ORIGIN_CERT_B64 secret is not set — custom domain SSL will not be configured"
+            echo "cert_decoded=false" >> $GITHUB_ENV
+          else
+            echo "$CERT_B64" | base64 -d > deployment/cloudflare-origin.pfx
+            echo "TF_VAR_cloudflare_origin_cert_frontend=deployment/cloudflare-origin.pfx" >> $GITHUB_ENV
+            echo "cert_decoded=true" >> $GITHUB_ENV
+          fi
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
@@ -864,7 +874,18 @@ jobs:
           if [ -n "$BACKEND_FQDN" ]; then
             BACKEND_URL="https://$BACKEND_FQDN"
             echo "Backend URL: $BACKEND_URL"
-            curl -sf "$BACKEND_URL/health" || echo "Backend health check pending..."
+            for i in 1 2 3; do
+              if curl -sf "$BACKEND_URL/health" --max-time 10; then
+                echo "Backend health check passed"
+                break
+              fi
+              if [ "$i" -eq 3 ]; then
+                echo "::error::Backend health check failed after 3 attempts"
+                exit 1
+              fi
+              echo "Attempt $i failed, retrying in 10s..."
+              sleep 10
+            done
             # Export for functional-tests job
             echo "backend_url=$BACKEND_URL" >> $GITHUB_OUTPUT
           else
@@ -1002,10 +1023,15 @@ jobs:
       - name: Decode Cloudflare Origin Certificate
         env:
           CERT_B64: ${{ secrets.CLOUDFLARE_ORIGIN_CERT_B64 }}
-        if: env.CERT_B64 != ''
         run: |
-          echo "$CERT_B64" | base64 -d > ${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx
-          echo "TF_VAR_cloudflare_origin_cert_frontend=${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx" >> $GITHUB_ENV
+          if [ -z "$CERT_B64" ]; then
+            echo "::warning::CLOUDFLARE_ORIGIN_CERT_B64 secret is not set — custom domain SSL will not be configured"
+            echo "cert_decoded=false" >> $GITHUB_ENV
+          else
+            echo "$CERT_B64" | base64 -d > ${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx
+            echo "TF_VAR_cloudflare_origin_cert_frontend=${{ env.TF_WORKING_DIR }}/cloudflare-origin.pfx" >> $GITHUB_ENV
+            echo "cert_decoded=true" >> $GITHUB_ENV
+          fi
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,6 +39,7 @@ android {
             // Firebase is disabled in debug builds — no crash reports or analytics sent.
             buildConfigField("Boolean", "FIREBASE_ENABLED", "false")
             buildConfigField("String", "PRIVACY_POLICY_URL", "\"${gradleProp("privacyPolicyUrl", "https://voxquieta.org/privacy")}\"")
+            buildConfigField("String", "FRONTEND_URL", "\"${gradleProp("frontendUrl", "https://voxquieta.org")}\"")
         }
         release {
             isMinifyEnabled = true
@@ -49,6 +50,7 @@ android {
             // Firebase is enabled only in release builds.
             buildConfigField("Boolean", "FIREBASE_ENABLED", "true")
             buildConfigField("String", "PRIVACY_POLICY_URL", "\"${gradleProp("privacyPolicyUrl", "https://voxquieta.org/privacy")}\"")
+            buildConfigField("String", "FRONTEND_URL", "\"${gradleProp("frontendUrl", "https://voxquieta.org")}\"")
         }
     }
 

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/TurnstileWebView.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/TurnstileWebView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import org.voxquieta.app.BuildConfig
 import org.voxquieta.app.security.TurnstileManager
 
 /**
@@ -89,7 +90,7 @@ fun TurnstileWebView(
                     "Android",
                 )
                 loadDataWithBaseURL(
-                    "https://voxquieta.org",
+                    BuildConfig.FRONTEND_URL,
                     htmlContent,
                     "text/html",
                     "UTF-8",

--- a/api/config.py
+++ b/api/config.py
@@ -134,7 +134,7 @@ class Settings(BaseSettings):
     # Skip verification for these paths (prefix match).
     # Health probes, docs, and info endpoints don't go through the frontend
     # Turnstile widget and must work without a token.
-    turnstile_skip_paths: str = "/health,/docs,/redoc,/openapi.json,/config,/"
+    turnstile_skip_paths: str = "/health,/docs,/redoc,/openapi.json,/config,/,/api/v1/client-errors"
     # Development: Use Cloudflare test keys for local testing
     # Test secret: 1x0000000000000000000000000000000AA (always passes)
     # Test secret: 2x0000000000000000000000000000000AA (always fails)

--- a/api/main.py
+++ b/api/main.py
@@ -30,7 +30,7 @@ if _appinsights_conn:
         print(f"WARNING: Failed to configure Application Insights: {e}")
         print(_traceback.format_exc())
 
-from fastapi import Depends, FastAPI  # noqa: E402
+from fastapi import Depends, FastAPI, Request  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import JSONResponse  # noqa: E402
 
@@ -303,6 +303,30 @@ async def get_config():
             ),
         },
     }
+
+
+@app.post("/api/v1/client-errors", include_in_schema=False)
+async def report_client_error(request: Request):
+    """Receive client-side error reports (Turnstile failures, etc.)."""
+    body = await request.json()
+    client_ip = request.headers.get(
+        "CF-Connecting-IP",
+        request.headers.get(
+            "X-Forwarded-For", request.client.host if request.client else "unknown"
+        ),
+    )
+    logger.warning(
+        "Client error report: %s — %s",
+        body.get("type", "unknown"),
+        body.get("detail", ""),
+        extra={
+            "error_type": body.get("type"),
+            "error_detail": body.get("detail"),
+            "user_agent": request.headers.get("user-agent"),
+            "ip": client_ip,
+        },
+    )
+    return {"status": "ok"}
 
 
 @app.get("/debug/embeddings", tags=["debug"], dependencies=[Depends(require_local_access)])

--- a/api/tests/e2e/test_frontend_e2e.py
+++ b/api/tests/e2e/test_frontend_e2e.py
@@ -33,11 +33,16 @@ FRONTEND_URL   Base URL of the frontend to test against.
 """
 
 import os
+import sys
+from pathlib import Path
 
 import httpx
 import pytest
 
-FRONTEND_URL = os.environ.get("FRONTEND_URL", "https://voxquieta.org")
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+from config import settings
+
+FRONTEND_URL = os.environ.get("FRONTEND_URL", settings.production_frontend_url)
 
 # 60 s gives enough headroom for Azure Container Apps cold-start after a fresh
 # deploy.  The previous 30 s limit caused intermittent ReadTimeout failures on

--- a/api/tests/test_access_audit.py
+++ b/api/tests/test_access_audit.py
@@ -21,6 +21,7 @@ from fastapi.testclient import TestClient
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from config import settings
 from main import app
 from middleware.access_audit import (
     _classify_user_agent,
@@ -32,6 +33,9 @@ from middleware.access_audit import (
 
 client = TestClient(app)
 
+# Use the configured production URL so tests stay in sync with config
+PROD_URL = settings.production_frontend_url
+
 
 class TestAccessClassification:
     """Test source classification logic via real HTTP requests."""
@@ -41,7 +45,7 @@ class TestAccessClassification:
         with patch("middleware.access_audit.api_access_counter") as mock_counter:
             client.get(
                 "/api/v1/scripture/translations",
-                headers={"Origin": "https://voxquieta.org"},
+                headers={"Origin": PROD_URL},
             )
             mock_counter.add.assert_called()
             call_args = mock_counter.add.call_args
@@ -54,7 +58,7 @@ class TestAccessClassification:
         with patch("middleware.access_audit.api_access_counter") as mock_counter:
             client.get(
                 "/api/v1/scripture/translations",
-                headers={"Referer": "https://voxquieta.org/chat"},
+                headers={"Referer": f"{PROD_URL}/chat"},
             )
             mock_counter.add.assert_called()
             attrs = mock_counter.add.call_args[0][1]
@@ -117,7 +121,7 @@ class TestAccessClassification:
         with patch("middleware.access_audit.api_access_counter") as mock_counter:
             client.post(
                 "/api/v1/chat/stream",
-                headers={"Origin": "https://voxquieta.org"},
+                headers={"Origin": PROD_URL},
                 json={"message": "test"},
             )
             mock_counter.add.assert_called()
@@ -189,7 +193,7 @@ class TestPathNormalization:
             # and verify path normalization via unit tests above.
             client.get(
                 "/api/v1/scripture/translations",
-                headers={"Origin": "https://voxquieta.org"},
+                headers={"Origin": PROD_URL},
             )
             mock_counter.add.assert_called()
             attrs = mock_counter.add.call_args[0][1]
@@ -221,23 +225,23 @@ class TestOriginMatching:
     """Verify Origin/Referer matching logic."""
 
     def test_exact_match(self):
-        origins = ["https://voxquieta.org"]
-        assert _origin_matches("https://voxquieta.org", origins)
+        origins = [PROD_URL]
+        assert _origin_matches(PROD_URL, origins)
 
     def test_trailing_slash(self):
-        origins = ["https://voxquieta.org"]
-        assert _origin_matches("https://voxquieta.org/", origins)
+        origins = [PROD_URL]
+        assert _origin_matches(f"{PROD_URL}/", origins)
 
     def test_referer_with_path(self):
-        origins = ["https://voxquieta.org"]
-        assert _origin_matches("https://voxquieta.org/chat", origins)
+        origins = [PROD_URL]
+        assert _origin_matches(f"{PROD_URL}/chat", origins)
 
     def test_no_match(self):
-        origins = ["https://voxquieta.org"]
+        origins = [PROD_URL]
         assert not _origin_matches("https://evil.example.com", origins)
 
     def test_empty_value(self):
-        origins = ["https://voxquieta.org"]
+        origins = [PROD_URL]
         assert not _origin_matches("", origins)
 
     def test_localhost(self):

--- a/api/tests/test_llama_guard.py
+++ b/api/tests/test_llama_guard.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from config import settings
 from providers.llama_guard import LlamaGuardProvider
 
 
@@ -343,7 +344,7 @@ async def test_api_call_format():
         assert call_args[0] == "https://openrouter.ai/api/v1/chat/completions"
         assert call_kwargs["headers"]["Authorization"] == "Bearer test-key"
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
-        assert call_kwargs["headers"]["HTTP-Referer"] == "https://voxquieta.org"
+        assert call_kwargs["headers"]["HTTP-Referer"] == settings.production_frontend_url
         assert call_kwargs["headers"]["X-Title"] == "VoxQuieta"
         assert call_kwargs["json"]["model"] == "meta-llama/llama-guard-3-8b"
         assert call_kwargs["json"]["temperature"] == 0

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -893,6 +893,112 @@ Budget alerts will email you at 80% and 100% of your $50 limit.
 - [pgvector on Azure](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-use-pgvector)
 - [Terraform AzureRM Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest)
 
+## Cloudflare Manual Configuration Checklist
+
+Some Cloudflare settings cannot be managed by Terraform and must be configured manually in the Cloudflare Dashboard. After deploying a new domain or changing certificates, verify all of these:
+
+### Turnstile Hostname Allow-List
+
+The Cloudflare Turnstile widget will silently fail if the hostname it runs on is not in the allow-list. When adding a new domain:
+
+1. Go to **Cloudflare Dashboard** -> **Turnstile** -> select your widget
+2. Under **Hostname Management**, add every domain the frontend runs on (e.g. `voxquieta.org`, `www.voxquieta.org`)
+3. The Turnstile site key in `terraform.tfvars` (`turnstile_site_key`) must match the widget
+
+**Symptom if missing:** Backend logs show "Missing Turnstile token" for all requests. Frontend silently falls back to sending requests without a token.
+
+### SSL/TLS Mode
+
+1. Go to **SSL/TLS** -> **Overview**
+2. Set mode to **Full (Strict)** when using Cloudflare Origin Certificates
+3. "Full (Strict)" validates the origin cert is trusted by Cloudflare; "Full" skips validation
+
+**Symptom if wrong:** Error 526 (Invalid SSL Certificate) when set to "Full (Strict)" without a valid origin cert installed.
+
+### Origin Certificate Creation
+
+When creating a new Cloudflare Origin Certificate:
+
+1. Go to **SSL/TLS** -> **Origin Server** -> **Create Certificate**
+2. Select RSA (2048), add hostnames: `yourdomain.com`, `*.yourdomain.com`
+3. Set validity to 15 years
+4. Save cert as `origin-cert.pem` and key as `origin-key.pem`
+5. Convert to PFX: `openssl pkcs12 -export -out cloudflare-origin.pfx -inkey origin-key.pem -in origin-cert.pem -passout pass:`
+6. Base64-encode for CI: `base64 -w 0 cloudflare-origin.pfx` and store as `CLOUDFLARE_ORIGIN_CERT_B64` GitHub secret
+
+**Important:** A wildcard cert (`*.voxquieta.org`) does NOT cover the apex domain (`voxquieta.org`). Ensure both are listed as hostnames when creating the cert.
+
+### DNS Records
+
+For each custom domain, create:
+
+| Type | Name | Target | Proxy |
+|------|------|--------|-------|
+| CNAME | `@` (or subdomain) | `<app>.agreeablesea-6ee07535.northeurope.azurecontainerapps.io` | Proxied |
+| TXT | `asuid.<domain>` | `<domain_verification_id>` (from `terraform output`) | DNS only |
+
+### Domain Verification ID
+
+Get the verification ID needed for the TXT record:
+
+```bash
+terraform output domain_verification_id
+```
+
+## Rollback: Emergency Cert Rebind
+
+If a deployment breaks custom domain HTTPS (e.g. Error 526), use these commands to manually fix it without waiting for a full CI/CD cycle:
+
+```bash
+# Variables — adjust for your environment
+ENV_NAME="bible-app-env"
+RG="bible-app-rg"
+FRONTEND_APP="bible-app-frontend"
+BACKEND_APP="bible-app-backend"
+
+# 1. Upload the certificate (if not already present)
+az containerapp env certificate upload \
+  --name $ENV_NAME \
+  --resource-group $RG \
+  --certificate-file cloudflare-origin.pfx \
+  --password ""
+
+# 2. Find the correct certificate by SAN
+az containerapp env certificate list \
+  --name $ENV_NAME \
+  --resource-group $RG \
+  --query "[].{name:name, SANs:properties.subjectAlternativeNames, expiry:properties.expirationDate}" \
+  -o table
+
+# 3. Get cert ID for voxquieta.org
+CERT_ID=$(az containerapp env certificate list \
+  --name $ENV_NAME \
+  --resource-group $RG \
+  --query "[?properties.subjectAlternativeNames[?contains(@, 'voxquieta.org')]] | [0].id" \
+  -o tsv)
+echo "Using cert: $CERT_ID"
+
+# 4. Bind to frontend
+az containerapp hostname bind \
+  --name $FRONTEND_APP \
+  --resource-group $RG \
+  --hostname voxquieta.org \
+  --certificate "$CERT_ID" \
+  --environment $ENV_NAME
+
+# 5. Bind to backend
+az containerapp hostname bind \
+  --name $BACKEND_APP \
+  --resource-group $RG \
+  --hostname api.voxquieta.org \
+  --certificate "$CERT_ID" \
+  --environment $ENV_NAME
+
+# 6. Verify through Cloudflare edge
+curl -sI https://voxquieta.org/health | grep -E 'HTTP|cf-ray'
+curl -sI https://api.voxquieta.org/health | grep -E 'HTTP|cf-ray'
+```
+
 ## 📝 License
 
 MIT License - see repository root for details.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -895,17 +895,22 @@ Budget alerts will email you at 80% and 100% of your $50 limit.
 
 ## Cloudflare Manual Configuration Checklist
 
-Some Cloudflare settings cannot be managed by Terraform and must be configured manually in the Cloudflare Dashboard. After deploying a new domain or changing certificates, verify all of these:
+Some Cloudflare settings cannot be managed by Terraform and must be
+configured manually in the Cloudflare Dashboard. After deploying a new
+domain or changing certificates, verify all of these:
 
 ### Turnstile Hostname Allow-List
 
-The Cloudflare Turnstile widget will silently fail if the hostname it runs on is not in the allow-list. When adding a new domain:
+The Cloudflare Turnstile widget will silently fail if the hostname it
+runs on is not in the allow-list. When adding a new domain:
 
 1. Go to **Cloudflare Dashboard** -> **Turnstile** -> select your widget
 2. Under **Hostname Management**, add every domain the frontend runs on (e.g. `voxquieta.org`, `www.voxquieta.org`)
 3. The Turnstile site key in `terraform.tfvars` (`turnstile_site_key`) must match the widget
 
-**Symptom if missing:** Backend logs show "Missing Turnstile token" for all requests. Frontend silently falls back to sending requests without a token.
+**Symptom if missing:** Backend logs show "Missing Turnstile token"
+for all requests. Frontend silently falls back to sending requests
+without a token.
 
 ### SSL/TLS Mode
 
@@ -923,10 +928,13 @@ When creating a new Cloudflare Origin Certificate:
 2. Select RSA (2048), add hostnames: `yourdomain.com`, `*.yourdomain.com`
 3. Set validity to 15 years
 4. Save cert as `origin-cert.pem` and key as `origin-key.pem`
-5. Convert to PFX: `openssl pkcs12 -export -out cloudflare-origin.pfx -inkey origin-key.pem -in origin-cert.pem -passout pass:`
+5. Convert to PFX:
+   `openssl pkcs12 -export -out cloudflare-origin.pfx -inkey origin-key.pem -in origin-cert.pem -passout pass:`
 6. Base64-encode for CI: `base64 -w 0 cloudflare-origin.pfx` and store as `CLOUDFLARE_ORIGIN_CERT_B64` GitHub secret
 
-**Important:** A wildcard cert (`*.voxquieta.org`) does NOT cover the apex domain (`voxquieta.org`). Ensure both are listed as hostnames when creating the cert.
+**Important:** A wildcard cert (`*.voxquieta.org`) does NOT cover
+the apex domain (`voxquieta.org`). Ensure both are listed as
+hostnames when creating the cert.
 
 ### DNS Records
 
@@ -947,7 +955,8 @@ terraform output domain_verification_id
 
 ## Rollback: Emergency Cert Rebind
 
-If a deployment breaks custom domain HTTPS (e.g. Error 526), use these commands to manually fix it without waiting for a full CI/CD cycle:
+If a deployment breaks custom domain HTTPS (e.g. Error 526), use
+these commands to manually fix without waiting for a full CI/CD cycle:
 
 ```bash
 # Variables — adjust for your environment

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -687,13 +687,14 @@ resource "null_resource" "frontend_custom_domain" {
   }
 
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
+      set -euo pipefail
       echo "Adding custom domain ${var.custom_domain_frontend} to ${azurerm_container_app.frontend.name}..."
       az containerapp hostname add \
         --name ${azurerm_container_app.frontend.name} \
         --resource-group ${azurerm_resource_group.main.name} \
-        --hostname ${var.custom_domain_frontend} \
-        || echo "Warning: Failed to add hostname. Ensure DNS is configured with CNAME pointing to ${azurerm_container_app.frontend.ingress[0].fqdn}"
+        --hostname ${var.custom_domain_frontend}
     EOT
   }
 
@@ -711,13 +712,14 @@ resource "null_resource" "backend_custom_domain" {
   }
 
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
+      set -euo pipefail
       echo "Adding custom domain ${var.custom_domain_backend} to ${azurerm_container_app.backend.name}..."
       az containerapp hostname add \
         --name ${azurerm_container_app.backend.name} \
         --resource-group ${azurerm_resource_group.main.name} \
-        --hostname ${var.custom_domain_backend} \
-        || echo "Warning: Failed to add hostname. Ensure DNS is configured with CNAME pointing to ${azurerm_container_app.backend.ingress[0].fqdn}"
+        --hostname ${var.custom_domain_backend}
     EOT
   }
 
@@ -749,14 +751,15 @@ resource "null_resource" "frontend_ssl_cert_upload" {
   }
 
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
+      set -euo pipefail
       echo "Uploading Cloudflare Origin Certificate for frontend..."
       az containerapp env certificate upload \
         --name ${azurerm_container_app_environment.main.name} \
         --resource-group ${azurerm_resource_group.main.name} \
         --certificate-file ${var.cloudflare_origin_cert_frontend} \
-        --password "${var.cloudflare_origin_cert_password}" \
-        || echo "Warning: Certificate may already exist or upload failed"
+        --password "${var.cloudflare_origin_cert_password}"
     EOT
   }
 
@@ -776,7 +779,9 @@ resource "null_resource" "frontend_ssl_cert_bind" {
   }
 
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
+      set -euo pipefail
       echo "Binding SSL certificate to ${var.custom_domain_frontend}..."
 
       # Get the certificate ID (most recently uploaded cert for this environment)
@@ -791,8 +796,7 @@ resource "null_resource" "frontend_ssl_cert_bind" {
           --resource-group ${azurerm_resource_group.main.name} \
           --hostname ${var.custom_domain_frontend} \
           --certificate "$CERT_ID" \
-          --environment ${azurerm_container_app_environment.main.name} \
-          || echo "Warning: Failed to bind certificate. Hostname may not be configured."
+          --environment ${azurerm_container_app_environment.main.name}
       else
         echo "Error: No certificate found in environment"
         exit 1
@@ -817,14 +821,15 @@ resource "null_resource" "backend_ssl_cert_upload" {
   }
 
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
+      set -euo pipefail
       echo "Uploading Cloudflare Origin Certificate for backend..."
       az containerapp env certificate upload \
         --name ${azurerm_container_app_environment.main.name} \
         --resource-group ${azurerm_resource_group.main.name} \
         --certificate-file ${var.cloudflare_origin_cert_backend} \
-        --password "${var.cloudflare_origin_cert_password}" \
-        || echo "Warning: Certificate may already exist or upload failed"
+        --password "${var.cloudflare_origin_cert_password}"
     EOT
   }
 
@@ -844,7 +849,9 @@ resource "null_resource" "backend_ssl_cert_bind" {
   }
 
   provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
+      set -euo pipefail
       echo "Binding SSL certificate to ${var.custom_domain_backend}..."
 
       # Get the certificate ID (most recently uploaded cert for this environment)
@@ -859,8 +866,7 @@ resource "null_resource" "backend_ssl_cert_bind" {
           --resource-group ${azurerm_resource_group.main.name} \
           --hostname ${var.custom_domain_backend} \
           --certificate "$CERT_ID" \
-          --environment ${azurerm_container_app_environment.main.name} \
-          || echo "Warning: Failed to bind certificate. Hostname may not be configured."
+          --environment ${azurerm_container_app_environment.main.name}
       else
         echo "Error: No certificate found in environment"
         exit 1

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -746,6 +746,7 @@ resource "null_resource" "frontend_ssl_cert_upload" {
 
   triggers = {
     cert_file      = var.cloudflare_origin_cert_frontend
+    cert_hash      = var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : ""
     environment    = azurerm_container_app_environment.main.name
     resource_group = azurerm_resource_group.main.name
   }
@@ -782,25 +783,34 @@ resource "null_resource" "frontend_ssl_cert_bind" {
     interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
       set -euo pipefail
-      echo "Binding SSL certificate to ${var.custom_domain_frontend}..."
+      DOMAIN="${var.custom_domain_frontend}"
+      echo "Binding SSL certificate to $DOMAIN..."
 
-      # Get the certificate ID (most recently uploaded cert for this environment)
+      # Find the certificate whose SANs cover this domain, sorted by expiry (newest first)
       CERT_ID=$(az containerapp env certificate list \
         --name ${azurerm_container_app_environment.main.name} \
         --resource-group ${azurerm_resource_group.main.name} \
-        --query "[-1].id" -o tsv)
+        --query "[?properties.subjectAlternativeNames[?contains(@, '$DOMAIN')] || properties.subjectAlternativeNames[?contains(@, '*.$DOMAIN')]] | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id" \
+        -o tsv)
 
-      if [ -n "$CERT_ID" ]; then
-        az containerapp hostname bind \
-          --name ${azurerm_container_app.frontend.name} \
+      if [ -z "$CERT_ID" ]; then
+        echo "ERROR: No certificate found with SAN covering $DOMAIN"
+        echo "Available certificates:"
+        az containerapp env certificate list \
+          --name ${azurerm_container_app_environment.main.name} \
           --resource-group ${azurerm_resource_group.main.name} \
-          --hostname ${var.custom_domain_frontend} \
-          --certificate "$CERT_ID" \
-          --environment ${azurerm_container_app_environment.main.name}
-      else
-        echo "Error: No certificate found in environment"
+          --query "[].{name:name, SANs:properties.subjectAlternativeNames, expiry:properties.expirationDate}" \
+          -o table
         exit 1
       fi
+
+      echo "Found certificate $CERT_ID for domain $DOMAIN"
+      az containerapp hostname bind \
+        --name ${azurerm_container_app.frontend.name} \
+        --resource-group ${azurerm_resource_group.main.name} \
+        --hostname $DOMAIN \
+        --certificate "$CERT_ID" \
+        --environment ${azurerm_container_app_environment.main.name}
     EOT
   }
 
@@ -816,6 +826,7 @@ resource "null_resource" "backend_ssl_cert_upload" {
 
   triggers = {
     cert_file      = var.cloudflare_origin_cert_backend
+    cert_hash      = var.cloudflare_origin_cert_backend != "" ? filemd5(var.cloudflare_origin_cert_backend) : ""
     environment    = azurerm_container_app_environment.main.name
     resource_group = azurerm_resource_group.main.name
   }
@@ -852,25 +863,34 @@ resource "null_resource" "backend_ssl_cert_bind" {
     interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
       set -euo pipefail
-      echo "Binding SSL certificate to ${var.custom_domain_backend}..."
+      DOMAIN="${var.custom_domain_backend}"
+      echo "Binding SSL certificate to $DOMAIN..."
 
-      # Get the certificate ID (most recently uploaded cert for this environment)
+      # Find the certificate whose SANs cover this domain, sorted by expiry (newest first)
       CERT_ID=$(az containerapp env certificate list \
         --name ${azurerm_container_app_environment.main.name} \
         --resource-group ${azurerm_resource_group.main.name} \
-        --query "[-1].id" -o tsv)
+        --query "[?properties.subjectAlternativeNames[?contains(@, '$DOMAIN')] || properties.subjectAlternativeNames[?contains(@, '*.$DOMAIN')]] | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id" \
+        -o tsv)
 
-      if [ -n "$CERT_ID" ]; then
-        az containerapp hostname bind \
-          --name ${azurerm_container_app.backend.name} \
+      if [ -z "$CERT_ID" ]; then
+        echo "ERROR: No certificate found with SAN covering $DOMAIN"
+        echo "Available certificates:"
+        az containerapp env certificate list \
+          --name ${azurerm_container_app_environment.main.name} \
           --resource-group ${azurerm_resource_group.main.name} \
-          --hostname ${var.custom_domain_backend} \
-          --certificate "$CERT_ID" \
-          --environment ${azurerm_container_app_environment.main.name}
-      else
-        echo "Error: No certificate found in environment"
+          --query "[].{name:name, SANs:properties.subjectAlternativeNames, expiry:properties.expirationDate}" \
+          -o table
         exit 1
       fi
+
+      echo "Found certificate $CERT_ID for domain $DOMAIN"
+      az containerapp hostname bind \
+        --name ${azurerm_container_app.backend.name} \
+        --resource-group ${azurerm_resource_group.main.name} \
+        --hostname $DOMAIN \
+        --certificate "$CERT_ID" \
+        --environment ${azurerm_container_app_environment.main.name}
     EOT
   }
 

--- a/frontend/src/lib/turnstile.tsx
+++ b/frontend/src/lib/turnstile.tsx
@@ -52,6 +52,14 @@ declare global {
   }
 }
 
+function reportTurnstileError(type: string, detail: string, apiUrl: string) {
+  fetch(`${apiUrl}/api/v1/client-errors`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ type: `turnstile_${type}`, detail }),
+  }).catch(() => {}); // fire-and-forget
+}
+
 export function TurnstileProvider({
   children,
   apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
@@ -88,6 +96,7 @@ export function TurnstileProvider({
         }
       } catch (error) {
         console.warn("Failed to fetch config for Turnstile:", error);
+        reportTurnstileError("config_fetch", String(error), apiUrl);
         // Proceed without Turnstile on error
         setIsReady(true);
       }
@@ -139,6 +148,7 @@ export function TurnstileProvider({
             console.error(
               "Turnstile failed after retries, proceeding without token",
             );
+            reportTurnstileError("challenge_failed", "max retries exceeded", apiUrl);
             setIsReady(true);
           }
         },
@@ -152,6 +162,7 @@ export function TurnstileProvider({
       });
     } catch (error) {
       console.error("Failed to render Turnstile widget:", error);
+      reportTurnstileError("render_failed", String(error), apiUrl);
       setIsReady(true);
     }
   }, [siteKey, refreshToken]);
@@ -175,6 +186,7 @@ export function TurnstileProvider({
     };
     script.onerror = () => {
       console.error("Failed to load Turnstile script");
+      reportTurnstileError("script_load", "failed to load turnstile script", apiUrl);
       setIsReady(true); // Proceed without Turnstile
     };
 

--- a/frontend/src/lib/turnstile.tsx
+++ b/frontend/src/lib/turnstile.tsx
@@ -148,7 +148,11 @@ export function TurnstileProvider({
             console.error(
               "Turnstile failed after retries, proceeding without token",
             );
-            reportTurnstileError("challenge_failed", "max retries exceeded", apiUrl);
+            reportTurnstileError(
+              "challenge_failed",
+              "max retries exceeded",
+              apiUrl,
+            );
             setIsReady(true);
           }
         },
@@ -186,7 +190,11 @@ export function TurnstileProvider({
     };
     script.onerror = () => {
       console.error("Failed to load Turnstile script");
-      reportTurnstileError("script_load", "failed to load turnstile script", apiUrl);
+      reportTurnstileError(
+        "script_load",
+        "failed to load turnstile script",
+        apiUrl,
+      );
       setIsReady(true); // Proceed without Turnstile
     };
 


### PR DESCRIPTION
## Summary

- **CI**: Replace silent `if: env.CERT_B64 != ''` cert decode skips with explicit `::warning::` annotations; add retry loop for post-deploy health check
- **Terraform**: Add bash strict mode (`set -euo pipefail`) and remove all `|| echo "Warning"` fallbacks in 6 local-exec provisioners; replace fragile `[-1].id` cert lookup with SAN-filtered JMESPath query; add `filemd5()` content-hash triggers for cert re-uploads
- **CI verification**: New "Verify Custom Domain HTTPS" step detects Error 526 and validates `cf-ray` header after deploy
- **Turnstile observability**: Add `POST /api/v1/client-errors` backend beacon endpoint; frontend reports from all 4 silent fail-open paths so Turnstile failures appear in backend logs
- **Runbook**: Add Cloudflare configuration checklist (Turnstile hostnames, SSL mode, origin cert) and emergency cert rebind commands to `deployment/README.md`

## Context

After deploying the `voxquieta.org` domain migration, a production outage (Cloudflare Error 526) went undetected because infrastructure code silently swallowed failures at every stage. The `[-1].id` JMESPath query picked the wrong certificate, `|| echo` fallbacks hid the upload failure, and the Turnstile widget silently fell back to sending requests without tokens. This PR eliminates all identified silent-failure patterns.

## Test plan

- [ ] `terraform plan` confirms no unexpected resource recreation from trigger changes
- [ ] Backend tests pass (`cd api && python -m pytest tests/ -x`)
- [ ] CI cert decode steps show `::warning::` annotation when secret is empty
- [ ] Post-deploy "Verify Custom Domain HTTPS" step passes with `cf-ray` headers
- [ ] Block Turnstile script in DevTools → confirm `POST /api/v1/client-errors` appears in backend logs

https://claude.ai/code/session_01PxUGBRzdMn2uumrXMmhQsu