### PR TITLE
fix(deploy): derive cert_hash from base64 secret to keep it deterministic

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -566,6 +566,12 @@ jobs:
                openssl pkcs12 -legacy -in "$PFX_FILE" -passin "pass:${CERT_PASS}" -noout 2>/dev/null; then
               # Path relative to TF working dir so filemd5() and az CLI resolve correctly
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
+              # Deterministic hash from the base64 secret — see deployment/main.tf
+              # null_resource cert_hash triggers. filemd5 of the decoded PFX is
+              # non-deterministic because the openssl pkcs12 -export step above
+              # uses random salt/IV, so plan and apply hashes disagree.
+              CERT_HASH=$(printf '%s' "$CERT_B64" | md5sum | awk '{print $1}')
+              echo "TF_VAR_cloudflare_origin_cert_hash=$CERT_HASH" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               # Plan-only: warn but don't block PRs on a broken cert secret.
@@ -866,7 +872,10 @@ jobs:
           else
             echo "$CERT_B64" | base64 -d > deployment/cloudflare-origin.pfx
             # Normalize PFX: convert legacy PKCS12 (RC2/3DES from OpenSSL 1.x) to modern AES
-            # format so newer Azure CLI (via azure/login@v3) can deserialize it
+            # format so newer Azure CLI (via azure/login@v3) can deserialize it.
+            # Note: openssl pkcs12 -export uses random salt/IV, so the resulting
+            # PFX bytes differ between runners. cert_hash trigger is computed
+            # from $CERT_B64 below, not from the file, to keep it deterministic.
             PFX_FILE="deployment/cloudflare-origin.pfx"
             CERT_PASS="${TF_VAR_cloudflare_origin_cert_password:-}"
             if openssl pkcs12 -legacy -in "$PFX_FILE" -passin "pass:${CERT_PASS}" \
@@ -884,6 +893,8 @@ jobs:
                openssl pkcs12 -legacy -in "$PFX_FILE" -passin "pass:${CERT_PASS}" -noout 2>/dev/null; then
               # Path relative to TF working dir so filemd5() and az CLI resolve correctly
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
+              CERT_HASH=$(printf '%s' "$CERT_B64" | md5sum | awk '{print $1}')
+              echo "TF_VAR_cloudflare_origin_cert_hash=$CERT_HASH" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."
@@ -1178,6 +1189,8 @@ jobs:
                openssl pkcs12 -legacy -in "$PFX_FILE" -passin "pass:${CERT_PASS}" -noout 2>/dev/null; then
               # Path relative to TF working dir so filemd5() and az CLI resolve correctly
               echo "TF_VAR_cloudflare_origin_cert_frontend=cloudflare-origin.pfx" >> $GITHUB_ENV
