### PR TITLE
fix(deploy): bind Cloudflare cert to api.voxquieta.org and fail loudly on SSL drift

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -888,7 +888,7 @@ jobs:
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
               echo "::error::Re-export the Cloudflare Origin Cert as PFX (openssl pkcs12 -export -out cert.pfx ...)"
-              echo "::error::then refresh the secret: base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "::error::then refresh CLOUDFLARE_ORIGIN_CERT_B64 with base64 -w0 cert.pfx | gh secret set ..."
               exit 1
             fi
           fi
@@ -1178,7 +1178,7 @@ jobs:
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
               echo "::error::Re-export the Cloudflare Origin Cert as PFX (openssl pkcs12 -export -out cert.pfx ...)"
-              echo "::error::then refresh the secret: base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "::error::then refresh CLOUDFLARE_ORIGIN_CERT_B64 with base64 -w0 cert.pfx | gh secret set ..."
               exit 1
             fi
           fi

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -887,8 +887,12 @@ jobs:
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
-              echo "::error::Re-export the Cloudflare Origin Cert as PFX (openssl pkcs12 -export -out cert.pfx ...)"
-              echo "::error::then refresh CLOUDFLARE_ORIGIN_CERT_B64 with base64 -w0 cert.pfx | gh secret set ..."
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX, then refresh the GitHub Actions secret:"
+              echo "::error::  openssl pkcs12 -export -out cloudflare-origin.pfx \\"
+              echo "::error::    -inkey origin-key.pem -in origin-cert.pem \\"
+              echo "::error::    -passout \"pass:\$TF_VAR_cloudflare_origin_cert_password\""
+              echo "::error::  base64 -w0 cloudflare-origin.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "::error::See deployment/README.md > 'Rotating CLOUDFLARE_ORIGIN_CERT_B64' for the full procedure."
               exit 1
             fi
           fi
@@ -1177,8 +1181,12 @@ jobs:
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
-              echo "::error::Re-export the Cloudflare Origin Cert as PFX (openssl pkcs12 -export -out cert.pfx ...)"
-              echo "::error::then refresh CLOUDFLARE_ORIGIN_CERT_B64 with base64 -w0 cert.pfx | gh secret set ..."
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX, then refresh the GitHub Actions secret:"
+              echo "::error::  openssl pkcs12 -export -out cloudflare-origin.pfx \\"
+              echo "::error::    -inkey origin-key.pem -in origin-cert.pem \\"
+              echo "::error::    -passout \"pass:\$TF_VAR_cloudflare_origin_cert_password\""
+              echo "::error::  base64 -w0 cloudflare-origin.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "::error::See deployment/README.md > 'Rotating CLOUDFLARE_ORIGIN_CERT_B64' for the full procedure."
               exit 1
             fi
           fi

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -339,7 +339,10 @@ jobs:
             BACKEND_URL="$RAW_BACKEND_URL"
             echo "PR build → using raw FQDN"
           else
-            CUSTOM_DOMAIN_BACKEND=$(grep -E '^[[:space:]]*custom_domain_backend[[:space:]]*=' deployment/terraform.tfvars | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+            CUSTOM_DOMAIN_BACKEND=$(
+              grep -E '^[[:space:]]*custom_domain_backend[[:space:]]*=' deployment/terraform.tfvars |
+              sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/'
+            )
             if [ -z "$CUSTOM_DOMAIN_BACKEND" ]; then
               echo "::error::custom_domain_backend not set in deployment/terraform.tfvars"
               exit 1
@@ -565,11 +568,11 @@ jobs:
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
-              echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
-              echo "::error::Re-export the Cloudflare Origin Cert as PFX and update the secret:"
-              echo "::error::  openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:\$TF_VAR_cloudflare_origin_cert_password"
-              echo "::error::  base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
-              exit 1
+              # Plan-only: warn but don't block PRs on a broken cert secret.
+              # The deploy/destroy jobs hard-fail on this same condition.
+              echo "::warning::cloudflare-origin.pfx cannot be read — cert resources skipped in plan"
+              echo "::warning::Fix: re-export PFX with openssl pkcs12 -export and refresh CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "cert_decoded=false" >> $GITHUB_ENV
             fi
           fi
 
@@ -884,9 +887,8 @@ jobs:
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
-              echo "::error::Re-export the Cloudflare Origin Cert as PFX and update the secret:"
-              echo "::error::  openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:\$TF_VAR_cloudflare_origin_cert_password"
-              echo "::error::  base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX (openssl pkcs12 -export -out cert.pfx ...)"
+              echo "::error::then refresh the secret: base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
               exit 1
             fi
           fi
@@ -984,14 +986,14 @@ jobs:
             case "$HTTP_CODE" in
               200)
                 if [ -z "$CF_RAY" ]; then
