### PR TITLE
feat(api): add monitor_probe_secret bypass for synthetic probes

### DIFF
--- a/.github/actions/notify-telegram/action.yml
+++ b/.github/actions/notify-telegram/action.yml
@@ -1,8 +1,7 @@
 name: Notify Telegram on probe transition
 description: >
-  Sends a Telegram alert when a monitor probe job transitions pass→fail or
-  fail→pass. Suppresses repeated alerts during sustained outages by stamping
-  the previous state into the GitHub Actions cache.
+  Sends a Telegram alert when a monitor probe job transitions pass→fail or fail→pass. Suppresses repeated alerts during
+  sustained outages by stamping the previous state into the GitHub Actions cache.
 
 inputs:
   job_status:

--- a/.github/actions/notify-telegram/action.yml
+++ b/.github/actions/notify-telegram/action.yml
@@ -1,0 +1,126 @@
+name: Notify Telegram on probe transition
+description: >
+  Sends a Telegram alert when a monitor probe job transitions pass→fail or
+  fail→pass. Suppresses repeated alerts during sustained outages by stamping
+  the previous state into the GitHub Actions cache.
+
+inputs:
+  job_status:
+    description: "github.job's status — 'success' or 'failure' (or 'cancelled')."
+    required: true
+  job_name:
+    description: "Logical probe name used as the cache key suffix and in messages."
+    required: true
+  state_branch:
+    description: "Reserved (state lives in the Actions cache, not a branch)."
+    required: false
+    default: gh-monitor-state
+  telegram_bot_token:
+    description: "Telegram bot token. Not logged."
+    required: true
+  telegram_chat_id:
+    description: "Telegram chat ID — negative for groups."
+    required: true
+  force_alert:
+    description: "If 'true', always send a test alert regardless of transition."
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Restore previous state
+      id: restore
+      uses: actions/cache/restore@v4
+      with:
+        # Cache key uses run_id so each run gets a fresh entry; restore-keys
+        # falls back to the latest prior cache for this job.
+        key: monitor-state-${{ inputs.job_name }}-${{ github.run_id }}
+        restore-keys: |
+          monitor-state-${{ inputs.job_name }}-
+        path: monitor-state.txt
+
+    - name: Compute transition and send alert
+      id: notify
+      shell: bash
+      env:
+        JOB_STATUS: ${{ inputs.job_status }}
+        JOB_NAME: ${{ inputs.job_name }}
+        TG_TOKEN: ${{ inputs.telegram_bot_token }}
+        TG_CHAT: ${{ inputs.telegram_chat_id }}
+        FORCE_ALERT: ${{ inputs.force_alert }}
+      run: |
+        set -euo pipefail
+
+        # Map job status → simple pass/fail token. Treat 'cancelled' as
+        # neither (don't update state, don't alert).
+        case "$JOB_STATUS" in
+          success) curr=pass ;;
+          failure) curr=fail ;;
+          *)
+            echo "skipping notify: job_status=$JOB_STATUS"
+            exit 0
+            ;;
+        esac
+
+        prev=""
+        if [ -f monitor-state.txt ]; then
+          prev=$(head -c 16 monitor-state.txt | tr -d '[:space:]' || true)
+        fi
+
+        # Decide message
+        msg=""
+        if [ "$FORCE_ALERT" = "true" ]; then
+          msg="🧪 *prod-monitor* test alert from \`${JOB_NAME}\` on \`${GITHUB_SHA::7}\` (status=${curr})"
+        elif [ "$prev" = "" ] && [ "$curr" = "fail" ]; then
+          msg="🚨 *prod-monitor / ${JOB_NAME}* failed (no prior state)"
+        elif [ "$prev" = "pass" ] && [ "$curr" = "fail" ]; then
+          msg="🚨 *prod-monitor / ${JOB_NAME}* failed"
+        elif [ "$prev" = "fail" ] && [ "$curr" = "pass" ]; then
+          msg="✅ *prod-monitor / ${JOB_NAME}* recovered"
+        else
+          echo "no transition (prev=${prev:-none} → curr=${curr}); not alerting"
+        fi
+
+        if [ -n "$msg" ]; then
+          # Append run link
+          msg="${msg}
+        Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          # Append failure detail if the job wrote one
+          detail_file="${RUNNER_TEMP}/detail.txt"
+          if [ -f "$detail_file" ] && [ -s "$detail_file" ]; then
+            detail=$(head -c 1500 "$detail_file")
+            msg="${msg}
+
+        Detail:
+        \`\`\`
+        ${detail}
+        \`\`\`"
+          fi
+
+          if [ -z "$TG_TOKEN" ] || [ -z "$TG_CHAT" ]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID not set; would send: $msg"
+          else
+            # Use --data-urlencode for text so newlines/markdown survive
+            http=$(curl -sS -o /tmp/tg-resp -w "%{http_code}" \
+              "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+              -d "chat_id=${TG_CHAT}" \
+              -d "parse_mode=Markdown" \
+              --data-urlencode "text=${msg}" || echo "000")
+            if [ "$http" != "200" ]; then
+              echo "::warning::Telegram sendMessage returned HTTP ${http}: $(cat /tmp/tg-resp)"
+            else
+              echo "telegram alert sent (${#msg} chars)"
+            fi
+          fi
+        fi
+
+        # Persist the new state for the next run (replace file content)
+        printf '%s' "$curr" > monitor-state.txt
+
+    - name: Save new state
+      uses: actions/cache/save@v4
+      with:
+        key: monitor-state-${{ inputs.job_name }}-${{ github.run_id }}
+        path: monitor-state.txt

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -446,6 +446,7 @@ jobs:
       TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
       TF_VAR_turnstile_site_key: ${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
+      TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
 
     steps:
       - name: Checkout
@@ -702,6 +703,7 @@ jobs:
       TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
       TF_VAR_turnstile_site_key: ${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
+      TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
 
     steps:
       - name: Checkout
@@ -1081,6 +1083,7 @@ jobs:
       TF_VAR_smtp2go_api_key: ${{ secrets.TF_VAR_SMTP2GO_API_KEY }}
       TF_VAR_turnstile_site_key: ${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
+      TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -448,6 +448,9 @@ jobs:
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
+      # Default to empty JSON array when the secret is unset; an empty TF_VAR_
+      # for a list(string) variable would crash terraform parsing otherwise.
+      TF_VAR_budget_alert_emails: ${{ secrets.TF_VAR_BUDGET_ALERT_EMAILS || '[]' }}
 
     steps:
       - name: Checkout
@@ -706,6 +709,9 @@ jobs:
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
+      # Default to empty JSON array when the secret is unset; an empty TF_VAR_
+      # for a list(string) variable would crash terraform parsing otherwise.
+      TF_VAR_budget_alert_emails: ${{ secrets.TF_VAR_BUDGET_ALERT_EMAILS || '[]' }}
 
     steps:
       - name: Checkout
@@ -1087,6 +1093,9 @@ jobs:
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
+      # Default to empty JSON array when the secret is unset; an empty TF_VAR_
+      # for a list(string) variable would crash terraform parsing otherwise.
+      TF_VAR_budget_alert_emails: ${{ secrets.TF_VAR_BUDGET_ALERT_EMAILS || '[]' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -447,6 +447,7 @@ jobs:
       TF_VAR_turnstile_site_key: ${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
+      TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
 
     steps:
       - name: Checkout
@@ -704,6 +705,7 @@ jobs:
       TF_VAR_turnstile_site_key: ${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
+      TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
 
     steps:
       - name: Checkout
@@ -1084,6 +1086,7 @@ jobs:
       TF_VAR_turnstile_site_key: ${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
+      TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -1,0 +1,201 @@
+name: Prod Monitor
+
+# Production monitoring + alerting via Telegram.
+#
+# Three independent jobs run every 5 minutes:
+#   - health        : cheap liveness check (/health/live, /health/ready)
+#   - synthetic-chat: real chat round-trip via /api/v1/chat/stream — catches
+#                     the failure mode where the backend returns HTTP 200 with
+#                     an in-band {"type":"error", ...} SSE chunk (e.g. a bad
+#                     OpenRouter API key).
+#   - log-scan      : Azure Log Analytics KQL query against the backend's
+#                     ContainerAppConsoleLogs_CL for error patterns over the
+#                     last 10 minutes.
+#
+# Each job sends a Telegram message on transition pass→fail or fail→pass.
+# State is stored in the gh-monitor-state branch (one tiny file per job) so
+# repeated failures don't spam the chat.
+#
+# Required repo secrets:
+#   TELEGRAM_BOT_TOKEN   - existing Telegram bot token (e.g. shared with N8N)
+#   TELEGRAM_CHAT_ID     - chat/group ID where alerts land (negative for groups)
+#   MONITOR_PROBE_SECRET - shared secret for the synthetic chat probe; must
+#                          match settings.monitor_probe_secret in the deployed
+#                          backend (wired via TF_VAR_monitor_probe_secret in
+#                          azure-deploy.yml)
+#   ARM_CLIENT_ID / ARM_CLIENT_SECRET / ARM_TENANT_ID / ARM_SUBSCRIPTION_ID
+#                        - service principal for the log-scan job (already
+#                          used by azure-deploy.yml)
+#
+# Required repo variables (vars.*):
+#   BACKEND_URL          - e.g. https://bible-app-backend.<region>.azurecontainerapps.io
+#                          (default: production hardcoded fallback below)
+#
+# Manual run:
+#   Actions → Prod Monitor → Run workflow
+#   (also useful for testing the Telegram setup with workflow_dispatch + force_alert=true)
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+    inputs:
+      force_alert:
+        description: "Send a test alert to Telegram regardless of probe outcome"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Allow scheduled runs to overlap minimally; manual runs take priority.
+  group: prod-monitor-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  BACKEND_URL: ${{ vars.BACKEND_URL || 'https://bible-app-backend.agreeablesea-6ee07535.northeurope.azurecontainerapps.io' }}
+  STATE_BRANCH: gh-monitor-state
+
+jobs:
+  # ---------------------------------------------------------------------------
+  health:
+    name: Health probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Check /health/live
+        id: live
+        run: |
+          set -o pipefail
+          body=$(curl -fsS --max-time 10 "${BACKEND_URL%/}/health/live")
+          echo "$body"
+          echo "$body" | grep -q '"alive"' || {
+            echo "live response missing 'alive': $body" > "$RUNNER_TEMP/detail.txt"
+            exit 1
+          }
+
+      - name: Check /health/ready
+        id: ready
+        run: |
+          set -o pipefail
+          body=$(curl -fsS --max-time 10 "${BACKEND_URL%/}/health/ready")
+          echo "$body"
+          echo "$body" | grep -q '"ready"' || {
+            echo "ready response missing 'ready': $body" > "$RUNNER_TEMP/detail.txt"
+            exit 1
+          }
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: health
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}
+
+  # ---------------------------------------------------------------------------
+  synthetic-chat:
+    name: Synthetic chat probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install probe deps
+        run: pip install httpx
+
+      - name: Run synthetic chat probe
+        id: probe
+        env:
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+          MONITOR_PROBE_SECRET: ${{ secrets.MONITOR_PROBE_SECRET }}
+          PROBE_MESSAGE: "hi"
+          PROBE_TIMEOUT_SECONDS: "30"
+          PROBE_FIRST_CHUNK_SECONDS: "20"
+        run: python scripts/monitor/synthetic_chat.py --detail-out "$RUNNER_TEMP/detail.txt"
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: synthetic-chat
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}
+
+  # ---------------------------------------------------------------------------
+  log-scan:
+    name: Log scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          creds: |
+            {
+              "clientId": "${{ secrets.ARM_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.ARM_CLIENT_SECRET }}",
+              "subscriptionId": "${{ secrets.ARM_SUBSCRIPTION_ID }}",
+              "tenantId": "${{ secrets.ARM_TENANT_ID }}"
+            }
+
+      - name: Resolve workspace ID
+        id: ws
+        run: |
+          ws_id=$(az monitor log-analytics workspace show \
+            --resource-group bible-app-rg \
+            --workspace-name "$(az monitor log-analytics workspace list \
+                --resource-group bible-app-rg \
+                --query '[0].name' -o tsv)" \
+            --query customerId -o tsv)
+          [ -n "$ws_id" ] || { echo "::error::could not resolve workspace ID"; exit 2; }
+          echo "id=$ws_id" >> "$GITHUB_OUTPUT"
+
+      - name: Query for backend errors (last 10 min)
+        id: query
+        run: |
+          set -o pipefail
+          query='ContainerAppConsoleLogs_CL
+            | where TimeGenerated > ago(10m)
+            | where ContainerAppName_s == "bible-app-backend"
+            | where Log_s matches regex "(?i)(openrouter error|llm streaming error|anthropic error|internal server error|traceback)"
+            | summarize cnt = count(), sample = any(Log_s)
+            | project cnt, sample'
+          result=$(az monitor log-analytics query \
+            --workspace "${{ steps.ws.outputs.id }}" \
+            --analytics-query "$query" \
+            -o json)
+          echo "$result"
+          cnt=$(echo "$result" | python -c 'import json,sys; rows=json.load(sys.stdin); print(rows[0].get("cnt",0) if rows else 0)')
+          if [ "${cnt:-0}" != "0" ]; then
+            sample=$(echo "$result" | python -c 'import json,sys; rows=json.load(sys.stdin); print((rows[0].get("sample") or "")[:1500])')
+            {
+              echo "$cnt error log line(s) in the last 10m on bible-app-backend."
+              echo ""
+              echo "Sample:"
+              echo "$sample"
+            } > "$RUNNER_TEMP/detail.txt"
+            exit 1
+          fi
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: log-scan
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}

--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -35,7 +35,8 @@ name: Prod Monitor
 #   Actions → Prod Monitor → Run workflow
 #   (also useful for testing the Telegram setup with workflow_dispatch + force_alert=true)
 
-on:
+# yamllint flags the unquoted `on` key as a YAML 1.1 truthy value.
+"on":
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
@@ -54,7 +55,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BACKEND_URL: ${{ vars.BACKEND_URL || 'https://bible-app-backend.agreeablesea-6ee07535.northeurope.azurecontainerapps.io' }}
+  BACKEND_URL:
+    ${{ vars.BACKEND_URL || 'https://bible-app-backend.agreeablesea-6ee07535.northeurope.azurecontainerapps.io' }}
   STATE_BRANCH: gh-monitor-state
 
 jobs:
@@ -166,20 +168,22 @@ jobs:
         id: query
         run: |
           set -o pipefail
-          query='ContainerAppConsoleLogs_CL
+          err_re='(?i)(openrouter error|llm streaming error|anthropic error'
+          err_re="${err_re}|internal server error|traceback)"
+          query="ContainerAppConsoleLogs_CL
             | where TimeGenerated > ago(10m)
-            | where ContainerAppName_s == "bible-app-backend"
-            | where Log_s matches regex "(?i)(openrouter error|llm streaming error|anthropic error|internal server error|traceback)"
+            | where ContainerAppName_s == \"bible-app-backend\"
+            | where Log_s matches regex \"${err_re}\"
             | summarize cnt = count(), sample = any(Log_s)
-            | project cnt, sample'
+            | project cnt, sample"
           result=$(az monitor log-analytics query \
             --workspace "${{ steps.ws.outputs.id }}" \
             --analytics-query "$query" \
             -o json)
           echo "$result"
-          cnt=$(echo "$result" | python -c 'import json,sys; rows=json.load(sys.stdin); print(rows[0].get("cnt",0) if rows else 0)')
+          cnt=$(echo "$result" | jq -r '.[0].cnt // 0')
           if [ "${cnt:-0}" != "0" ]; then
-            sample=$(echo "$result" | python -c 'import json,sys; rows=json.load(sys.stdin); print((rows[0].get("sample") or "")[:1500])')
+            sample=$(echo "$result" | jq -r '.[0].sample // ""' | head -c 1500)
             {
               echo "$cnt error log line(s) in the last 10m on bible-app-backend."
               echo ""

--- a/api/config.py
+++ b/api/config.py
@@ -140,6 +140,11 @@ class Settings(BaseSettings):
     # Test secret: 2x0000000000000000000000000000000AA (always fails)
     # Test secret: 3x0000000000000000000000000000000AA (forces interactive challenge)
 
+    # Synthetic monitor probe — shared secret that lets an authorized
+    # server-to-server probe bypass Turnstile and rate limits via the
+    # X-Monitor-Probe-Secret header. Leave None/empty to disable bypass.
+    monitor_probe_secret: str | None = None
+
     # Azure Content Safety Settings
     azure_content_safety_enabled: bool = False  # Enable Azure Content Safety API
     azure_content_safety_endpoint: str | None = None  # Azure endpoint URL

--- a/api/tests/test_monitor_probe.py
+++ b/api/tests/test_monitor_probe.py
@@ -1,0 +1,65 @@
+"""
+Tests for the synthetic-monitor probe bypass helper.
+
+The helper gates Turnstile + rate-limit bypass behind a shared secret that
+must match what's deployed in the backend. These tests cover the critical
+fail-closed paths (header without server config, mismatched value, empty
+strings) since a bug here lets unauthenticated clients bypass bot
+protection.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.monitor_probe import PROBE_HEADER, is_monitor_probe
+
+
+def _request_with_header(value: str | None) -> Request:
+    req = MagicMock(spec=Request)
+    req.headers = {PROBE_HEADER: value} if value is not None else {}
+    return req
+
+
+class TestIsMonitorProbe:
+    @pytest.mark.parametrize("server_secret", [None, ""])
+    def test_unconfigured_server_never_bypasses(self, server_secret):
+        """Empty/None server secret = bypass disabled, even if header matches."""
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = server_secret
+            assert is_monitor_probe(_request_with_header("anything")) is False
+
+    def test_missing_header_does_not_bypass(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "configured-secret"
+            assert is_monitor_probe(_request_with_header(None)) is False
+
+    def test_empty_header_does_not_bypass(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "configured-secret"
+            assert is_monitor_probe(_request_with_header("")) is False
+
+    def test_mismatched_header_does_not_bypass(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "configured-secret"
+            assert is_monitor_probe(_request_with_header("wrong-secret")) is False
+
+    def test_matching_header_bypasses(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "configured-secret"
+            assert is_monitor_probe(_request_with_header("configured-secret")) is True
+
+    def test_compare_is_constant_time(self):
+        """Sanity: the helper uses hmac.compare_digest, so case/length
+        differences should not short-circuit early. We can't test timing
+        directly, but we can confirm the matching path returns True for
+        equal-length strings and False otherwise."""
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "abc-123"
+            assert is_monitor_probe(_request_with_header("abc-124")) is False
+            assert is_monitor_probe(_request_with_header("abc-1230")) is False

--- a/api/tests/test_monitor_probe.py
+++ b/api/tests/test_monitor_probe.py
@@ -36,22 +36,22 @@ class TestIsMonitorProbe:
 
     def test_missing_header_does_not_bypass(self):
         with patch("utils.monitor_probe.settings") as s:
-            s.monitor_probe_secret = "configured-secret"
+            s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
             assert is_monitor_probe(_request_with_header(None)) is False
 
     def test_empty_header_does_not_bypass(self):
         with patch("utils.monitor_probe.settings") as s:
-            s.monitor_probe_secret = "configured-secret"
+            s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
             assert is_monitor_probe(_request_with_header("")) is False
 
     def test_mismatched_header_does_not_bypass(self):
         with patch("utils.monitor_probe.settings") as s:
-            s.monitor_probe_secret = "configured-secret"
+            s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
             assert is_monitor_probe(_request_with_header("wrong-secret")) is False
 
     def test_matching_header_bypasses(self):
         with patch("utils.monitor_probe.settings") as s:
-            s.monitor_probe_secret = "configured-secret"
+            s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
             assert is_monitor_probe(_request_with_header("configured-secret")) is True
 
     def test_compare_is_constant_time(self):
@@ -60,6 +60,6 @@ class TestIsMonitorProbe:
         directly, but we can confirm the matching path returns True for
         equal-length strings and False otherwise."""
         with patch("utils.monitor_probe.settings") as s:
-            s.monitor_probe_secret = "abc-123"
+            s.monitor_probe_secret = "abc-123"  # pragma: allowlist secret
             assert is_monitor_probe(_request_with_header("abc-124")) is False
             assert is_monitor_probe(_request_with_header("abc-1230")) is False

--- a/api/utils/monitor_probe.py
+++ b/api/utils/monitor_probe.py
@@ -1,0 +1,36 @@
+"""
+Synthetic-monitor probe bypass.
+
+Production has Turnstile and rate limits enabled. A server-to-server probe
+(GitHub Actions runner) cannot produce a valid Turnstile token, so we let
+authorized probes opt-in via a shared secret header. The probe sends:
+
+    X-Monitor-Probe-Secret: <value>
+
+If the value matches `settings.monitor_probe_secret` (constant-time compare),
+Turnstile and per-IP/session rate limits are skipped for the request. Other
+guardrails (content filter, request validation, application logic) still
+apply, so the probe exercises the same code path as a real user.
+
+Bypass is fail-closed: if `settings.monitor_probe_secret` is unset/empty,
+the header is ignored regardless of value.
+"""
+
+import hmac
+
+from fastapi import Request
+
+from config import settings
+
+PROBE_HEADER = "X-Monitor-Probe-Secret"  # noqa: S105 - header name, not a secret
+
+
+def is_monitor_probe(request: Request) -> bool:
+    """Return True iff the request is an authorized synthetic monitor probe."""
+    expected = settings.monitor_probe_secret
+    if not expected:
+        return False
+    provided = request.headers.get(PROBE_HEADER)
+    if not provided:
+        return False
+    return hmac.compare_digest(expected, provided)

--- a/api/utils/security.py
+++ b/api/utils/security.py
@@ -19,6 +19,7 @@ from fastapi import Depends, HTTPException, Request
 from config import settings
 
 from .logging_config import get_logger
+from .monitor_probe import is_monitor_probe
 from .rate_limiter import get_rate_limiter
 
 logger = get_logger(__name__)
@@ -183,6 +184,13 @@ async def require_rate_limit(request: Request) -> None:
     Raises HTTPException 429 if rate limit exceeded.
     """
     if not settings.rate_limit_enabled:
+        return
+
+    if is_monitor_probe(request):
+        logger.info(
+            "Monitor probe — bypassing rate limit",
+            extra={"path": request.url.path},
+        )
         return
 
     ip_address = get_client_ip(request)

--- a/api/utils/turnstile.py
+++ b/api/utils/turnstile.py
@@ -25,6 +25,8 @@ from fastapi import Depends, HTTPException, Request
 
 from config import settings
 
+from .monitor_probe import is_monitor_probe
+
 logger = logging.getLogger(__name__)
 
 TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
@@ -172,6 +174,14 @@ async def require_turnstile(request: Request) -> None:
 
     # Skip CORS preflight and HEAD requests (harmless, no side effects)
     if request.method in ("HEAD", "OPTIONS"):
+        return
+
+    # Authorized synthetic monitor probe — bypass.
+    if is_monitor_probe(request):
+        logger.info(
+            "Monitor probe — bypassing Turnstile",
+            extra={"path": request.url.path},
+        )
         return
 
     verifier = get_turnstile_verifier()

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -200,6 +200,13 @@ locals {
       "TURNSTILE_SITE_KEY" = {
         value = var.turnstile_site_key
       }
+    } : {},
+
+    # Synthetic monitor probe bypass (only when secret is provided)
+    var.monitor_probe_secret != "" ? {
+      "MONITOR_PROBE_SECRET" = {
+        secret_name = "monitor-probe-secret" # pragma: allowlist secret
+      }
     } : {}
   )
 
@@ -451,7 +458,14 @@ resource "azurerm_postgresql_flexible_server_database" "app" {
 # the backend container app via replace_triggered_by.
 
 resource "terraform_data" "backend_secret_trigger" {
-  triggers_replace = sha256(var.openrouter_api_key)
+  # Hash all GH-sourced sensitive values that flow into ACA `secret` blocks.
+  # When any of them changes, terraform_data is replaced, which forces a
+  # replacement of azurerm_container_app.backend (via replace_triggered_by),
+  # bypassing the lifecycle { ignore_changes = [secret] } rotation trap.
+  triggers_replace = sha256(join("|", [
+    var.openrouter_api_key,
+    var.monitor_probe_secret,
+  ]))
 }
 
 # -----------------------------------------------------------------------------
@@ -568,6 +582,15 @@ resource "azurerm_container_app" "backend" {
     content {
       name  = "turnstile-secret-key"
       value = var.turnstile_secret_key
+    }
+  }
+
+  # Synthetic monitor probe shared secret (only when set)
+  dynamic "secret" {
+    for_each = var.monitor_probe_secret != "" ? [1] : []
+    content {
+      name  = "monitor-probe-secret"
+      value = var.monitor_probe_secret
     }
   }
 

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -980,7 +980,7 @@ resource "azurerm_cognitive_deployment" "embedding" {
 # -----------------------------------------------------------------------------
 
 resource "azurerm_consumption_budget_resource_group" "main" {
-  count             = var.create_budget_alert ? 1 : 0
+  count             = var.create_budget_alert && length(var.budget_alert_emails) > 0 ? 1 : 0
   name              = "${local.name_prefix}-budget"
   resource_group_id = azurerm_resource_group.main.id
 

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -1,0 +1,139 @@
+# -----------------------------------------------------------------------------
+# Production monitoring & alerting (native Azure baseline)
+# -----------------------------------------------------------------------------
+#
+# This is the *backup* delivery channel for production alerts. The primary
+# channel is Telegram via .github/workflows/prod-monitor.yml, which catches
+# functional failures (e.g. in-band SSE error chunks the way the OpenRouter
+# 401 incident manifested). This Azure-native baseline covers the case where
+# GitHub Actions itself is degraded.
+#
+# All resources are gated on var.alert_email being non-empty; leave it empty
+# in non-prod to skip the email action group and downstream alerts entirely.
+#
+# Resources defined here:
+#   - azurerm_monitor_action_group.ops_email
+#       Email-only action group, target: var.alert_email.
+#   - azurerm_monitor_metric_alert.backend_availability
+#       Wires the existing azurerm_application_insights_standard_web_test
+#       (defined in main.tf) to the action group. Without this, the web test
+#       runs but never alerts.
+#   - azurerm_monitor_metric_alert.backend_restarts
+#       Fires when the backend container app reports >0 restarts in 15 min.
+#   - azurerm_monitor_scheduled_query_rules_alert_v2.backend_errors
+#       Same KQL the prod-monitor.yml log-scan job runs; alerts via email if
+#       any backend error log line is seen in the last 10 minutes.
+
+locals {
+  alerts_enabled = var.alert_email != "" && var.enable_application_insights
+}
+
+resource "azurerm_monitor_action_group" "ops_email" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-ops-email"
+  resource_group_name = azurerm_resource_group.main.name
+  short_name          = "ops"
+
+  email_receiver {
+    name                    = "ops-email"
+    email_address           = var.alert_email
+    use_common_alert_schema = true
+  }
+
+  tags = local.tags
+}
+
+# Wire the existing standard web test to the action group so a region failing
+# to reach /health/ready triggers an email.
+resource "azurerm_monitor_metric_alert" "backend_availability" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-availability-failed"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes = [
+    azurerm_application_insights_standard_web_test.backend_availability[0].id,
+    azurerm_application_insights.main[0].id,
+  ]
+  description = "Backend availability test failing from one or more regions."
+  severity    = 1
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_standard_web_test.backend_availability[0].id
+    component_id          = azurerm_application_insights.main[0].id
+    failed_location_count = 2
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
+# Backend container app restart alert. Restarts are normal during deploys but
+# unexpected ones often signal OOM/crash-loop.
+resource "azurerm_monitor_metric_alert" "backend_restarts" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-backend-restarts"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_container_app.backend.id]
+  description         = "Backend Container App reported one or more restarts in the last 15 minutes."
+  severity            = 2
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "microsoft.app/containerapps"
+    metric_name      = "RestartCount"
+    aggregation      = "Total"
+    operator         = "GreaterThan"
+    threshold        = 0
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
+# Backend error-log alert (mirror of prod-monitor.yml's log-scan job).
+# Runs every 5 minutes; fires if any error-shaped log line was emitted in the
+# last 10 minutes.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_errors" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-backend-error-logs"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_log_analytics_workspace.main.id]
+  severity             = 2
+  description          = "Backend logs contain error-shaped messages (OpenRouter, LLM, traceback) in the last 10 minutes."
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      | where TimeGenerated > ago(10m)
+      | where ContainerAppName_s == "${azurerm_container_app.backend.name}"
+      | where Log_s matches regex "(?i)(openrouter error|llm streaming error|anthropic error|internal server error|traceback)"
+      | summarize cnt = count() by bin(TimeGenerated, 5m)
+      | where cnt > 0
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -112,7 +112,8 @@ enable_application_insights = true
 
 create_budget_alert = true
 monthly_budget      = 50
-budget_alert_emails = ["zioalex@gmail.com"]
+# budget_alert_emails is sourced from repo secret TF_VAR_BUDGET_ALERT_EMAILS
+# (JSON array, e.g. '["alerts@example.com"]'). Defaults to [] if unset.
 
 # -----------------------------------------------------------------------------
 # Custom Domain

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -417,9 +417,15 @@ variable "monthly_budget" {
 }
 
 variable "budget_alert_emails" {
-  description = "Email addresses for budget alerts"
+  description = <<-EOT
+    Email addresses that receive Azure budget alerts. Provided via repo secret
+    TF_VAR_BUDGET_ALERT_EMAILS as a JSON array (e.g. '["alerts@example.com"]')
+    so the value never lands in the checked-in terraform.tfvars. Marked
+    sensitive so plan/apply output redacts it.
+  EOT
   type        = list(string)
   default     = []
+  sensitive   = true
 }
 
 # -----------------------------------------------------------------------------

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -239,10 +239,12 @@ variable "alert_email" {
     delivery channel for the case where GitHub Actions itself is degraded
     and prod-monitor.yml cannot send Telegram messages. Leave empty to
     disable Azure Monitor alert delivery (the action group + alerts are
-    skipped entirely).
+    skipped entirely). Provided via repo secret TF_VAR_ALERT_EMAIL — kept
+    sensitive so the value never appears in terraform plan/apply output.
   EOT
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "monitor_probe_secret" {

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -232,6 +232,32 @@ variable "openrouter_api_key" {
   sensitive   = true
 }
 
+variable "alert_email" {
+  description = <<-EOT
+    Email address that receives critical Azure Monitor alerts (Container App
+    restarts, log-query alerts on backend errors). This is the *backup*
+    delivery channel for the case where GitHub Actions itself is degraded
+    and prod-monitor.yml cannot send Telegram messages. Leave empty to
+    disable Azure Monitor alert delivery (the action group + alerts are
+    skipped entirely).
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "monitor_probe_secret" {
+  description = <<-EOT
+    Shared secret that lets the synthetic monitor probe bypass Turnstile and
+    rate limits via the X-Monitor-Probe-Secret header. Must match the value
+    sent by .github/workflows/prod-monitor.yml (repo secret MONITOR_PROBE_SECRET).
+    Leave empty to disable bypass (the probe will then receive 403 from
+    Turnstile in production).
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "openrouter_model" {
   description = "OpenRouter model name (e.g., meta-llama/llama-3.3-70b-instruct:free)"
   type        = string

--- a/scripts/monitor/synthetic_chat.py
+++ b/scripts/monitor/synthetic_chat.py
@@ -1,0 +1,173 @@
+"""
+Synthetic chat probe.
+
+Sends a tiny chat request to /api/v1/chat/stream and validates the SSE
+response. Catches the exact failure mode that caused the OpenRouter 401
+incident — HTTP 200 with an in-band {"type": "error", ...} chunk that
+naive 5xx alerts cannot see.
+
+Exit codes:
+    0 — probe passed (saw a 'completion' chunk, no errors)
+    1 — probe failed (in-band error, missing chunks, timeout, or HTTP error)
+
+The failure detail is also written to a file path passed via --detail-out
+so the caller (CI workflow) can include it in alert messages.
+
+Required environment variables:
+    BACKEND_URL              — backend ACA URL, e.g. https://bible-app-backend.<...>.azurecontainerapps.io
+    MONITOR_PROBE_SECRET     — shared secret matching settings.monitor_probe_secret
+                               (sent as X-Monitor-Probe-Secret header to bypass Turnstile + rate limits)
+
+Optional:
+    PROBE_MESSAGE            — prompt to send (default: "hi")
+    PROBE_TIMEOUT_SECONDS    — overall timeout (default: 30)
+    PROBE_FIRST_CHUNK_SECONDS — fail if no content chunk arrives within this (default: 15)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+
+import httpx
+
+
+def fail(detail: str, detail_out: str | None) -> int:
+    print(f"PROBE FAIL: {detail}", file=sys.stderr)
+    if detail_out:
+        try:
+            with open(detail_out, "w", encoding="utf-8") as f:
+                f.write(detail)
+        except OSError as e:
+            print(f"could not write detail to {detail_out}: {e}", file=sys.stderr)
+    return 1
+
+
+def parse_sse_line(line: str) -> dict | str | None:
+    """Parse one SSE 'data:' line. Returns the JSON object, the literal '[DONE]',
+    or None for non-data lines (comments, blank lines, event:, id:, retry:)."""
+    if not line.startswith("data:"):
+        return None
+    payload = line[5:].lstrip()
+    if payload == "[DONE]":
+        return "[DONE]"
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Synthetic chat probe.")
+    parser.add_argument(
+        "--detail-out",
+        default=None,
+        help="Path to write failure detail (for CI alert payload).",
+    )
+    args = parser.parse_args()
+
+    backend_url = os.environ.get("BACKEND_URL", "").rstrip("/")
+    probe_secret = os.environ.get("MONITOR_PROBE_SECRET", "")
+    if not backend_url:
+        return fail("BACKEND_URL env var is required", args.detail_out)
+    if not probe_secret:
+        return fail("MONITOR_PROBE_SECRET env var is required", args.detail_out)
+
+    message = os.environ.get("PROBE_MESSAGE", "hi")
+    overall_timeout = float(os.environ.get("PROBE_TIMEOUT_SECONDS", "30"))
+    first_chunk_timeout = float(os.environ.get("PROBE_FIRST_CHUNK_SECONDS", "15"))
+
+    url = f"{backend_url}/api/v1/chat/stream"
+    session_id = f"monitor-probe-{uuid.uuid4().hex[:12]}"
+    body = {
+        "message": message,
+        "conversation_history": [],
+        "include_search": False,
+        "session_id": session_id,
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "X-Monitor-Probe-Secret": probe_secret,
+    }
+
+    started = time.monotonic()
+    saw_content = False
+    saw_completion = False
+    first_chunk_at: float | None = None
+    last_chunk: dict | None = None
+
+    try:
+        with httpx.Client(timeout=httpx.Timeout(overall_timeout, read=overall_timeout)) as client:
+            with client.stream("POST", url, json=body, headers=headers) as response:
+                if response.status_code != 200:
+                    text = response.read().decode("utf-8", errors="replace")[:500]
+                    return fail(
+                        f"HTTP {response.status_code} from {url}: {text}",
+                        args.detail_out,
+                    )
+
+                for raw_line in response.iter_lines():
+                    if time.monotonic() - started > overall_timeout:
+                        return fail(
+                            f"overall timeout {overall_timeout}s exceeded "
+                            f"(saw_content={saw_content} last={last_chunk!r})",
+                            args.detail_out,
+                        )
+                    if (
+                        not saw_content
+                        and time.monotonic() - started > first_chunk_timeout
+                    ):
+                        return fail(
+                            f"no content chunk within {first_chunk_timeout}s "
+                            f"(last={last_chunk!r})",
+                            args.detail_out,
+                        )
+
+                    parsed = parse_sse_line(raw_line)
+                    if parsed is None:
+                        continue
+                    if parsed == "[DONE]":
+                        break
+                    last_chunk = parsed
+                    chunk_type = parsed.get("type")
+                    if chunk_type == "error":
+                        err = parsed.get("error", "<no error field>")
+                        code = parsed.get("error_code")
+                        return fail(
+                            f"in-band SSE error: {err}"
+                            + (f" (code={code})" if code else ""),
+                            args.detail_out,
+                        )
+                    if chunk_type == "content":
+                        if not saw_content:
+                            first_chunk_at = time.monotonic() - started
+                        saw_content = True
+                    elif chunk_type == "completion":
+                        saw_completion = True
+    except httpx.TimeoutException as e:
+        return fail(f"httpx timeout: {e}", args.detail_out)
+    except httpx.HTTPError as e:
+        return fail(f"httpx error: {e}", args.detail_out)
+
+    if not saw_content:
+        return fail("stream ended without any content chunk", args.detail_out)
+    if not saw_completion:
+        return fail(
+            f"stream ended without completion chunk (last={last_chunk!r})",
+            args.detail_out,
+        )
+
+    elapsed = time.monotonic() - started
+    print(
+        f"PROBE OK: first_chunk={first_chunk_at:.2f}s total={elapsed:.2f}s "
+        f"session={session_id}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Production has Turnstile + per-IP rate limits enabled, so a server-to-server
synthetic monitor probe (GitHub Actions runner, no browser) cannot reach
the chat endpoint to validate that the LLM round-trip actually works. This
adds an opt-in bypass via a shared secret header:

    X-Monitor-Probe-Secret: <value>

When the value matches settings.monitor_probe_secret (constant-time compare
via hmac.compare_digest), require_turnstile and require_rate_limit return
early. Content filter, request validation, and application logic still
apply, so the probe exercises the same code path as a real user.

Bypass is fail-closed: an unset/empty server secret means the header is
ignored regardless of value. Tested in test_monitor_probe.py covering
unconfigured server, missing/empty/mismatched headers, and the matching
case.

This is the backend half of the prod-monitor.yml workflow that catches
in-band SSE error chunks (the failure mode of the OpenRouter 401 incident
that HTTP-level alerts cannot see).

https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J