### PR TITLE
fix(tests): drop backend-config import from frontend e2e test

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1026,6 +1026,7 @@ jobs:
         id: e2e
         env:
           FRONTEND_URL: ${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
+          DATABASE_URL: postgresql://e2e:e2e@localhost/e2e
         run: |
           cd api
           python -m pytest tests/e2e/ -m e2e -v --tb=short

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1026,7 +1026,7 @@ jobs:
         id: e2e
         env:
           FRONTEND_URL: ${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
-          DATABASE_URL: postgresql://e2e:e2e@localhost/e2e
+          DATABASE_URL: postgresql://e2e:e2e@localhost/e2e # pragma: allowlist secret
         run: |
           cd api
           python -m pytest tests/e2e/ -m e2e -v --tb=short

--- a/api/tests/e2e/test_frontend_e2e.py
+++ b/api/tests/e2e/test_frontend_e2e.py
@@ -33,16 +33,11 @@ FRONTEND_URL   Base URL of the frontend to test against.
 """
 
 import os
-import sys
-from pathlib import Path
 
 import httpx
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-from config import settings
-
-FRONTEND_URL = os.environ.get("FRONTEND_URL", settings.production_frontend_url)
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "https://voxquieta.org")
 
 # 60 s gives enough headroom for Azure Container Apps cold-start after a fresh
 # deploy.  The previous 30 s limit caused intermittent ReadTimeout failures on


### PR DESCRIPTION
## Summary

The `Run e2e tests` step in `azure-deploy.yml` currently fails at pytest collection with:

```
config.py:290: in <module>
    settings = get_settings()
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
database_url
  Value error, DATABASE_URL must be configured (currently set to placeholder value).
```

`api/tests/e2e/test_frontend_e2e.py` is an HTTP-only smoke test against the Next.js frontend — it does not need backend Settings. The `from config import settings` indirection was forcing full pydantic validation on import, which crashes when `DATABASE_URL` is unset.

## Changes (2 files, 8 lines)

- `api/tests/e2e/test_frontend_e2e.py` — drop the `from config import settings` import plus the now-unused `import sys`, `from pathlib import Path`, and `sys.path.insert(...)` scaffolding. Inline the `https://voxquieta.org` fallback URL (matches the default at `api/config.py:96`).
- `.github/workflows/azure-deploy.yml:1029` — defensive `DATABASE_URL=postgresql://e2e:e2e@localhost/e2e` in the e2e step's `env:`. Belt-and-braces against any future config-touching import being re-added.

## Test plan

- [ ] CI: e2e step collects tests successfully (`collected N items` instead of `ImportError`)
- [ ] Local: `cd api && FRONTEND_URL=https://voxquieta.org python -m pytest tests/e2e/ -m e2e -v --co` works without setting `DATABASE_URL`

## Context

This commit (`cecb712`) was originally pushed to `claude/fix-deployment-verification-NB4ry` *after* PR #432 squash-merged that branch — leaving it orphaned on a closed-PR branch. Re-publishing here as a one-commit PR.

https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J


---
_Generated by [Claude Code](https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J)_