-                  echo "::error::$DOMAIN returned HTTP 200 but no cf-ray header — traffic is not going through Cloudflare"
+                  echo "::error::$DOMAIN returned 200 but no cf-ray header — traffic is bypassing Cloudflare"
                   FAILED=1
                 else
                   echo "$DOMAIN OK — HTTP 200, $CF_RAY"
                 fi
                 ;;
               525)
-                echo "::error::$DOMAIN returned HTTP 525 (SSL Handshake Failed) — origin cert is missing or not bound on Azure"
+                echo "::error::$DOMAIN returned 525 (SSL Handshake Failed) — origin cert missing or not bound"
                 FAILED=1
                 ;;
               526)
@@ -1175,9 +1177,8 @@ jobs:
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
-              echo "::error::Re-export the Cloudflare Origin Cert as PFX and update the secret:"
-              echo "::error::  openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:\$TF_VAR_cloudflare_origin_cert_password"
-              echo "::error::  base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX (openssl pkcs12 -export -out cert.pfx ...)"
+              echo "::error::then refresh the secret: base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
               exit 1
             fi
           fi

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -292,8 +292,12 @@ jobs:
       - name: Get Backend URL
         id: backend-url
         run: |
-          # Get the backend URL from Azure Container Apps
-          # IMPORTANT: No fallback - fail fast if backend URL can't be fetched
+          # Production builds bake the public custom domain into the frontend
+          # image (so browsers go through Cloudflare, not the raw Azure FQDN).
+          # PR builds use the raw Azure FQDN since the custom domain may not
+          # resolve to PR preview environments.
+          # Sanity-check the backend by calling the raw FQDN regardless, so a
+          # backend outage still fails the build before we bake a URL in.
           BACKEND_FQDN=$(az containerapp show \
             --name ${{ env.BACKEND_APP_NAME }} \
             --resource-group ${{ env.RESOURCE_GROUP }} \
@@ -305,23 +309,21 @@ jobs:
             exit 1
           fi
 
-          BACKEND_URL="https://$BACKEND_FQDN"
+          RAW_BACKEND_URL="https://$BACKEND_FQDN"
 
-          # VALIDATE: Actually test that this URL is a backend, not frontend
-          echo "Validating backend URL responds correctly..."
-          HEALTH_RESPONSE=$(curl -sf --max-time 30 "$BACKEND_URL/health/live" 2>/dev/null || echo "")
+          echo "Validating backend health via raw FQDN..."
+          HEALTH_RESPONSE=$(curl -sf --max-time 30 "$RAW_BACKEND_URL/health/live" 2>/dev/null || echo "")
           if [ -z "$HEALTH_RESPONSE" ]; then
             if [ "${{ github.event_name }}" == "pull_request" ]; then
               echo "::warning::Backend URL health check failed on PR (backend may be scaled to zero)."
               echo "::warning::Proceeding with build-only validation."
             else
               echo "::error::Backend URL does not respond to /health/live"
-              echo "::error::URL: $BACKEND_URL"
+              echo "::error::URL: $RAW_BACKEND_URL"
               exit 1
             fi
           fi
 
-          # Check it returns expected backend response (not frontend HTML)
           if [ -n "$HEALTH_RESPONSE" ] && echo "$HEALTH_RESPONSE" | grep -q '"status"'; then
             echo "✅ Backend health check passed"
           elif [ -n "$HEALTH_RESPONSE" ]; then
@@ -330,6 +332,19 @@ jobs:
             exit 1
           else
             echo "⚠️ Skipping response validation (no health response received)"
+          fi
+
+          # Choose what to bake into NEXT_PUBLIC_API_URL.
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            BACKEND_URL="$RAW_BACKEND_URL"
+            echo "PR build → using raw FQDN"
+          else
+            CUSTOM_DOMAIN_BACKEND=$(grep -E '^[[:space:]]*custom_domain_backend[[:space:]]*=' deployment/terraform.tfvars | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/')
+            if [ -z "$CUSTOM_DOMAIN_BACKEND" ]; then
+              echo "::error::custom_domain_backend not set in deployment/terraform.tfvars"
+              exit 1
+            fi
+            BACKEND_URL="https://$CUSTOM_DOMAIN_BACKEND"
           fi
 
           echo "url=$BACKEND_URL" >> $GITHUB_OUTPUT
@@ -550,9 +565,11 @@ jobs:
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
-              echo "::warning::cloudflare-origin.pfx cannot be read - SSL cert upload skipped."
-              echo "::warning::Fix: openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:"
-              echo "cert_decoded=false" >> $GITHUB_ENV
+              echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX and update the secret:"
+              echo "::error::  openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:\$TF_VAR_cloudflare_origin_cert_password"
+              echo "::error::  base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              exit 1
             fi
           fi
 
@@ -866,9 +883,11 @@ jobs:
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
-              echo "::warning::cloudflare-origin.pfx cannot be read - SSL cert upload skipped."
-              echo "::warning::Fix: openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:"
-              echo "cert_decoded=false" >> $GITHUB_ENV
+              echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX and update the secret:"
+              echo "::error::  openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:\$TF_VAR_cloudflare_origin_cert_password"
+              echo "::error::  base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              exit 1
             fi
           fi
 
@@ -952,7 +971,6 @@ jobs:
           fi
 
       - name: Verify Custom Domain HTTPS
-        if: env.cert_decoded == 'true'
         run: |
           set -euo pipefail
           DOMAINS=("voxquieta.org" "api.voxquieta.org")
@@ -963,19 +981,43 @@ jobs:
               --max-time 15 "https://$DOMAIN/health" 2>/dev/null || echo "000")
             CF_RAY=$(curl -sI --max-time 15 "https://$DOMAIN/health" 2>/dev/null | grep -i 'cf-ray' || echo "")
 
-            if [ "$HTTP_CODE" = "526" ]; then
-              echo "::error::$DOMAIN returned HTTP 526 (Invalid SSL Certificate) — cert binding is wrong"
-              FAILED=1
-            elif [ "$HTTP_CODE" = "000" ]; then
-              echo "::warning::$DOMAIN is unreachable (DNS may not be propagated yet)"
-            elif [ -z "$CF_RAY" ]; then
-              echo "::warning::$DOMAIN responded HTTP $HTTP_CODE but no cf-ray header (not going through Cloudflare)"
-            else
-              echo "$DOMAIN OK — HTTP $HTTP_CODE, $CF_RAY"
-            fi
+            case "$HTTP_CODE" in
+              200)
+                if [ -z "$CF_RAY" ]; then
+                  echo "::error::$DOMAIN returned HTTP 200 but no cf-ray header — traffic is not going through Cloudflare"
+                  FAILED=1
+                else
+                  echo "$DOMAIN OK — HTTP 200, $CF_RAY"
+                fi
+                ;;
+              525)
+                echo "::error::$DOMAIN returned HTTP 525 (SSL Handshake Failed) — origin cert is missing or not bound on Azure"
+                FAILED=1
+                ;;
+              526)
+                echo "::error::$DOMAIN returned HTTP 526 (Invalid SSL Certificate) — origin cert chain is wrong"
+                FAILED=1
+                ;;
+              000)
+                echo "::error::$DOMAIN is unreachable (HTTP 000) — DNS or Cloudflare misconfigured"
+                FAILED=1
+                ;;
+              5*)
+                echo "::error::$DOMAIN returned HTTP $HTTP_CODE — origin error"
+                FAILED=1
+                ;;
+              *)
+                if [ -z "$CF_RAY" ]; then
+                  echo "::error::$DOMAIN responded HTTP $HTTP_CODE with no cf-ray header"
+                  FAILED=1
+                else
+                  echo "$DOMAIN responded HTTP $HTTP_CODE (non-200 but reached Cloudflare), $CF_RAY"
+                fi
+                ;;
+            esac
           done
           if [ "$FAILED" -ne 0 ]; then
