### PR TITLE
Add Prod Monitor status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vox Quieta
 
+[![Prod Monitor](https://github.com/zioalex/getinspiredbythebible/actions/workflows/prod-monitor.yml/badge.svg)](https://github.com/zioalex/getinspiredbythebible/actions/workflows/prod-monitor.yml)
+
 A conversational AI that helps people find spiritual encouragement and relevant scripture
 based on their life situations. Built with a modular architecture that supports multiple
 LLM backends.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions status badge for the `Prod Monitor` workflow to the README, directly below the project title
- The badge was missing despite the workflow existing — this makes the production monitoring status visible from the repo homepage

## Test plan
- [ ] Verify badge renders on the merged README (green/red depending on last monitor run)
- [ ] Click badge confirms it links to the `prod-monitor.yml` workflow run history

---
_Generated by [Claude Code](https://claude.ai/code/session_0128HHVtZGeVDPeJ3sSnZoyj)_