### PR TITLE
fix(web): empty Turnstile build-arg must fall back to /config + wire site key in deploy

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -367,7 +367,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             NEXT_PUBLIC_API_URL=${{ steps.backend-url.outputs.url }}
-            NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+            NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ vars.TF_VAR_TURNSTILE_SITE_KEY }}
 
       - name: Verify API URL in image
         if: github.event_name != 'pull_request'

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -367,6 +367,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             NEXT_PUBLIC_API_URL=${{ steps.backend-url.outputs.url }}
+            NEXT_PUBLIC_TURNSTILE_SITE_KEY=${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
 
       - name: Verify API URL in image
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -148,16 +148,17 @@ These are inlined into the Next.js bundle at build time (e.g.
 | `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | Backend API URL. |
 | `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | _(unset)_ | Cloudflare Turnstile site key. See note below. |
 
-**About `NEXT_PUBLIC_TURNSTILE_SITE_KEY`:** When set, the frontend skips
-the runtime `GET /config` round-trip and starts loading the Turnstile
-widget on first paint — closing the brief window in which a fast first
-message could race past Turnstile and get bounced with
-`403 TURNSTILE_REQUIRED`. The site key is **public by design** and
+**About `NEXT_PUBLIC_TURNSTILE_SITE_KEY`:** When set to a real site key,
+the frontend skips the runtime `GET /config` round-trip and starts
+loading the Turnstile widget on first paint — closing the brief window
+in which a fast first message could race past Turnstile and get bounced
+with `403 TURNSTILE_REQUIRED`. The site key is **public by design** and
 visible to every browser that loads the widget; only the backend
 **secret** key (used to call Cloudflare's `siteverify`) must stay
-private. Set the variable to an empty string to explicitly disable
-Turnstile at build time, or leave it unset to fall back to runtime
-`/config`.
+private. Leave the variable unset (or empty) to fall back to the
+runtime `/config` path. To disable Turnstile entirely, set
+`TURNSTILE_ENABLED=false` on the backend — `/config` will then report
+that to the frontend, which will not gate any requests.
 
 ### Switching LLM Providers
 

--- a/frontend/src/lib/turnstile.test.tsx
+++ b/frontend/src/lib/turnstile.test.tsx
@@ -49,23 +49,32 @@ describe("TurnstileProvider build-time site key", () => {
     });
   });
 
-  it("treats an empty-string site key as explicit build-time disable", async () => {
+  it("falls back to /config when the site key is an empty string", async () => {
+    // Regression guard: an empty `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (which is
+    // what an unconfigured `ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY=` Dockerfile
+    // produces) must NOT be treated as "Turnstile disabled" — that would
+    // suppress the widget while the backend still requires a token. Empty
+    // and unset both fall through to the runtime /config fetch.
     const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        security: { turnstile_enabled: false },
+      }),
+    });
 
     const { result } = renderHook(() => useTurnstile(), {
       wrapper: wrapper(""),
     });
 
-    // Disabled: configLoaded=true, isEnabled=false, isReady=true.
-    expect(result.current.configLoaded).toBe(true);
+    // Empty key → behaves identically to "unset": waits on /config.
+    expect(result.current.configLoaded).toBe(false);
     expect(result.current.isEnabled).toBe(false);
-    expect(result.current.isReady).toBe(true);
 
     await waitFor(() => {
-      expect(fetchMock).not.toHaveBeenCalledWith(
-        expect.stringContaining("/config"),
-      );
+      expect(result.current.configLoaded).toBe(true);
     });
+    expect(fetchMock).toHaveBeenCalledWith("http://test.example/config");
   });
 
   it("falls back to /config fetch when no override is supplied", async () => {
@@ -92,9 +101,22 @@ describe("TurnstileProvider build-time site key", () => {
     expect(fetchMock).toHaveBeenCalledWith("http://test.example/config");
   });
 
-  it("awaitToken resolves with null immediately when build-time disabled", async () => {
+  it("awaitToken resolves with null when /config reports Turnstile disabled", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ security: { turnstile_enabled: false } }),
+      }),
+    );
+
     const { result } = renderHook(() => useTurnstile(), {
-      wrapper: wrapper(""),
+      wrapper: wrapper(undefined),
+    });
+
+    // Wait for /config to resolve.
+    await waitFor(() => {
+      expect(result.current.configLoaded).toBe(true);
     });
 
     let resolved: string | null | undefined;
@@ -134,13 +156,30 @@ describe("TurnstileProvider initial render", () => {
     expect(hidden).not.toBeNull();
   });
 