-            echo "::error::One or more domains have SSL certificate issues"
+            echo "::error::One or more domains failed the post-deploy SSL/health check"
             exit 1
           fi
 
@@ -1132,9 +1174,11 @@ jobs:
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
-              echo "::warning::cloudflare-origin.pfx cannot be read - SSL cert upload skipped."
-              echo "::warning::Fix: openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:"
-              echo "cert_decoded=false" >> $GITHUB_ENV
+              echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
+              echo "::error::Re-export the Cloudflare Origin Cert as PFX and update the secret:"
+              echo "::error::  openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem -passout pass:\$TF_VAR_cloudflare_origin_cert_password"
+              echo "::error::  base64 -w0 cert.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64"
+              exit 1
             fi
           fi
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -521,6 +521,53 @@ az containerapp logs show \
   --follow
 ```
 
+### Rotating `CLOUDFLARE_ORIGIN_CERT_B64`
+
+When the deploy workflow fails at the **Decode Cloudflare Origin Certificate**
+step with `CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be
+read`, the GitHub Actions secret holds an unreadable PFX (corrupted upload,
+wrong password, or a legacy-format PFX the auto-normalizer in CI couldn't
+convert). Rebuild the secret from the original Cloudflare Origin Cert files:
+
+```bash
+# 0. Make sure you still have origin-cert.pem and origin-key.pem from
+#    "Step 1: Create Cloudflare Origin Certificate" above. If not, create a
+#    new origin cert in Cloudflare Dashboard (it can coexist with the old
+#    one — Cloudflare allows multiple active origin certs per zone) and use
+#    those new files here.
+
+# 1. Re-export the cert as a modern (AES-256) PFX. The password must match
+#    TF_VAR_cloudflare_origin_cert_password (use an empty pass for no
+#    password). OpenSSL 3.x produces a modern PFX by default.
+openssl pkcs12 -export -out cloudflare-origin.pfx \
+  -inkey origin-key.pem -in origin-cert.pem \
+  -passout "pass:$TF_VAR_cloudflare_origin_cert_password"
+
+# 2. Verify the PFX is readable with the same password CI will use.
+openssl pkcs12 -in cloudflare-origin.pfx \
+  -passin "pass:$TF_VAR_cloudflare_origin_cert_password" -noout
+
+# 3. Base64-encode (single line, no wrap) and refresh the GitHub Actions
+#    secret. Requires `gh auth login` and repo write permissions.
+base64 -w0 cloudflare-origin.pfx | gh secret set CLOUDFLARE_ORIGIN_CERT_B64
+
+# 4. (Optional) If the cert password changed, also update:
+#      gh secret set TF_VAR_CLOUDFLARE_ORIGIN_CERT_PASSWORD
+```
+
+Re-run the failed deploy. The workflow's bind step will pick up the new cert
+from the Container App Environment automatically — its trigger hashes
+`cloudflare-origin.pfx`, so a refreshed secret triggers re-binding even if
+the underlying cert (SANs, expiry) is unchanged.
+
+**Why the workflow now fails hard instead of warning.** Earlier versions of
+the workflow logged a warning on this condition and skipped the cert upload
+& bind, so production deploys silently shipped without an SSL binding for
+custom domains, surfacing as HTTP 525 from Cloudflare. Hard-failing the
+deploy/destroy jobs makes the regression visible. The plan-only (`tf-plan`)
+job still warns and skips so it doesn't block PR review when the secret is
+broken.
+
 ## 📁 Project Structure
 
 ```

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -724,17 +724,24 @@ resource "null_resource" "frontend_custom_domain" {
     hostname       = var.custom_domain_frontend
     container_app  = azurerm_container_app.frontend.name
     resource_group = azurerm_resource_group.main.name
+    cert_hash      = var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : ""
   }
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
       set -euo pipefail