+              CERT_HASH=$(printf '%s' "$CERT_B64" | md5sum | awk '{print $1}')
+              echo "TF_VAR_cloudflare_origin_cert_hash=$CERT_HASH" >> $GITHUB_ENV
               echo "cert_decoded=true" >> $GITHUB_ENV
             else
               echo "::error::CLOUDFLARE_ORIGIN_CERT_B64 is set but the resulting PFX cannot be read."

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -724,7 +724,7 @@ resource "null_resource" "frontend_custom_domain" {
     hostname       = var.custom_domain_frontend
     container_app  = azurerm_container_app.frontend.name
     resource_group = azurerm_resource_group.main.name
-    cert_hash      = var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : ""
+    cert_hash      = var.cloudflare_origin_cert_hash
   }
 
   provisioner "local-exec" {
@@ -756,7 +756,7 @@ resource "null_resource" "backend_custom_domain" {
     hostname       = var.custom_domain_backend
     container_app  = azurerm_container_app.backend.name
     resource_group = azurerm_resource_group.main.name
-    cert_hash      = var.cloudflare_origin_cert_backend != "" ? filemd5(var.cloudflare_origin_cert_backend) : (var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : "")
+    cert_hash      = var.cloudflare_origin_cert_hash
   }
 
   provisioner "local-exec" {
@@ -800,7 +800,7 @@ resource "null_resource" "frontend_ssl_cert_upload" {
 
   triggers = {
     cert_file      = var.cloudflare_origin_cert_frontend
-    cert_hash      = var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : ""
+    cert_hash      = var.cloudflare_origin_cert_hash
     environment    = azurerm_container_app_environment.main.name
     resource_group = azurerm_resource_group.main.name
   }
@@ -828,7 +828,7 @@ resource "null_resource" "frontend_ssl_cert_bind" {
   triggers = {
     hostname       = var.custom_domain_frontend
     cert_file      = var.cloudflare_origin_cert_frontend
-    cert_hash      = var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : ""
+    cert_hash      = var.cloudflare_origin_cert_hash
     container_app  = azurerm_container_app.frontend.name
     resource_group = azurerm_resource_group.main.name
     environment    = azurerm_container_app_environment.main.name
@@ -884,7 +884,7 @@ resource "null_resource" "backend_ssl_cert_upload" {
 
   triggers = {
     cert_file      = var.cloudflare_origin_cert_backend
-    cert_hash      = var.cloudflare_origin_cert_backend != "" ? filemd5(var.cloudflare_origin_cert_backend) : ""
+    cert_hash      = var.cloudflare_origin_cert_hash
     environment    = azurerm_container_app_environment.main.name
     resource_group = azurerm_resource_group.main.name
   }
@@ -912,7 +912,7 @@ resource "null_resource" "backend_ssl_cert_bind" {
   triggers = {
     hostname       = var.custom_domain_backend
     cert_file      = var.cloudflare_origin_cert_backend != "" ? var.cloudflare_origin_cert_backend : var.cloudflare_origin_cert_frontend
-    cert_hash      = var.cloudflare_origin_cert_backend != "" ? filemd5(var.cloudflare_origin_cert_backend) : (var.cloudflare_origin_cert_frontend != "" ? filemd5(var.cloudflare_origin_cert_frontend) : "")
+    cert_hash      = var.cloudflare_origin_cert_hash
     container_app  = azurerm_container_app.backend.name
     resource_group = azurerm_resource_group.main.name
     environment    = azurerm_container_app_environment.main.name

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -203,6 +203,12 @@ variable "cloudflare_origin_cert_password" {
   sensitive   = true
 }
 
+variable "cloudflare_origin_cert_hash" {
+  description = "MD5 of the base64-encoded Cloudflare Origin Certificate, computed by the deploy workflow. Used as a stable trigger value on null_resource cert binds so a rotation forces re-binding. We do not use filemd5() on the decoded PFX because the workflow re-encrypts via openssl pkcs12 -export with random salt/IV, producing different bytes on every runner."
+  type        = string
+  default     = ""
+}
+
 # -----------------------------------------------------------------------------
 # LLM Configuration
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to PR #438. The first production deploy after merge crashed during `terraform apply tfplan` with three identical errors:

```
Error: Provider produced inconsistent final plan
.triggers["cert_hash"]: was StringVal("0572e2..."), but now StringVal("bf3f8b...")
```

…on `null_resource.frontend_custom_domain`, `null_resource.backend_custom_domain`, and `null_resource.frontend_ssl_cert_upload`. The user recovered by rotating the origin cert and re-running, but the bug is latent and will recur on every cert-resource-changing deploy.

## Root cause

`deployment/main.tf` uses `cert_hash = filemd5(var.cloudflare_origin_cert_*)` in six `null_resource` triggers. The Decode step in the workflow doesn't just base64-decode the PFX — it also re-encrypts it via `openssl pkcs12 -export` to normalize the legacy PKCS12 format to the modern AES variant so newer Azure CLI can read it. **`openssl pkcs12 -export` uses random salt/IV**, so the resulting PFX bytes (and therefore `filemd5`) differ between the tf-plan runner and the deploy runner — even when the input secret is identical. The plan bakes in one md5 and the apply re-evaluates to another → terraform refuses to proceed.

## Fix

Compute the hash **once, deterministically, from the base64 secret itself** (which is byte-identical across runners and unchanged across re-runs of the same deploy), export it as a Terraform variable, and use it in the triggers in place of `filemd5(...)`.

- `.github/workflows/azure-deploy.yml` (3 Decode steps — tf-plan, deploy, destroy): added `CERT_HASH=$(printf '%s' "$CERT_B64" | md5sum | awk '{print $1}')` and exported as `TF_VAR_cloudflare_origin_cert_hash`.
- `deployment/variables.tf`: added `variable "cloudflare_origin_cert_hash"` with `""` default.
- `deployment/main.tf`: replaced 6 occurrences of `cert_hash = … filemd5(var.cloudflare_origin_cert_*) …` with `cert_hash = var.cloudflare_origin_cert_hash`.

The intent of the trigger is preserved — rotating the secret changes its base64 string → changes the md5 → changes the variable → re-triggers the bind/upload resources.

## Test plan

- [ ] `tf-plan` job is green (no "inconsistent final plan" error in the plan stage).
- [ ] On merge to `main`, the production deploy completes `Terraform Apply` cleanly.
- [ ] `Verify Custom Domain HTTPS` step passes for both `voxquieta.org` and `api.voxquieta.org`.
- [ ] `curl -sI https://api.voxquieta.org/health` returns HTTP/2 200 with a `cf-ray` header (sanity check that the SSL bind is still healthy after the trigger change).
- [ ] Re-running the deploy with no other changes is a no-op (the same secret yields the same hash → no resource changes proposed).
- [ ] Future cert rotation: changing `CLOUDFLARE_ORIGIN_CERT_B64` causes `null_resource.*_ssl_cert_upload` and `null_resource.*_ssl_cert_bind` to be re-created on the next apply.

https://claude.ai/code/session_01YSPojtuAAqAXcxYDtsQPzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSPojtuAAqAXcxYDtsQPzh)_