-  it("does not render the widget container when build-time disabled", () => {
-    const { container } = render(
+  it("does not render the widget container when /config disables Turnstile", async () => {
+    const { container, findByText } = render(
+      <TurnstileProvider apiUrl="http://test.example">
+        <div>app</div>
+      </TurnstileProvider>,
+    );
+    // Wait for /config to resolve so isEnabled is settled.
+    await findByText("app");
+    await waitFor(() => {
+      expect(container.querySelector('div[aria-hidden="true"]')).toBeNull();
+    });
+  });
+
+  it("does not render the widget container when the site key is empty", async () => {
+    // Regression: empty key must not silently disable the widget — it must
+    // fall back to /config, which in this test reports turnstile_enabled=false.
+    const { container, findByText } = render(
       <TurnstileProvider apiUrl="http://test.example" siteKeyOverride="">
         <div>app</div>
       </TurnstileProvider>,
     );
-    const hidden = container.querySelector('div[aria-hidden="true"]');
-    expect(hidden).toBeNull();
+    await findByText("app");
+    await waitFor(() => {
+      expect(container.querySelector('div[aria-hidden="true"]')).toBeNull();
+    });
   });
 });

--- a/frontend/src/lib/turnstile.tsx
+++ b/frontend/src/lib/turnstile.tsx
@@ -79,24 +79,24 @@ export function TurnstileProvider({
   siteKeyOverride,
 }: TurnstileProviderProps) {
   // Build-time site key takes precedence over the runtime /config fetch.
-  // An empty string is treated as "explicitly disabled at build time" so the
-  // /config round-trip is also skipped.
-  const buildTimeSiteKey =
+  // Only a *non-empty* value enables the fast path — an empty string (which
+  // is what an unconfigured `ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY=` in the
+  // Dockerfile produces) falls back to /config, same as if the var were
+  // unset. To disable Turnstile entirely, configure the backend to return
+  // `turnstile_enabled: false` from /config; the frontend will pick that up.
+  const rawBuildTimeSiteKey =
     siteKeyOverride ?? process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-  const hasBuildTimeConfig = buildTimeSiteKey !== undefined;
-  const buildTimeEnabled = !!buildTimeSiteKey;
+  const buildTimeSiteKey =
+    typeof rawBuildTimeSiteKey === "string" && rawBuildTimeSiteKey.length > 0
+      ? rawBuildTimeSiteKey
+      : null;
+  const hasBuildTimeKey = buildTimeSiteKey !== null;
 
   const [token, setToken] = useState<string | null>(null);
-  // When Turnstile is disabled at build time, we're already "ready" — no
-  // widget needs to render and no /config response is needed.
-  const [isReady, setIsReady] = useState(
-    hasBuildTimeConfig && !buildTimeEnabled,
-  );
-  const [isEnabled, setIsEnabled] = useState(buildTimeEnabled);
-  const [configLoaded, setConfigLoaded] = useState(hasBuildTimeConfig);
-  const [siteKey, setSiteKey] = useState<string | null>(
-    buildTimeEnabled ? (buildTimeSiteKey as string) : null,
-  );
+  const [isReady, setIsReady] = useState(false);
+  const [isEnabled, setIsEnabled] = useState(hasBuildTimeKey);
+  const [configLoaded, setConfigLoaded] = useState(hasBuildTimeKey);
+  const [siteKey, setSiteKey] = useState<string | null>(buildTimeSiteKey);
   const widgetIdRef = useRef<string | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const retryCountRef = useRef(0);
@@ -167,7 +167,7 @@ export function TurnstileProvider({
 
   // Fetch config to get Turnstile settings (skipped when build-time config is set)
   useEffect(() => {
-    if (hasBuildTimeConfig) {
+    if (hasBuildTimeKey) {
       return;
     }
     const fetchConfig = async () => {
@@ -200,7 +200,7 @@ export function TurnstileProvider({
     };
 
     fetchConfig();
-  }, [apiUrl, hasBuildTimeConfig]);
+  }, [apiUrl, hasBuildTimeKey]);
 
   // Define refreshToken first so it can be used in renderWidget
   const refreshToken = useCallback(() => {


### PR DESCRIPTION
## Summary

Hotfix: PR #449 broke production. After the merge, every chat send was bounced as `403 TURNSTILE_REQUIRED` and the backend logged repeated "Missing Turnstile token" warnings.

### Root cause

1. The Dockerfile added in #449 defaults `ARG NEXT_PUBLIC_TURNSTILE_SITE_KEY=` to an empty string.
2. `azure-deploy.yml` only forwarded `NEXT_PUBLIC_API_URL` as a build-arg, **not** the Turnstile key.
3. Every production build therefore shipped with `NEXT_PUBLIC_TURNSTILE_SITE_KEY=""`.
4. The frontend logic in #449 treated an empty value as **"Turnstile explicitly disabled at build time"** → no widget rendered, no token issued.
5. Backend still had `TURNSTILE_ENABLED=true` → 100% 403s.

### Fix (commit 1)

`turnstile.tsx` now treats only a **non-empty** site key as build-time enabled. Empty and unset both fall through to the runtime `/config` path, which is safe (the original behaviour before #449).

The "empty = disable" feature is removed — it was strictly more dangerous than useful, since silently disabling the widget while the backend still gates requests is the worst possible failure mode. To disable Turnstile entirely, set `TURNSTILE_ENABLED=false` on the backend; the frontend will pick that up via `/config`.

### Optimisation (commit 2)

`azure-deploy.yml` now forwards `vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY` as a build-arg, activating the build-time fast path that was the original intent of #449. With this in place, deployed builds skip the `/config` round-trip and start loading the Turnstile widget on first paint.

If the GitHub Actions variable is unset or empty, the build still succeeds — the frontend just falls back to runtime `/config` (the safe path restored in commit 1).

## Test plan

Automated:
- [x] `npm run test:unit` — 469 tests pass (was 468 + 1 regression-guard test asserting empty key falls back to `/config`)
- [x] `npm run type-check`
- [x] `pre-commit run` (markdownlint, prettier, yamllint, eslint, etc.)

After merge:
- [ ] Confirm the next deploy bakes the site key into `NEXT_PUBLIC_TURNSTILE_SITE_KEY` (the workflow logs `✅ Building frontend with NEXT_PUBLIC_API_URL=...` — check that the same image build now also has the Turnstile key).
- [ ] Hard-refresh the deployed frontend; first message should go through immediately (no spinner / no 403).
- [ ] Backend `utils.turnstile` warnings should drop back to zero for organic traffic.

## Notes

- The GitHub Actions variable is read as `vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY`. Make sure it's set under **Variables** (not Secrets) in repo settings — the site key is public by design.
- The existing `vars.TF_VAR_TURNSTILE_SITE_KEY` (used by Terraform for the backend) is a separate variable; both should hold the same site-key value.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgvPe29TYWtrqHXHvGG6MG)_