### PR TITLE
fix(android): remove dead 192.168.0.0 cleartext exception

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext (HTTP) only for local development (emulator + LAN IPs) -->
+    <!-- Allow cleartext (HTTP) only for local development (emulator host aliases) -->
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="false">10.0.2.2</domain>   <!-- emulator → host -->
         <domain includeSubdomains="false">10.0.3.2</domain>   <!-- Genymotion → host -->
         <domain includeSubdomains="false">localhost</domain>
-        <domain includeSubdomains="false">192.168.0.0</domain>
     </domain-config>
     <!-- All other traffic must use HTTPS -->
     <base-config cleartextTrafficPermitted="false">


### PR DESCRIPTION
The `192.168.0.0` entry in `network_security_config.xml` matched a single literal IP, not the LAN subnet (the `<domain>` element has no CIDR support). It was effectively dead. Removed. Cleartext still allowed for `10.0.2.2`, `10.0.3.2`, and `localhost`.