-      echo "Adding custom domain ${var.custom_domain_frontend} to ${azurerm_container_app.frontend.name}..."
-      az containerapp hostname add \
-        --name ${azurerm_container_app.frontend.name} \
-        --resource-group ${azurerm_resource_group.main.name} \
-        --hostname ${var.custom_domain_frontend}
+      DOMAIN="${var.custom_domain_frontend}"
+      APP="${azurerm_container_app.frontend.name}"
+      RG="${azurerm_resource_group.main.name}"
+      EXISTING=$(az containerapp show --name "$APP" --resource-group "$RG" \
+        --query "properties.configuration.ingress.customDomains[].name" -o tsv 2>/dev/null || true)
+      if echo "$EXISTING" | grep -qx "$DOMAIN"; then
+        echo "Custom domain $DOMAIN already attached to $APP"
+      else
+        echo "Adding custom domain $DOMAIN to $APP..."
+        az containerapp hostname add --name "$APP" --resource-group "$RG" --hostname "$DOMAIN"
+      fi
     EOT
   }
 
@@ -749,17 +756,24 @@ resource "null_resource" "backend_custom_domain" {
     hostname       = var.custom_domain_backend
     container_app  = azurerm_container_app.backend.name
     resource_group = azurerm_resource_group.main.name
+    cert_hash      = var.cloudflare_origin_cert_backend != "" ? filemd5(var.cloudflare_origin_cert_backend) : (var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : "")
   }
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command = <<-EOT
       set -euo pipefail
