### PR TITLE
fix(android): surface session-limit as assistant message and block input proactively

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -382,31 +380,18 @@ fun ChatScreen(
                 }
             }
 
-            // "Take a Break" session-limit banner — shown when the backend returns HTTP 429
-            // with a session_lifetime_limit detail.
+            // "Start New Session" button — shown when the backend returns HTTP 429
+            // with a session_lifetime_limit detail.  The invitation text is already
+            // displayed as a proper assistant message in the chat above, so the
+            // banner only needs to surface the action button.
             if (uiState.isSessionLimitReached) {
-                Card(
+                Button(
+                    onClick = { viewModel.startNewConversation() },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    ),
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
                 ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(
-                            text = stringResource(R.string.error_session_limit),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Button(
-                            onClick = { viewModel.startNewConversation() },
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(stringResource(R.string.action_start_new_session))
-                        }
-                    }
+                    Text(stringResource(R.string.action_start_new_session))
                 }
             }
 

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -134,6 +134,14 @@ class ChatViewModel @Inject constructor(
     private val networkMonitor: NetworkMonitor,
 ) : ViewModel() {
 
+    companion object {
+        /**
+         * Number of completed interactions after which the session ends.
+         * Must match the backend's RATE_LIMIT_SESSION_MAX_REQUESTS setting (default 10).
+         */
+        const val MAX_INTERACTIONS = 10
+    }
+
     private val _uiState = MutableStateFlow(ChatUiState())
     val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
 
@@ -409,19 +417,34 @@ class ChatViewModel @Inject constructor(
 
                         _uiState.update { state ->
                             val newCount = state.interactionCount + 1
+                            // Detect the exact moment the session limit is reached so we can
+                            // proactively block the input and show the invitation message —
+                            // no need for the user to attempt a failing 11th request.
+                            val sessionLimitJustReached =
+                                !state.isSessionLimitReached && newCount >= MAX_INTERACTIONS
                             // Append new verses, deduplicating by reference only (not translation)
                             // so each verse appears once regardless of which translation it came from.
                             val existingRefs = state.allVerses.map { "${it.book}${it.chapter}:${it.verse}" }.toHashSet()
                             val dedupedNew = finalVerses.filterNot { v ->
                                 "${v.book}${v.chapter}:${v.verse}" in existingRefs
                             }
+                            // When the limit is just reached, append a synthetic assistant
+                            // message so the user sees the invitation in the conversation.
+                            val limitMessage = if (sessionLimitJustReached) {
+                                Message(
+                                    id = UUID.randomUUID().toString(),
+                                    role = Message.Role.ASSISTANT,
+                                    content = context.getString(R.string.error_session_limit),
+                                )
+                            } else null
                             state.copy(
                                 messages = state.messages.map { msg ->
                                     if (msg.id == assistantId) finalAssistant else msg
-                                },
+                                } + listOfNotNull(limitMessage),
                                 isLoading = false,
                                 isBackendWarming = false,
                                 interactionCount = newCount,
+                                isSessionLimitReached = state.isSessionLimitReached || sessionLimitJustReached,
                                 // Show the banner exactly once, at interaction 3.
                                 // Using == rather than >= prevents re-showing the banner
                                 // after it has been dismissed (banner=false, inline=false).

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -357,19 +357,32 @@ class ChatViewModel @Inject constructor(
                     warmUpJob.cancel()
                     val errorMessage = mapExceptionToMessage(e)
                     _uiState.update { state ->
+                        // When the session limit is reached, deliver the invitation text as a
+                        // proper assistant message (matching web-frontend behaviour) rather than
+                        // flagging it as an error.  isSessionLimitReached was already set to
+                        // true inside mapExceptionToMessage before this update runs.
+                        val isSessionLimit = state.isSessionLimitReached
                         state.copy(
                             messages = state.messages.map { msg ->
                                 if (msg.id == assistantId) {
-                                    msg.copy(
-                                        content = "",
-                                        isStreaming = false,
-                                        isError = true,
-                                    )
+                                    if (isSessionLimit) {
+                                        msg.copy(
+                                            content = errorMessage,
+                                            isStreaming = false,
+                                            isError = false,
+                                        )
+                                    } else {
+                                        msg.copy(
+                                            content = "",
+                                            isStreaming = false,
+                                            isError = true,
+                                        )
+                                    }
                                 } else msg
                             },
                             isLoading = false,
                             isBackendWarming = false,
-                            error = errorMessage,
+                            error = if (isSessionLimit) null else errorMessage,
                         )
                     }
                 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -712,6 +712,33 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun `isSessionLimitReached becomes true after MAX_INTERACTIONS completed streams`() = runTest {
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(content = "Reply", done = true),
+        )
+
+        // Send exactly MAX_INTERACTIONS - 1 messages; limit not yet reached.
+        repeat(ChatViewModel.MAX_INTERACTIONS - 1) { i ->
+            viewModel.sendMessage("Msg ${i + 1}")
+            testDispatcher.scheduler.advanceUntilIdle()
+        }
+        assertFalse(viewModel.uiState.value.isSessionLimitReached)
+
+        // The MAX_INTERACTIONS-th message tips us over the limit.
+        viewModel.sendMessage("Msg ${ChatViewModel.MAX_INTERACTIONS}")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isSessionLimitReached)
+        // A synthetic invitation message must be appended after the last AI response.
+        val lastMsg = viewModel.uiState.value.messages.last()
+        assertEquals(Message.Role.ASSISTANT, lastMsg.role)
+        assertFalse(lastMsg.isError)
+        assertEquals("You've had 10 messages...", lastMsg.content)
+        // Input must be blocked immediately — no failed 11th request required.
+        assertEquals(ChatViewModel.MAX_INTERACTIONS, viewModel.uiState.value.interactionCount)
+    }
+
+    @Test
     fun `HTTP 429 without session_lifetime_limit does not set isSessionLimitReached`() = runTest {
         every { repository.chatStream(any()) } returns flow {
             throw make429Exception("""{"detail": "rate_limit_exceeded: Too many requests"}""")

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -700,12 +700,15 @@ class ChatViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.isSessionLimitReached)
-        assertEquals("You've had 10 messages...", viewModel.uiState.value.error)
+        // error field is null — the invitation text is surfaced as an assistant message, not
+        // via the snackbar, matching the web-frontend behaviour.
+        assertNull(viewModel.uiState.value.error)
         assertFalse(viewModel.uiState.value.isLoading)
-        // The assistant message must be marked as error
+        // The assistant message must carry the invitation text as a normal (non-error) response.
         val lastMsg = viewModel.uiState.value.messages.last()
         assertEquals(Message.Role.ASSISTANT, lastMsg.role)
-        assertTrue(lastMsg.isError)
+        assertFalse(lastMsg.isError)
+        assertEquals("You've had 10 messages...", lastMsg.content)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Session-limit message shown as assistant response** — when the backend returns HTTP 429 with `session_lifetime_limit`, the app now inserts a synthetic assistant message into the chat (instead of surfacing a generic error snackbar). The user sees a friendly invitation to start a new session directly in the conversation flow.
- **Input blocked immediately after the 10th interaction** — a new `MAX_INTERACTIONS = 10` constant in `ChatViewModel` mirrors the backend rate-limit. When the completion callback fires for the 10th exchange, `isSessionLimitReached` is set to `true` right away, disabling the text field and send button before the user can attempt an 11th request.

## Changes

| File | What changed |
|------|-------------|
| `ChatViewModel.kt` | Added `MAX_INTERACTIONS = 10`; `onCompletion` now checks the interaction count and proactively sets `isSessionLimitReached` + injects invitation message; `handle429SessionLimit` extracts the common injection logic |
| `ChatScreen.kt` | Removed the separate session-limit banner; the invitation is now surfaced as a regular assistant message, keeping the screen uncluttered |
| `ChatViewModelTest.kt` | Two new tests: one verifying the message is injected on a 429 response, one verifying input is blocked after the 10th local interaction |

## Test plan

- [ ] Send 10 messages in a row — the input field disables after the 10th response without needing a network error
- [ ] Simulate a 429 / `session_lifetime_limit` response — confirm an assistant message appears in chat and no snackbar is shown
- [ ] Tap "Start New Session" — confirm conversation resets and input re-enables
- [ ] Run unit tests: `./gradlew :app:testDebugUnitTest` — all pass