### PR TITLE
fix: show correct session limit message instead of connection error

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -319,9 +319,9 @@ export async function sendMessage(
       // Handle 429 rate limit errors
       if (response.status === 429) {
         const data = await response.json().catch(() => ({}));
-        if (data.error === "session_lifetime_limit") {
+        if (data.detail?.error === "session_lifetime_limit") {
           throw new SessionLimitError(
-            data.message ||
+            data.detail?.message ||
               "Session limit reached. Start a new session to continue.",
           );
         }
@@ -403,9 +403,9 @@ export async function* streamMessage(
     // Handle 429 rate limit errors
     if (response.status === 429) {
       const data = await response.json().catch(() => ({}));
-      if (data.error === "session_lifetime_limit") {
+      if (data.detail?.error === "session_lifetime_limit") {
         throw new SessionLimitError(
-          data.message ||
+          data.detail?.message ||
             "Session limit reached. Start a new session to continue.",
         );
       }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- FastAPI wraps `HTTPException` detail in a top-level `"detail"` key, returning `{"detail": {"error": "session_lifetime_limit"}}` on 429 responses
- The frontend was checking `data.error` (always `undefined`) instead of `data.detail?.error`, so `SessionLimitError` was never thrown
- Users saw the generic connection error ("I'm sorry, I'm having trouble connecting...") instead of the session limit message ("You've had 10 messages in this session!")
- The "Start New Session" button never appeared

## Changes

- `frontend/src/lib/api.ts`: fixed `data.error` → `data.detail?.error` (and `data.message` → `data.detail?.message`) in both `sendMessage` and `streamMessage`

## Android

No change needed — Android uses `body.contains("session_lifetime_limit")` (raw string search), which works correctly regardless of JSON nesting.

## Test plan

- [ ] Send 10 messages in a session on the web app
- [ ] On the 11th message: verify the session limit message appears ("You've had 10 messages in this session!")
- [ ] Verify the "Start New Session" button appears
- [ ] Verify the generic connection error does NOT appear
- [ ] Click "Start New Session" and confirm new messages go through

https://claude.ai/code/session_01DBTJM4a1BL262QECQpD5WJ
EOF
)