### PR TITLE
fix(ci): verify deployment against /health/live instead of gated /health

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -913,7 +913,7 @@ jobs:
             BACKEND_URL="https://$BACKEND_FQDN"
             echo "Backend URL: $BACKEND_URL"
             for i in 1 2 3; do
-              if curl -sf "$BACKEND_URL/health" --max-time 10; then
+              if curl -sf "$BACKEND_URL/health/live" --max-time 10; then
                 echo "Backend health check passed"
                 break
               fi


### PR DESCRIPTION
## Summary

The `Verify Deployment` step in `.github/workflows/azure-deploy.yml` curled `$BACKEND_URL/health` from the GitHub Actions runner, but `/health` is gated by `Depends(require_local_access)` in `api/routes/health.py:182` (introduced together with the new health module in #363). That dependency reads the first IP from `X-Forwarded-For` — which Azure Container Apps populates with the real public client IP — and returns **403** to anything outside RFC1918/loopback. Public CI runners therefore always failed the 3-attempt retry loop:

```
Backend URL: https://bible-app-backend.agreeablesea-6ee07535.northeurope.azurecontainerapps.io
Attempt 1 failed, retrying in 10s...
Attempt 2 failed, retrying in 10s...
```

The bug was latent since #363 (Mar 24) but only surfaced as a CI failure after #408 (Apr 14) replaced the silent health-check fallback with a loud retry loop. Recent PRs #422/#423 are unrelated.

## Fix

One-line change at `.github/workflows/azure-deploy.yml:916` — switch the verify probe to `/health/live`:

- `/health/live` (`api/routes/health.py:239`) is unauthenticated, has no DB/LLM dependency, and always returns `200 {"status":"alive"}` when the process is up — the correct semantic for a post-deploy "is it up" check.
- The PR-check path at line 312 already uses `/health/live`; this aligns the verify step with it.
- No other call sites need changes — `deployment/main.tf` ACA probes already target `/health/live` and `/health/ready`, the Dockerfile HEALTHCHECK runs inside the container (localhost passes the local-access gate), and `test_update.yml` runs against localhost too.

## Test plan

- [ ] Re-run the manual Azure deploy from this branch and confirm the `Verify Deployment` step passes on attempt 1
- [ ] Sanity check from a shell after deploy: `curl -i $BACKEND_URL/health/live` returns 200, `curl -i $BACKEND_URL/health` returns 403 (expected — local-only)

https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J)_