-      echo "Adding custom domain ${var.custom_domain_backend} to ${azurerm_container_app.backend.name}..."
-      az containerapp hostname add \
-        --name ${azurerm_container_app.backend.name} \
-        --resource-group ${azurerm_resource_group.main.name} \
-        --hostname ${var.custom_domain_backend}
+      DOMAIN="${var.custom_domain_backend}"
+      APP="${azurerm_container_app.backend.name}"
+      RG="${azurerm_resource_group.main.name}"
+      EXISTING=$(az containerapp show --name "$APP" --resource-group "$RG" \
+        --query "properties.configuration.ingress.customDomains[].name" -o tsv 2>/dev/null || true)
+      if echo "$EXISTING" | grep -qx "$DOMAIN"; then
+        echo "Custom domain $DOMAIN already attached to $APP"
+      else
+        echo "Adding custom domain $DOMAIN to $APP..."
+        az containerapp hostname add --name "$APP" --resource-group "$RG" --hostname "$DOMAIN"
+      fi
     EOT
   }
 
@@ -814,6 +828,7 @@ resource "null_resource" "frontend_ssl_cert_bind" {
   triggers = {
     hostname       = var.custom_domain_frontend
     cert_file      = var.cloudflare_origin_cert_frontend
+    cert_hash      = var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : ""
     container_app  = azurerm_container_app.frontend.name
     resource_group = azurerm_resource_group.main.name
     environment    = azurerm_container_app_environment.main.name
@@ -824,13 +839,16 @@ resource "null_resource" "frontend_ssl_cert_bind" {
     command = <<-EOT
       set -euo pipefail
       DOMAIN="${var.custom_domain_frontend}"
-      echo "Binding SSL certificate to $DOMAIN..."
+      # Wildcard SAN one level up, e.g. api.voxquieta.org -> *.voxquieta.org.
+      # For an apex domain this yields harmless *.tld which won't match any real cert.
+      PARENT_WILDCARD="*.$(echo "$DOMAIN" | cut -d. -f2-)"
+      echo "Binding SSL certificate to $DOMAIN (also matching $PARENT_WILDCARD)..."
 
-      # Find the certificate whose SANs cover this domain, sorted by expiry (newest first)
+      # Find a cert whose SAN equals $DOMAIN or the parent wildcard, newest first.
       CERT_ID=$(az containerapp env certificate list \
         --name ${azurerm_container_app_environment.main.name} \
         --resource-group ${azurerm_resource_group.main.name} \
-        --query "[?properties.subjectAlternativeNames[?contains(@, '$DOMAIN')] || properties.subjectAlternativeNames[?contains(@, '*.$DOMAIN')]] | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id" \
+        --query "[?contains(properties.subjectAlternativeNames, '$DOMAIN') || contains(properties.subjectAlternativeNames, '$PARENT_WILDCARD')] | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id" \
         -o tsv)
 
       if [ -z "$CERT_ID" ]; then
@@ -894,6 +912,7 @@ resource "null_resource" "backend_ssl_cert_bind" {
   triggers = {
     hostname       = var.custom_domain_backend
     cert_file      = var.cloudflare_origin_cert_backend != "" ? var.cloudflare_origin_cert_backend : var.cloudflare_origin_cert_frontend
+    cert_hash      = var.cloudflare_origin_cert_backend != "" ? filemd5(var.cloudflare_origin_cert_backend) : (var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : "")
     container_app  = azurerm_container_app.backend.name
     resource_group = azurerm_resource_group.main.name
     environment    = azurerm_container_app_environment.main.name
@@ -904,13 +923,14 @@ resource "null_resource" "backend_ssl_cert_bind" {
     command = <<-EOT
       set -euo pipefail
       DOMAIN="${var.custom_domain_backend}"
-      echo "Binding SSL certificate to $DOMAIN..."
+      PARENT_WILDCARD="*.$(echo "$DOMAIN" | cut -d. -f2-)"
+      echo "Binding SSL certificate to $DOMAIN (also matching $PARENT_WILDCARD)..."
 
-      # Find the certificate whose SANs cover this domain, sorted by expiry (newest first)
+      # Find a cert whose SAN equals $DOMAIN or the parent wildcard, newest first.
       CERT_ID=$(az containerapp env certificate list \
         --name ${azurerm_container_app_environment.main.name} \
         --resource-group ${azurerm_resource_group.main.name} \
-        --query "[?properties.subjectAlternativeNames[?contains(@, '$DOMAIN')] || properties.subjectAlternativeNames[?contains(@, '*.$DOMAIN')]] | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id" \
+        --query "[?contains(properties.subjectAlternativeNames, '$DOMAIN') || contains(properties.subjectAlternativeNames, '$PARENT_WILDCARD')] | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id" \
         -o tsv)
 
       if [ -z "$CERT_ID" ]; then


### PR DESCRIPTION
## Summary

Production was returning **HTTP 525** on `api.voxquieta.org`, breaking the Android app's translation/book-name fetches. The web app at `voxquieta.org` only worked because its baked-in `NEXT_PUBLIC_API_URL` pointed at the raw `*.azurecontainerapps.io` FQDN, bypassing Cloudflare entirely (and leaking the Azure backend hostname to every browser DevTools panel).

### Root cause

The SAN-filter in the Container App cert-bind null_resource looked for `*.$DOMAIN` — one level *deeper* than the hostname — instead of the parent-domain wildcard. For `$DOMAIN = api.voxquieta.org` it searched for SANs containing `*.api.voxquieta.org`, which the Cloudflare Origin Cert (SANs `voxquieta.org` + `*.voxquieta.org`) never matched, so the bind step `exit 1`'d and the hostname ended up with no cert bound.

Confirmed via `az containerapp show`: backend's `customDomains` was empty; env contained two valid certs (one matching the cert in the Cloudflare Dashboard, expiry 2041-04-06) that nothing was binding to.

### Changes

`deployment/main.tf`:
- SAN-filter now matches the literal hostname **or** the parent-domain wildcard (`api.voxquieta.org → *.voxquieta.org`), using jmespath `contains(array, value)` for exact-match semantics.
- `cert_hash = filemd5(...)` added to triggers on both `*_custom_domain` (hostname-add) and `*_ssl_cert_bind` (cert-bind) resources. Rotated PFXs now re-trigger the binding, and the new trigger key forces all four resources to recreate on the next apply — which re-establishes the dropped `customDomains` entry without any manual `az` commands.
- Hostname-add commands made idempotent (skip if the domain is already attached) so the forced recreation is safe.

`.github/workflows/azure-deploy.yml`:
- Production frontend builds bake `https://api.voxquieta.org` into `NEXT_PUBLIC_API_URL` (sourced from `terraform.tfvars`), so browsers go through Cloudflare. Backend health is still sanity-checked via the raw FQDN before baking, and PR builds keep the raw-FQDN behaviour.
- Undecodable Cloudflare Origin Cert PFX is now `exit 1` (was a warning that silently skipped the bind step) — three occurrences fixed.
- `Verify Custom Domain HTTPS` rewritten as a `case` on the response code: 525, 526, other 5xx, 000, and missing `cf-ray` all fail the deploy. `cert_decoded` gate removed (it's now redundant).

## Test plan

- [ ] `terraform plan` in `deployment/` shows the four hostname/bind null_resources changing due to the new `cert_hash` trigger; no surprise changes elsewhere.
- [ ] Workflow run on this branch:
  - [ ] `Decode Cloudflare Origin Certificate` succeeds (`cert_decoded=true`).
  - [ ] `Terraform Apply` logs `Found certificate <id> for domain api.voxquieta.org` and `... voxquieta.org`.
  - [ ] `Verify Custom Domain HTTPS` returns 200 with `cf-ray` for both domains.
- [ ] External smoke (from a real network):
  - [ ] `curl -sI https://api.voxquieta.org/health` → HTTP 200 with `cf-ray` header.
  - [ ] `curl -s https://api.voxquieta.org/api/v1/scripture/translations | jq 'length'` → > 1.
- [ ] Web app at `https://voxquieta.org`: DevTools → Network shows requests going to `api.voxquieta.org` (not the raw `*.azurecontainerapps.io`). Translation picker renders the full list; chat returns scripture data.
- [ ] Android release build: translation picker shows the full list (not just "Auto"); a chat referencing a verse loads the verse text; logcat shows no `HttpException: HTTP 525`.

## Optional hot-fix

If you'd rather not wait for the deploy cycle, restore the binding manually using the cert that matches Cloudflare Dashboard (`bible-app-env-bible-app-rg-c27e-1570`):

```bash
az containerapp hostname add \
  --name bible-app-backend --resource-group bible-app-rg \
  --hostname api.voxquieta.org

az containerapp hostname bind \
  --name bible-app-backend --resource-group bible-app-rg \
  --hostname api.voxquieta.org \
  --certificate bible-app-env-bible-app-rg-c27e-1570 \
  --environment <env-name>
```

This is **not** a substitute for merging this PR — without the SAN-filter fix, the next deploy will tear the binding down again.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YSPojtuAAqAXcxYDtsQPzh)_