### PR TITLE
fix(web): wait briefly for Turnstile token before first POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ vox-quieta/
 | `ANTHROPIC_API_KEY` | - | For Claude provider |
 | `OPENROUTER_API_KEY` | - | For OpenRouter provider |
 
+#### Frontend build-time variables
+
+These must be set when the Next.js bundle is built (e.g. `docker build --build-arg ...` or in your CI env). They are inlined into the JS at build time.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | Backend API URL the frontend calls. |
+| `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | _(unset)_ | Cloudflare Turnstile **site** key. When set, the frontend skips the runtime `GET /config` round-trip and starts loading the Turnstile widget on first paint — eliminating the brief window in which a fast first-message click could race past Turnstile and be bounced as `403 TURNSTILE_REQUIRED`. The site key is public by design and visible to every browser that loads the widget; only the matching **secret** key (used by the backend to call Cloudflare's `siteverify`) must stay private. Set to an empty string to explicitly disable Turnstile at build time. Leave unset to fall back to runtime `/config`. |
+
 ### Switching LLM Providers
 
 #### Using Claude

--- a/README.md
+++ b/README.md
@@ -140,12 +140,24 @@ vox-quieta/
 
 #### Frontend build-time variables
 
-These must be set when the Next.js bundle is built (e.g. `docker build --build-arg ...` or in your CI env). They are inlined into the JS at build time.
+These are inlined into the Next.js bundle at build time (e.g.
+`docker build --build-arg ...` or via the CI env).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | Backend API URL the frontend calls. |
-| `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | _(unset)_ | Cloudflare Turnstile **site** key. When set, the frontend skips the runtime `GET /config` round-trip and starts loading the Turnstile widget on first paint — eliminating the brief window in which a fast first-message click could race past Turnstile and be bounced as `403 TURNSTILE_REQUIRED`. The site key is public by design and visible to every browser that loads the widget; only the matching **secret** key (used by the backend to call Cloudflare's `siteverify`) must stay private. Set to an empty string to explicitly disable Turnstile at build time. Leave unset to fall back to runtime `/config`. |
+| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | Backend API URL. |
+| `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | _(unset)_ | Cloudflare Turnstile site key. See note below. |
+
+**About `NEXT_PUBLIC_TURNSTILE_SITE_KEY`:** When set, the frontend skips
+the runtime `GET /config` round-trip and starts loading the Turnstile
+widget on first paint — closing the brief window in which a fast first
+message could race past Turnstile and get bounced with
+`403 TURNSTILE_REQUIRED`. The site key is **public by design** and
+visible to every browser that loads the widget; only the backend
+**secret** key (used to call Cloudflare's `siteverify`) must stay
+private. Set the variable to an empty string to explicitly disable
+Turnstile at build time, or leave it unset to fall back to runtime
+`/config`.
 
 ### Switching LLM Providers
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,6 +31,13 @@ RUN mkdir -p public
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 
+# Optional: Cloudflare Turnstile site key. When set, the frontend skips the
+# runtime /config round-trip and starts loading the Turnstile widget on first
+# paint. The site key is public — only the matching secret key (used by the
+# backend to verify tokens) must stay private.
+ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+ENV NEXT_PUBLIC_TURNSTILE_SITE_KEY=${NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+
 # Build the application
 RUN npm run build
 

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -66,8 +66,31 @@ export default async function LocaleLayout({
   setRequestLocale(locale);
   const messages = await getMessages();
 
+  // When the Turnstile site key is baked into the build, kick off the script
+  // fetch from <head> so it races with the HTML download and the dynamic
+  // <script> injection in TurnstileProvider hits a warm cache.
+  const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const preloadTurnstile = !!turnstileSiteKey;
+
   return (
     <html lang={locale} dir={locale === "ar" ? "rtl" : "ltr"}>
+      <head>
+        {preloadTurnstile && (
+          <>
+            <link
+              rel="preconnect"
+              href="https://challenges.cloudflare.com"
+              crossOrigin="anonymous"
+            />
+            <link
+              rel="preload"
+              as="script"
+              href="https://challenges.cloudflare.com/turnstile/v0/api.js"
+              crossOrigin="anonymous"
+            />
+          </>
+        )}
+      </head>
       <body>
         <NextIntlClientProvider messages={messages}>
           <Providers>

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -136,7 +136,9 @@ describe("Home page responsive layout", () => {
       isReady: true,
       isEnabled: false,
       token: null,
+      configLoaded: true,
       refreshToken: vi.fn(),
+      awaitToken: vi.fn().mockResolvedValue(null),
     });
   });
 
@@ -431,7 +433,9 @@ describe("Home page responsive layout", () => {
         isReady: false,
         isEnabled: true,
         token: null,
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       renderWithIntl(<Home />);
@@ -449,13 +453,44 @@ describe("Home page responsive layout", () => {
       });
     });
 
+    it("disables suggested prompts before /config has resolved", () => {
+      // Initial state: config still loading. Until we know whether Turnstile
+      // is enabled, all gated POSTs would race past it without a token.
+      vi.mocked(turnstile.useTurnstile).mockReturnValue({
+        isReady: false,
+        isEnabled: false,
+        token: null,
+        configLoaded: false,
+        refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
+      });
+
+      renderWithIntl(<Home />);
+
+      const prompts = screen
+        .getAllByRole("button")
+        .filter(
+          (b) => !b.querySelector("svg") && b.className.includes("text-left"),
+        );
+
+      prompts.forEach((prompt) => {
+        expect(prompt).toBeDisabled();
+      });
+
+      expect(
+        screen.getByText("Preparing secure connection..."),
+      ).toBeInTheDocument();
+    });
+
     it("enables suggested prompts when Turnstile is ready", () => {
       // Mock Turnstile as enabled and ready
       vi.mocked(turnstile.useTurnstile).mockReturnValue({
         isReady: true,
         isEnabled: true,
         token: "test-token",
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       renderWithIntl(<Home />);
@@ -479,7 +514,9 @@ describe("Home page responsive layout", () => {
         isReady: false,
         isEnabled: true,
         token: null,
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       const { container } = renderWithIntl(<Home />);
@@ -498,7 +535,9 @@ describe("Home page responsive layout", () => {
         isReady: true,
         isEnabled: true,
         token: "test-token",
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       const { container } = renderWithIntl(<Home />);
@@ -527,7 +566,9 @@ describe("Home page responsive layout", () => {
         isReady: false,
         isEnabled: true,
         token: null,
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       renderWithIntl(<Home />);
@@ -544,7 +585,9 @@ describe("Home page responsive layout", () => {
         isReady: true,
         isEnabled: true,
         token: "test-token",
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       renderWithIntl(<Home />);
@@ -561,7 +604,9 @@ describe("Home page responsive layout", () => {
         isReady: true,
         isEnabled: false,
         token: null,
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       const { container } = renderWithIntl(<Home />);
@@ -603,7 +648,9 @@ describe("Home page responsive layout", () => {
         isReady: false,
         isEnabled: true,
         token: null,
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       vi.mocked(api.streamMessage).mockImplementation(async function* () {
@@ -643,7 +690,9 @@ describe("Home page responsive layout", () => {
         isReady: true,
         isEnabled: true,
         token: "test-token",
+        configLoaded: true,
         refreshToken: vi.fn(),
+        awaitToken: vi.fn().mockResolvedValue(null),
       });
 
       vi.mocked(api.streamMessage).mockImplementation(async function* () {

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -66,8 +66,16 @@ export default function Home() {
   const tChat = useTranslations("Chat");
   const tVerses = useTranslations("Verses");
   const tFeedback = useTranslations("Feedback");
-  const { isReady: turnstileReady, isEnabled: turnstileEnabled } =
-    useTurnstile();
+  const {
+    isReady: turnstileReady,
+    isEnabled: turnstileEnabled,
+    configLoaded: turnstileConfigLoaded,
+  } = useTurnstile();
+  // Block submissions until /config has resolved: until then we don't yet
+  // know whether Turnstile is enabled, and a fast click could fire a POST
+  // without an X-Turnstile-Token header and get bounced as 403.
+  const turnstileBlocked =
+    !turnstileConfigLoaded || (turnstileEnabled && !turnstileReady);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
@@ -697,7 +705,7 @@ export default function Home() {
               </p>
 
               {/* Security check loading indicator */}
-              {turnstileEnabled && !turnstileReady && (
+              {turnstileBlocked && (
                 <div className="flex items-center gap-2 text-sm text-gray-400 mb-4">
                   <Loader2 className="w-4 h-4 animate-spin" />
                   <span>Preparing secure connection...</span>
@@ -710,7 +718,7 @@ export default function Home() {
                   <button
                     key={index}
                     onClick={() => submitMessage(prompt)}
-                    disabled={turnstileEnabled && !turnstileReady}
+                    disabled={turnstileBlocked}
                     className="text-left px-4 py-3 bg-white border border-primary-200 rounded-lg text-sm text-gray-700 hover:border-primary-400 hover:bg-primary-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {prompt}
@@ -795,7 +803,7 @@ export default function Home() {
                 isLoading ||
                 !input.trim() ||
                 showSessionLimitButton ||
-                (turnstileEnabled && !turnstileReady)
+                turnstileBlocked
               }
               className="px-6 py-3 bg-primary-600 text-white rounded-xl hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
             >

--- a/frontend/src/app/[locale]/providers.tsx
+++ b/frontend/src/app/[locale]/providers.tsx
@@ -2,7 +2,11 @@
 
 import { TurnstileProvider } from "@/lib/turnstile";
 import { useEffect, useState } from "react";
-import { setTurnstileToken, setOnTokenConsumed } from "@/lib/api";
+import {
+  setTurnstileToken,
+  setOnTokenConsumed,
+  setTurnstileAwaiter,
+} from "@/lib/api";
 import { useTurnstile } from "@/lib/turnstile";
 import { SplashScreen } from "@/components/SplashScreen";
 
@@ -19,7 +23,7 @@ function setSplashCookie(): void {
 }
 
 function TurnstileTokenSync({ children }: { children: React.ReactNode }) {
-  const { token, refreshToken } = useTurnstile();
+  const { token, refreshToken, awaitToken } = useTurnstile();
 
   // Sync token to API client whenever it changes
   useEffect(() => {
@@ -31,6 +35,13 @@ function TurnstileTokenSync({ children }: { children: React.ReactNode }) {
     setOnTokenConsumed(refreshToken);
     return () => setOnTokenConsumed(null);
   }, [refreshToken]);
+
+  // Register awaiter so POST helpers in api.ts can briefly wait for a token
+  // before firing requests (covers the "first send before /config resolves" race).
+  useEffect(() => {
+    setTurnstileAwaiter(awaitToken);
+    return () => setTurnstileAwaiter(null);
+  }, [awaitToken]);
 
   return <>{children}</>;
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -11,6 +11,7 @@ import {
   warmupBackend,
   setTurnstileToken,
   setOnTokenConsumed,
+  setTurnstileAwaiter,
   submitFeedback,
   ColdStartError,
   type ChatResponse,
@@ -814,5 +815,97 @@ describe("Turnstile token consumption", () => {
     expect(
       (global.fetch as any).mock.calls[0][1].headers["X-Turnstile-Token"],
     ).toBeUndefined();
+  });
+});
+
+describe("Turnstile awaiter (ensureTurnstileToken)", () => {
+  afterEach(() => {
+    setTurnstileToken(null);
+    setOnTokenConsumed(null);
+    setTurnstileAwaiter(null);
+  });
+
+  it("waits for the awaiter when no cached token is set, then attaches header", async () => {
+    const awaiter = vi.fn().mockResolvedValue("late-token");
+    setTurnstileAwaiter(awaiter);
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        message: "ok",
+        provider: "ollama",
+        model: "llama3",
+      }),
+    });
+
+    await sendMessage("Hello");
+
+    expect(awaiter).toHaveBeenCalledTimes(1);
+    expect((global.fetch as any).mock.calls[0][1].headers).toEqual(
+      expect.objectContaining({ "X-Turnstile-Token": "late-token" }),
+    );
+  });
+
+  it("skips the awaiter when a token is already cached", async () => {
+    const awaiter = vi.fn().mockResolvedValue("late-token");
+    setTurnstileAwaiter(awaiter);
+    setTurnstileToken("cached-token");
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        message: "ok",
+        provider: "ollama",
+        model: "llama3",
+      }),
+    });
+
+    await sendMessage("Hello");
+
+    expect(awaiter).not.toHaveBeenCalled();
+    expect((global.fetch as any).mock.calls[0][1].headers).toEqual(
+      expect.objectContaining({ "X-Turnstile-Token": "cached-token" }),
+    );
+  });
+
+  it("falls open when the awaiter resolves with null (Turnstile disabled)", async () => {
+    const awaiter = vi.fn().mockResolvedValue(null);
+    setTurnstileAwaiter(awaiter);
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        message: "ok",
+        provider: "ollama",
+        model: "llama3",
+      }),
+    });
+
+    await sendMessage("Hello");
+
+    expect(awaiter).toHaveBeenCalledTimes(1);
+    const headers = (global.fetch as any).mock.calls[0][1].headers;
+    expect(headers["X-Turnstile-Token"]).toBeUndefined();
+  });
+
+  it("invokes the awaiter on each Turnstile-gated POST", async () => {
+    const awaiter = vi.fn().mockResolvedValue(null);
+    setTurnstileAwaiter(awaiter);
+
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await sendMessage("msg");
+    await searchChurches("Zurich");
+    await submitFeedback({
+      message_id: "test",
+      rating: "positive",
+      user_message: "q",
+      assistant_response: "a",
+    });
+
+    expect(awaiter).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,6 +58,14 @@ export async function checkBackendReady(): Promise<boolean> {
 // Turnstile token for bot protection
 let turnstileToken: string | null = null;
 let onTokenConsumed: (() => void) | null = null;
+type TurnstileAwaiter = (timeoutMs?: number) => Promise<string | null>;
+let turnstileAwaiter: TurnstileAwaiter | null = null;
+
+// Default wait for Turnstile-gated POSTs. Mirrors the Android client (PR #439):
+// before firing a POST we briefly wait for the widget to issue a token so the
+// first send after page load (config still loading) doesn't race past it and
+// get bounced as 403 TURNSTILE_REQUIRED.
+const DEFAULT_TURNSTILE_WAIT_MS = 5000;
 
 /**
  * Set the Turnstile token for API requests
@@ -75,6 +83,15 @@ export function setOnTokenConsumed(callback: (() => void) | null): void {
 }
 
 /**
+ * Register a function that resolves with the current Turnstile token,
+ * waiting briefly if config / widget is still loading. Called before
+ * Turnstile-gated POSTs.
+ */
+export function setTurnstileAwaiter(awaiter: TurnstileAwaiter | null): void {
+  turnstileAwaiter = awaiter;
+}
+
+/**
  * Consume the current token (use it once then trigger refresh).
  * Turnstile tokens are single-use — Cloudflare rejects reused tokens
  * with "timeout-or-duplicate".
@@ -83,6 +100,21 @@ function consumeToken(): void {
   if (turnstileToken) {
     turnstileToken = null;
     onTokenConsumed?.();
+  }
+}
+
+/**
+ * Wait briefly for a Turnstile token to be available before sending a
+ * gated POST. No-op if no awaiter is registered (e.g. server-side or
+ * before the React provider mounts).
+ */
+async function ensureTurnstileToken(
+  timeoutMs: number = DEFAULT_TURNSTILE_WAIT_MS,
+): Promise<void> {
+  if (turnstileToken || !turnstileAwaiter) return;
+  const awaited = await turnstileAwaiter(timeoutMs);
+  if (awaited && !turnstileToken) {
+    turnstileToken = awaited;
   }
 }
 
@@ -297,6 +329,7 @@ export async function sendMessage(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
+    await ensureTurnstileToken();
     const headers = getHeaders();
     consumeToken();
 
@@ -384,6 +417,7 @@ export async function* streamMessage(
   preferredTranslation?: string,
   sessionId?: string,
 ): AsyncGenerator<StreamChunk> {
+  await ensureTurnstileToken();
   const headers = getHeaders();
   consumeToken();
 
@@ -592,6 +626,7 @@ export async function getTranslations(): Promise<TranslationInfo[]> {
 export async function searchChurches(
   location: string,
 ): Promise<ChurchSearchResponse> {
+  await ensureTurnstileToken();
   const headers = getHeaders();
   consumeToken();
 
@@ -614,6 +649,7 @@ export async function searchChurches(
 export async function submitFeedback(
   feedback: FeedbackRequest,
 ): Promise<FeedbackResponse> {
+  await ensureTurnstileToken();
   const headers = getHeaders();
   consumeToken();
 
@@ -636,6 +672,7 @@ export async function submitFeedback(
 export async function submitContactForm(
   contact: ContactRequest,
 ): Promise<ContactResponse> {
+  await ensureTurnstileToken();
   const headers = getHeaders();
   consumeToken();
 

--- a/frontend/src/lib/turnstile.test.tsx
+++ b/frontend/src/lib/turnstile.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { TurnstileProvider, useTurnstile } from "./turnstile";
+
+// jsdom doesn't load <script> tags, so we never actually fetch turnstile.
+// We just need the provider to mount and expose its initial state.
+
+function wrapper(siteKeyOverride?: string) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <TurnstileProvider
+        apiUrl="http://test.example"
+        siteKeyOverride={siteKeyOverride}
+      >
+        {children}
+      </TurnstileProvider>
+    );
+  };
+}
+
+describe("TurnstileProvider build-time site key", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("skips /config when a build-time site key is provided", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useTurnstile(), {
+      wrapper: wrapper("test-site-key"),
+    });
+
+    // Provider should be configured synchronously: configLoaded=true,
+    // isEnabled=true, no /config request.
+    expect(result.current.configLoaded).toBe(true);
+    expect(result.current.isEnabled).toBe(true);
+    expect(result.current.isReady).toBe(false); // widget hasn't issued a token yet
+
+    // Give any spurious effects a tick to run; still no /config call.
+    await waitFor(() => {
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("/config"),
+      );
+    });
+  });
+
+  it("treats an empty-string site key as explicit build-time disable", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+    const { result } = renderHook(() => useTurnstile(), {
+      wrapper: wrapper(""),
+    });
+
+    // Disabled: configLoaded=true, isEnabled=false, isReady=true.
+    expect(result.current.configLoaded).toBe(true);
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.isReady).toBe(true);
+
+    await waitFor(() => {
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("/config"),
+      );
+    });
+  });
+
+  it("falls back to /config fetch when no override is supplied", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        security: { turnstile_enabled: false },
+      }),
+    });
+
+    const { result } = renderHook(() => useTurnstile(), {
+      wrapper: wrapper(undefined),
+    });
+
+    // Initially configLoaded=false (waiting on /config).
+    expect(result.current.configLoaded).toBe(false);
+
+    // After /config resolves, configLoaded becomes true.
+    await waitFor(() => {
+      expect(result.current.configLoaded).toBe(true);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("http://test.example/config");
+  });
+
+  it("awaitToken resolves with null immediately when build-time disabled", async () => {
+    const { result } = renderHook(() => useTurnstile(), {
+      wrapper: wrapper(""),
+    });
+
+    let resolved: string | null | undefined;
+    await act(async () => {
+      resolved = await result.current.awaitToken(50);
+    });
+    expect(resolved).toBeNull();
+  });
+});
+
+describe("TurnstileProvider initial render", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ security: { turnstile_enabled: false } }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the hidden widget container only when Turnstile is enabled", () => {
+    const { container } = render(
+      <TurnstileProvider
+        apiUrl="http://test.example"
+        siteKeyOverride="test-site-key"
+      >
+        <div>app</div>
+      </TurnstileProvider>,
+    );
+    // Hidden container is the only direct fixed-position div in our tree.
+    const hidden = container.querySelector('div[aria-hidden="true"]');
+    expect(hidden).not.toBeNull();
+  });
+
+  it("does not render the widget container when build-time disabled", () => {
+    const { container } = render(
+      <TurnstileProvider apiUrl="http://test.example" siteKeyOverride="">
+        <div>app</div>
+      </TurnstileProvider>,
+    );
+    const hidden = container.querySelector('div[aria-hidden="true"]');
+    expect(hidden).toBeNull();
+  });
+});

--- a/frontend/src/lib/turnstile.test.tsx
+++ b/frontend/src/lib/turnstile.test.tsx
@@ -107,10 +107,13 @@ describe("TurnstileProvider build-time site key", () => {
 
 describe("TurnstileProvider initial render", () => {
   beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ security: { turnstile_enabled: false } }),
-    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ security: { turnstile_enabled: false } }),
+      }),
+    );
   });
 
   afterEach(() => {

--- a/frontend/src/lib/turnstile.tsx
+++ b/frontend/src/lib/turnstile.tsx
@@ -13,14 +13,22 @@ interface TurnstileContextValue {
   token: string | null;
   isReady: boolean;
   isEnabled: boolean;
+  configLoaded: boolean;
   refreshToken: () => void;
+  // Resolves with the current token (or null if Turnstile is disabled / unavailable).
+  // Waits up to timeoutMs for config to load and a token to arrive; on timeout
+  // returns whatever is currently cached (typically null) so the caller can
+  // fail open and let the backend respond.
+  awaitToken: (timeoutMs?: number) => Promise<string | null>;
 }
 
 const TurnstileContext = createContext<TurnstileContextValue>({
   token: null,
   isReady: false,
   isEnabled: false,
+  configLoaded: false,
   refreshToken: () => {},
+  awaitToken: async () => null,
 });
 
 export function useTurnstile() {
@@ -67,11 +75,75 @@ export function TurnstileProvider({
   const [token, setToken] = useState<string | null>(null);
   const [isReady, setIsReady] = useState(false);
   const [isEnabled, setIsEnabled] = useState(false);
+  const [configLoaded, setConfigLoaded] = useState(false);
   const [siteKey, setSiteKey] = useState<string | null>(null);
   const widgetIdRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const retryCountRef = useRef(0);
   const MAX_RETRIES = 3;
+
+  // Refs mirror state so awaitToken (called outside React) can read live values
+  // and notify any pending waiters whenever the relevant state changes.
+  const tokenRef = useRef<string | null>(null);
+  const isEnabledRef = useRef(false);
+  const configLoadedRef = useRef(false);
+  const waitersRef = useRef<Set<() => void>>(new Set());
+
+  const notifyWaiters = useCallback(() => {
+    waitersRef.current.forEach((cb) => cb());
+  }, []);
+
+  useEffect(() => {
+    tokenRef.current = token;
+    notifyWaiters();
+  }, [token, notifyWaiters]);
+  useEffect(() => {
+    isEnabledRef.current = isEnabled;
+    notifyWaiters();
+  }, [isEnabled, notifyWaiters]);
+  useEffect(() => {
+    configLoadedRef.current = configLoaded;
+    notifyWaiters();
+  }, [configLoaded, notifyWaiters]);
+
+  const awaitToken = useCallback(
+    (timeoutMs: number = 5000): Promise<string | null> => {
+      return new Promise((resolve) => {
+        // Returns the token (or null) when we know enough to proceed,
+        // otherwise undefined to keep waiting.
+        const peek = (): string | null | undefined => {
+          if (configLoadedRef.current && !isEnabledRef.current) return null;
+          if (tokenRef.current) return tokenRef.current;
+          return undefined;
+        };
+
+        const immediate = peek();
+        if (immediate !== undefined) {
+          resolve(immediate);
+          return;
+        }
+
+        const onChange = () => {
+          const v = peek();
+          if (v !== undefined) {
+            cleanup();
+            resolve(v);
+          }
+        };
+        const onTimeout = () => {
+          cleanup();
+          resolve(tokenRef.current);
+        };
+        const handle = setTimeout(onTimeout, timeoutMs);
+        const cleanup = () => {
+          clearTimeout(handle);
+          waitersRef.current.delete(onChange);
+        };
+        waitersRef.current.add(onChange);
+      });
+    },
+    [],
+  );
 
   // Fetch config to get Turnstile settings
   useEffect(() => {
@@ -99,6 +171,8 @@ export function TurnstileProvider({
         reportTurnstileError("config_fetch", String(error), apiUrl);
         // Proceed without Turnstile on error
         setIsReady(true);
+      } finally {
+        setConfigLoaded(true);
       }
     };
 
@@ -210,7 +284,14 @@ export function TurnstileProvider({
 
   return (
     <TurnstileContext.Provider
-      value={{ token, isReady, isEnabled, refreshToken }}
+      value={{
+        token,
+        isReady,
+        isEnabled,
+        configLoaded,
+        refreshToken,
+        awaitToken,
+      }}
     >
       {/* Hidden container for the invisible Turnstile widget */}
       {isEnabled && (

--- a/frontend/src/lib/turnstile.tsx
+++ b/frontend/src/lib/turnstile.tsx
@@ -38,6 +38,11 @@ export function useTurnstile() {
 interface TurnstileProviderProps {
   children: React.ReactNode;
   apiUrl?: string;
+  // Build-time site key. When provided (or when NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  // is set at build time), the provider skips the runtime /config round-trip
+  // and starts the Turnstile widget immediately. Pass an empty string to
+  // explicitly disable Turnstile without falling through to /config.
+  siteKeyOverride?: string;
 }
 
 declare global {
@@ -71,12 +76,27 @@ function reportTurnstileError(type: string, detail: string, apiUrl: string) {
 export function TurnstileProvider({
   children,
   apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+  siteKeyOverride,
 }: TurnstileProviderProps) {
+  // Build-time site key takes precedence over the runtime /config fetch.
+  // An empty string is treated as "explicitly disabled at build time" so the
+  // /config round-trip is also skipped.
+  const buildTimeSiteKey =
+    siteKeyOverride ?? process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const hasBuildTimeConfig = buildTimeSiteKey !== undefined;
+  const buildTimeEnabled = !!buildTimeSiteKey;
+
   const [token, setToken] = useState<string | null>(null);
-  const [isReady, setIsReady] = useState(false);
-  const [isEnabled, setIsEnabled] = useState(false);
-  const [configLoaded, setConfigLoaded] = useState(false);
-  const [siteKey, setSiteKey] = useState<string | null>(null);
+  // When Turnstile is disabled at build time, we're already "ready" — no
+  // widget needs to render and no /config response is needed.
+  const [isReady, setIsReady] = useState(
+    hasBuildTimeConfig && !buildTimeEnabled,
+  );
+  const [isEnabled, setIsEnabled] = useState(buildTimeEnabled);
+  const [configLoaded, setConfigLoaded] = useState(hasBuildTimeConfig);
+  const [siteKey, setSiteKey] = useState<string | null>(
+    buildTimeEnabled ? (buildTimeSiteKey as string) : null,
+  );
   const widgetIdRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const retryCountRef = useRef(0);
@@ -145,8 +165,11 @@ export function TurnstileProvider({
     [],
   );
 
-  // Fetch config to get Turnstile settings
+  // Fetch config to get Turnstile settings (skipped when build-time config is set)
   useEffect(() => {
+    if (hasBuildTimeConfig) {
+      return;
+    }
     const fetchConfig = async () => {
       try {
         const response = await fetch(`${apiUrl}/config`);
@@ -177,7 +200,7 @@ export function TurnstileProvider({
     };
 
     fetchConfig();
-  }, [apiUrl]);
+  }, [apiUrl, hasBuildTimeConfig]);
 
   // Define refreshToken first so it can be used in renderWidget
   const refreshToken = useCallback(() => {


### PR DESCRIPTION
## Summary

Mirrors the Android fix in #439 for the web frontend. The very first chat send (and occasionally the first suggested-prompt click) could be bounced by the backend as `403 TURNSTILE_REQUIRED` because the request fired without an `X-Turnstile-Token` header. Two issues combined:

1. **`/config` is async.** During the brief window before it resolves, both `isEnabled` and `isReady` are false, so the existing button-disabled check `turnstileEnabled && !turnstileReady` evaluated to false — leaving the suggested-prompt and send buttons clickable. A fast click would fire a POST without a token.
2. **No wait in the API client.** The API client read whatever `turnstileToken` happened to be in the module-level slot at request time, with no mechanism to wait for the widget to issue one.

## Changes

- **`turnstile.tsx`** — added `configLoaded` flag and `awaitToken(timeoutMs)` to the context. `awaitToken` resolves immediately when Turnstile is disabled, with the current token once `/config` has loaded and a token is available, or falls open after a 5 s timeout.
- **`api.ts`** — added `setTurnstileAwaiter` + `ensureTurnstileToken()`, called before every Turnstile-gated POST (`sendMessage`, `streamMessage`, `searchChurches`, `submitFeedback`, `submitContactForm`).
- **`providers.tsx`** — `TurnstileTokenSync` registers `awaitToken` into the API client.
- **`page.tsx`** — UI guard tightened: buttons + "Preparing secure connection..." spinner now also gate on `!configLoaded`, so a fast click can't beat the config response.

## Test plan

Automated:
- [x] `npm run test:unit` — 462 tests pass, including:
  - 1 new page test: prompts disabled and spinner shown while `configLoaded === false`.
  - 4 new api tests: awaiter is invoked when no cached token, attaches the resolved token; cached token bypasses the wait; null awaiter falls open with no header; each gated POST invokes the awaiter.
- [x] `npm run type-check`
- [x] `npm run lint` — no new warnings (2 pre-existing `apiUrl` deps warnings unchanged)
- [x] `npm run build`

Manual:
- [ ] Cold-load the page on a slow connection, immediately click a suggested prompt → spinner shows briefly, then the request goes through (was occasionally 403 before).
- [ ] Cold-load, type a message and hit Enter as fast as possible → send button is disabled until config + token resolve.
- [ ] Force `TURNSTILE_ENABLED=false` on the backend → buttons enable as soon as `/config` returns; no header is sent; no wait.
- [ ] With Turnstile enabled, send two messages back-to-back → second one waits briefly for the widget to refresh after `consumeToken`, then succeeds.

## Notes

- This is the web counterpart of #439 (which fixed the same race in the Android `OkHttp` interceptor). The mechanism is different — `awaitToken` is exposed via the React Turnstile context and registered into the API client at provider mount — but the behaviour is equivalent: bound the wait to 5 s and fail open so the user gets the existing failure UI rather than a hang.
- Doesn't address the pre-existing race where two concurrent POSTs grab the same single-use token (would need request-level token reservation). Same scope-out as #439.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgvPe29TYWtrqHXHvGG6MG)_