### PR TITLE
fix(ops): add actions/checkout to prod-monitor health and log-scan jobs

### DIFF
--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -66,6 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      # Required so `uses: ./.github/actions/notify-telegram` can resolve the
+      # local composite action — without checkout, the runner has no repo files.
+      - uses: actions/checkout@v6
+
       - name: Check /health/live
         id: live
         run: |
@@ -141,6 +145,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Required so `uses: ./.github/actions/notify-telegram` can resolve the
+      # local composite action — without checkout, the runner has no repo files.
+      - uses: actions/checkout@v6
+
       - name: Login to Azure
         uses: azure/login@v3
         with:


### PR DESCRIPTION
## Summary

The first scheduled `Prod Monitor` run on `main` ([run #24941281829](https://github.com/zioalex/getinspiredbythebible/actions/runs/24941281829)) had all three jobs fail:

- **Health probe** & **Log scan**: failed with
  > Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/.../.github/actions/notify-telegram'

- **Synthetic chat probe**: failed with `exit code 1` (orthogonal — `MONITOR_PROBE_SECRET` wasn't yet set in the runtime container env; that fixes itself once you add the GH secret + redeploy)

## Root cause

`uses: ./.github/actions/notify-telegram` references a **local composite action**, which the GitHub Actions runner can only resolve if the repo has been checked out into the workspace. The `health` and `log-scan` jobs never ran `actions/checkout@v6`, so the workspace was empty when `notify-telegram` was invoked.

The `synthetic-chat` job already ran checkout (because it needs `scripts/monitor/synthetic_chat.py`), so it didn't hit this error — it failed for a different, expected reason.

## Fix

Add `- uses: actions/checkout@v6` as the first step in `health` and `log-scan` jobs. Eight new lines, no behaviour change beyond the runner having access to the local action.

## Test plan

- [x] yamllint, prettier-yaml, check-yaml all pass on the updated file
- [ ] Once merged, manually trigger Prod Monitor with `force_alert: true` — all three jobs should reach the `Notify Telegram` step (and post a test alert if the Telegram secrets are set)

https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbfJNC6BsAGhpc1TWXw37J)_