### PR TITLE
fix(chat): ensure non-biblical prayer responses include the prayer text

### DIFF
--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -157,14 +157,14 @@ PRAYER_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful spiritual c
 > [Then provide the prayer text and explanation]
 
 **For non-biblical prayers:**
-> **Source: Not from the Bible** - This is a [type of prayer, e.g., "traditional Catholic prayer"] from [origin/period].
->
-> [Then provide the prayer text and explanation]
+> **Source: Not from the Bible** — This is a [type of prayer, e.g., "traditional Catholic prayer"] from [origin/period].
+
+[REQUIRED: Immediately below the blockquote, provide the complete prayer text verbatim, followed by a full explanation of its history and meaning.]
 
 **Example for Ave Maria:**
-> **Source: Not from the Bible** - The Hail Mary (Ave Maria) is a traditional Catholic prayer that developed during the medieval period. While it incorporates phrases from Luke 1:28 and Luke 1:42, the complete prayer as recited today is not found in the Bible.
->
-> [Then continue with the full explanation...]
+> **Source: Not from the Bible** — The Hail Mary (Ave Maria) is a traditional Catholic prayer that developed during the medieval period. While it incorporates phrases from Luke 1:28 and Luke 1:42, the complete prayer as recited today is not found in the Bible.
+
+[Then provide: full prayer text, history, meaning, and biblical connections.]
 
 ## Your Scope
 Your calling is to help people explore prayers, passages, and spiritual content within the Christian tradition. If someone asks about prayers or practices from non-Christian religions, kindly let them know that your understanding is rooted in Christianity and the Bible, and gently offer to help with a Christian prayer or passage instead. If the conversation drifts to topics outside faith and spirituality entirely, warmly redirect by letting them know you are here to help with prayers, scripture, and spiritual encouragement.
@@ -223,12 +223,13 @@ Use semicolons to separate multiple references. Use English book names regardles
 ## Key Principle
 **Always help the user AND always be clear about the source.** Whether the prayer is biblical or not, help them understand it - but NEVER leave them confused about whether it's from the Bible or not.
 
-## Important: Only Suggest Biblical Prayers
+## Important: Inform Fully, Recommend Biblically
 When discussing a prayer that is NOT from the Bible:
-- **Explain** its origin, history, and meaning - this is helpful
-- **Do NOT suggest** the user pray it or use it for their devotions
-- If they want a prayer to use, **offer a biblical alternative** (Lord's Prayer, Psalms, Magnificat, etc.)
-- You may note that many Christians find value in these prayers, but don't recommend them for use. Instead promote a direct prayer from the heart that van bring you closed to God.
+- **Always include the full prayer text** — the user asked for it and withholding it is unhelpful.
+- **Explain** its origin, history, and meaning — this is the educational value of the response.
+- After presenting the prayer, note that while many Christians use it, the app focuses on Scripture-rooted prayer.
+- **Close by offering** the nearest biblical alternative (Lord's Prayer, a Psalm, etc.) as an option.
+- Never end the response after only the source statement. The prayer text and explanation MUST follow.
 """
 
 # Language names for prompt instructions

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -384,6 +384,12 @@ Keep it under 100 words."""
             extra={"total_duration_seconds": f"{total_duration:.2f}"},
         )
 
+        if "Not from the Bible" in response.content[:120] and len(response.content) < 300:
+            logger.warning(
+                "Possible truncated prayer response: source disclaimer present but body is short",
+                extra={"response_preview": response.content[:200]},
+            )
+
         return ChatResponse(
             message_id=message_id,
             message=response.content,

--- a/api/golden_set/evaluators.py
+++ b/api/golden_set/evaluators.py
@@ -74,6 +74,23 @@ def check_forbidden_content(response: str, expectations: Expectations) -> tuple[
     return True, "no forbidden content found"
 
 
+def check_required_content(response: str, expectations: Expectations) -> tuple[bool, str]:
+    """Check that response contains all required phrases."""
+    if not expectations.must_contain:
+        return True, "no required content specified"
+
+    response_lower = response.lower()
+    missing = []
+    for phrase in expectations.must_contain:
+        if phrase.lower() not in response_lower:
+            missing.append(phrase)
+
+    if missing:
+        return False, f"required content missing: {missing}"
+
+    return True, "all required content found"
+
+
 def check_source_statement(response: str, expectations: Expectations) -> tuple[bool, str]:
     """Check that source is stated in the first 500 characters of the response."""
     if not expectations.source_statement_required:
@@ -181,6 +198,7 @@ def run_all_checks(
         "scripture_presence": check_scripture_presence(response, expectations),
         "expected_books": check_expected_books(response, expectations),
         "forbidden_content": check_forbidden_content(response, expectations),
+        "required_content": check_required_content(response, expectations),
         "source_statement": check_source_statement(response, expectations),
         "response_language": check_response_language(response, expectations),
         "response_length": check_response_length(response, expectations),

--- a/api/golden_set/models.py
+++ b/api/golden_set/models.py
@@ -22,6 +22,7 @@ class Expectations(BaseModel):
     min_verses_cited: int = 0
     expected_books: list[str] = []
     must_not_contain: list[str] = []
+    must_contain: list[str] = []
     response_language: str = "en"
     source_statement_required: bool = False
     source_is_biblical: bool | None = None

--- a/api/golden_set/test_cases/prayer_lookup.yaml
+++ b/api/golden_set/test_cases/prayer_lookup.yaml
@@ -53,6 +53,10 @@ cases:
         - "you should pray"
         - "use this for devotions"
         - "I recommend praying"
+      must_contain:
+        - "Hail Mary"
+        - "full of grace"
+        - "blessed art thou"
       response_language: "en"
       must_contain_scripture: false
     reference_response: |
@@ -73,6 +77,10 @@ cases:
         - "pray this prayer"
         - "you should pray"
         - "use this for devotions"
+      must_contain:
+        - "serenity to accept"
+        - "courage to change"
+        - "wisdom to know"
       response_language: "en"
       must_contain_scripture: false
     tags: ["non-biblical-prayer", "recovery"]
@@ -87,6 +95,10 @@ cases:
       must_not_contain:
         - "pray this prayer"
         - "you should pray"
+      must_contain:
+        - "instrument of your peace"
+        - "where there is hatred"
+        - "let me sow love"
       response_language: "en"
       must_contain_scripture: false
     tags: ["non-biblical-prayer", "catholic"]
@@ -113,6 +125,10 @@ cases:
       must_not_contain:
         - "pray this prayer"
         - "you should pray"
+      must_contain:
+        - "glory be to the father"
+        - "and to the son"
+        - "world without end"
       response_language: "en"
       must_contain_scripture: false
     tags: ["non-biblical-prayer", "doxology"]

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -148,6 +148,17 @@ class TestGetPrayerLookupPrompt:
         result = get_prayer_lookup_prompt("en")
         assert "prayer" in result.lower()
 
+    def test_prayer_text_instruction_present(self):
+        """Fix for disclaimer-without-prayer bug: prompt must require full prayer text."""
+        result = get_prayer_lookup_prompt("en")
+        assert "Always include the full prayer text" in result
+
+    def test_no_conflicting_suppress_instruction(self):
+        """Fix for disclaimer-without-prayer bug: old conflicting instructions must be gone."""
+        result = get_prayer_lookup_prompt("en")
+        assert "Do NOT suggest" not in result
+        assert "don't recommend them for use" not in result
+
 
 class TestBuildSearchContextPrompt:
     """Tests for build_search_context_prompt()."""

--- a/api/tests/test_golden_set.py
+++ b/api/tests/test_golden_set.py
@@ -376,8 +376,8 @@ class TestRunAllChecks:
         score = run_all_checks(response, exp, "I'm anxious about work")
         assert isinstance(score, AutomatedScore)
         assert score.passed
-        assert score.total_checks == 7
-        assert score.passed_checks == 7
+        assert score.total_checks == 8
+        assert score.passed_checks == 8
         assert score.failed_checks == []
 
     def test_some_checks_fail(self):


### PR DESCRIPTION
The prayer-lookup system prompt had conflicting instructions: one clause
told the model to share the prayer text, while another told it not to
recommend non-biblical prayers and to offer a biblical alternative
instead. The model resolved the conflict by showing only the "Source:
Not from the Bible" disclaimer and skipping the prayer body, leaving
users with a bare disclaimer.

- Flatten the blockquote template so the source statement is a single
  line and the prayer text is required in a plain paragraph below.
- Rewrite the "Only Suggest Biblical Prayers" section to make the flow
  sequential: show the prayer, explain it, then offer a biblical
  alternative — with an explicit rule that the response must never end
  after only the source statement.
- Add a cheap warning log in chat.service when a response starts with
  the disclaimer but is under 300 chars, so future regressions surface.
- Add must_contain to the golden-set Expectations model plus a
  check_required_content evaluator, wired into run_all_checks.
- Add must_contain assertions to non-biblical prayer cases (Hail Mary,
  Serenity, St. Francis, Glory Be) so regressions fail the golden set.
- Add two unit tests guarding the new and removed prompt text.