### PR TITLE
fix(android): inline field validation for contact and church-finder forms

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChurchFinderBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChurchFinderBottomSheet.kt
@@ -69,6 +69,7 @@ fun ChurchFinderBottomSheet(
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
 ) {
     var locationInput by rememberSaveable { mutableStateOf("") }
+    var locationTouched by rememberSaveable { mutableStateOf(false) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -108,11 +109,22 @@ fun ChurchFinderBottomSheet(
             }
 
             // ── Location input ───────────────────────────────────────────────
+            val locationError = locationTouched && locationInput.isBlank()
             OutlinedTextField(
                 value = locationInput,
-                onValueChange = { locationInput = it },
+                onValueChange = {
+                    locationInput = it
+                    locationTouched = true
+                },
                 label = { Text(stringResource(R.string.church_finder_search_placeholder)) },
-                supportingText = { Text(stringResource(R.string.church_finder_location_hint)) },
+                supportingText = {
+                    if (locationError) {
+                        Text(stringResource(R.string.church_finder_location_required))
+                    } else {
+                        Text(stringResource(R.string.church_finder_location_hint))
+                    }
+                },
+                isError = locationError,
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(
@@ -120,13 +132,19 @@ fun ChurchFinderBottomSheet(
                     imeAction = ImeAction.Search,
                 ),
                 keyboardActions = KeyboardActions(
-                    onSearch = { if (locationInput.isNotBlank()) onSearch(locationInput) },
+                    onSearch = {
+                        locationTouched = true
+                        if (locationInput.isNotBlank()) onSearch(locationInput)
+                    },
                 ),
             )
 
             // ── Search button ─────────────────────────────────────────────────
             Button(
-                onClick = { if (locationInput.isNotBlank()) onSearch(locationInput) },
+                onClick = {
+                    locationTouched = true
+                    if (locationInput.isNotBlank()) onSearch(locationInput)
+                },
                 modifier = Modifier.fillMaxWidth(),
                 enabled = locationInput.isNotBlank() && churchFinderState !is ChurchFinderSheetState.Loading,
             ) {

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt
@@ -78,6 +78,7 @@ fun ContactFormBottomSheet(
     var subjectDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var emailInput by rememberSaveable { mutableStateOf("") }
     var messageInput by rememberSaveable { mutableStateOf("") }
+    var messageTouched by rememberSaveable { mutableStateOf(false) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -190,15 +191,23 @@ fun ContactFormBottomSheet(
             )
 
             // ── Message input ─────────────────────────────────────────────────
+            val messageError = messageTouched && messageInput.isBlank()
             OutlinedTextField(
                 value = messageInput,
-                onValueChange = { messageInput = it },
+                onValueChange = {
+                    messageInput = it
+                    messageTouched = true
+                },
                 label = { Text(stringResource(R.string.contact_message_label)) },
                 placeholder = { Text(stringResource(R.string.contact_message_placeholder)) },
                 minLines = 4,
                 maxLines = 8,
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default),
+                isError = messageError,
+                supportingText = if (messageError) {
+                    { Text(stringResource(R.string.contact_message_required)) }
+                } else null,
             )
 
             // ── Privacy note ──────────────────────────────────────────────────
@@ -220,6 +229,7 @@ fun ContactFormBottomSheet(
             // ── Send button ───────────────────────────────────────────────────
             Button(
                 onClick = {
+                    messageTouched = true
                     if (messageInput.isNotBlank()) {
                         onSubmit(
                             selectedSubject.value,

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">مدينة بالإنجليزية (مثل: Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">بحث</string>
     <string name="church_finder_location_hint">استخدم أسماء المدن بالإنجليزية</string>
+    <string name="church_finder_location_required">الرجاء إدخال مدينة أو موقع</string>
     <string name="church_finder_enter_location">أدخل موقعاً للبحث</string>
     <plurals name="church_finder_found_count">
         <item quantity="zero">لم يتم العثور على أي كنيسة</item>
@@ -202,6 +203,7 @@
     <string name="contact_email_placeholder">you@example.com</string>
     <string name="contact_message_label">الرسالة</string>
     <string name="contact_message_placeholder">شارك أفكارك أو أبلغ عن مشكلة أو اقترح تحسيناً…</string>
+    <string name="contact_message_required">الرجاء إدخال رسالة</string>
     <string name="contact_privacy_note">ستُخزَّن رسالتك لمساعدتنا في تحسين الخدمة.</string>
     <string name="contact_send_button">إرسال الرسالة</string>
     <string name="contact_success_title">تم إرسال الرسالة بنجاح!</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">Stadt auf Englisch (z. B. Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">Suchen</string>
     <string name="church_finder_location_hint">Bitte englische Städtenamen verwenden</string>
+    <string name="church_finder_location_required">Bitte eine Stadt oder einen Ort eingeben</string>
     <string name="church_finder_enter_location">Ort für die Suche eingeben</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">%d Kirche gefunden</item>
@@ -198,6 +199,7 @@
     <string name="contact_email_placeholder">du@beispiel.de</string>
     <string name="contact_message_label">Nachricht</string>
     <string name="contact_message_placeholder">Teile deine Gedanken, melde ein Problem oder schlage eine Verbesserung vor…</string>
+    <string name="contact_message_required">Bitte eine Nachricht eingeben</string>
     <string name="contact_privacy_note">Deine Nachricht wird gespeichert, um uns bei der Verbesserung des Dienstes zu helfen.</string>
     <string name="contact_send_button">Nachricht senden</string>
     <string name="contact_success_title">Nachricht erfolgreich gesendet!</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">Ciudad en inglés (p. ej., Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">Buscar</string>
     <string name="church_finder_location_hint">Usa nombres de ciudades en inglés</string>
+    <string name="church_finder_location_required">Por favor ingresa una ciudad o ubicación</string>
     <string name="church_finder_enter_location">Ingresa una ubicación para buscar</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">Se encontró %d iglesia</item>
@@ -199,6 +200,7 @@
     <string name="contact_email_placeholder">tu@ejemplo.com</string>
     <string name="contact_message_label">Mensaje</string>
     <string name="contact_message_placeholder">Comparte tus pensamientos, informa un problema o sugiere una mejora…</string>
+    <string name="contact_message_required">Por favor ingresa un mensaje</string>
     <string name="contact_privacy_note">Tu mensaje se almacenará para ayudarnos a mejorar el servicio.</string>
     <string name="contact_send_button">Enviar mensaje</string>
     <string name="contact_success_title">¡Mensaje enviado con éxito!</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">Ville en anglais (ex. Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">Rechercher</string>
     <string name="church_finder_location_hint">Utilisez les noms de villes en anglais</string>
+    <string name="church_finder_location_required">Veuillez entrer une ville ou un lieu</string>
     <string name="church_finder_enter_location">Entrez un lieu pour rechercher</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">%d église trouvée</item>
@@ -199,6 +200,7 @@
     <string name="contact_email_placeholder">vous@exemple.fr</string>
     <string name="contact_message_label">Message</string>
     <string name="contact_message_placeholder">Partagez vos pensées, signalez un problème ou suggérez une amélioration…</string>
+    <string name="contact_message_required">Veuillez entrer un message</string>
     <string name="contact_privacy_note">Votre message sera enregistré pour nous aider à améliorer le service.</string>
     <string name="contact_send_button">Envoyer le message</string>
     <string name="contact_success_title">Message envoyé avec succès !</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">शहर का अंग्रेजी नाम (जैसे Delhi, Mumbai)</string>
     <string name="church_finder_search_button">खोजें</string>
     <string name="church_finder_location_hint">शहरों के अंग्रेजी नामों का उपयोग करें</string>
+    <string name="church_finder_location_required">कृपया एक शहर या स्थान दर्ज करें</string>
     <string name="church_finder_enter_location">खोजने के लिए स्थान दर्ज करें</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">%d चर्च मिला</item>
@@ -198,6 +199,7 @@
     <string name="contact_email_placeholder">aap@udaharan.com</string>
     <string name="contact_message_label">संदेश</string>
     <string name="contact_message_placeholder">अपने विचार साझा करें, कोई समस्या रिपोर्ट करें या सुधार सुझाएं…</string>
+    <string name="contact_message_required">कृपया एक संदेश दर्ज करें</string>
     <string name="contact_privacy_note">आपका संदेश सेवा सुधार के लिए संग्रहीत किया जाएगा।</string>
     <string name="contact_send_button">संदेश भेजें</string>
     <string name="contact_success_title">संदेश सफलतापूर्वक भेजा गया!</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">Città in inglese (es. Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">Cerca</string>
     <string name="church_finder_location_hint">Usa i nomi delle città in inglese</string>
+    <string name="church_finder_location_required">Inserisci una città o una posizione</string>
     <string name="church_finder_enter_location">Inserisci una posizione per cercare</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">%d chiesa trovata</item>
@@ -199,6 +200,7 @@
     <string name="contact_email_placeholder">tu@esempio.it</string>
     <string name="contact_message_label">Messaggio</string>
     <string name="contact_message_placeholder">Condividi i tuoi pensieri, segnala un problema o suggerisci un miglioramento…</string>
+    <string name="contact_message_required">Inserisci un messaggio</string>
     <string name="contact_privacy_note">Il tuo messaggio verrà archiviato per aiutarci a migliorare il servizio.</string>
     <string name="contact_send_button">Invia messaggio</string>
     <string name="contact_success_title">Messaggio inviato con successo!</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">영문 도시명 (예: Seoul, Busan)</string>
     <string name="church_finder_search_button">검색</string>
     <string name="church_finder_location_hint">영문 도시명을 사용하세요</string>
+    <string name="church_finder_location_required">도시나 위치를 입력해 주세요</string>
     <string name="church_finder_enter_location">검색할 위치를 입력하세요</string>
     <plurals name="church_finder_found_count">
         <item quantity="other">교회 %d개 발견</item>
@@ -197,6 +198,7 @@
     <string name="contact_email_placeholder">you@example.com</string>
     <string name="contact_message_label">메시지</string>
     <string name="contact_message_placeholder">생각을 나눠주시거나, 문제를 신고하거나, 개선 사항을 제안해 주세요…</string>
+    <string name="contact_message_required">메시지를 입력해 주세요</string>
     <string name="contact_privacy_note">귀하의 메시지는 서비스 개선을 위해 저장됩니다.</string>
     <string name="contact_send_button">메시지 보내기</string>
     <string name="contact_success_title">메시지가 성공적으로 전송되었습니다!</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">Cidade em inglês (ex. Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">Pesquisar</string>
     <string name="church_finder_location_hint">Use nomes de cidades em inglês</string>
+    <string name="church_finder_location_required">Por favor, insira uma cidade ou localização</string>
     <string name="church_finder_enter_location">Insira um local para pesquisar</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">%d igreja encontrada</item>
@@ -199,6 +200,7 @@
     <string name="contact_email_placeholder">voce@exemplo.com</string>
     <string name="contact_message_label">Mensagem</string>
     <string name="contact_message_placeholder">Compartilhe seus pensamentos, relate um problema ou sugira uma melhoria…</string>
+    <string name="contact_message_required">Por favor, insira uma mensagem</string>
     <string name="contact_privacy_note">Sua mensagem será armazenada para nos ajudar a melhorar o serviço.</string>
     <string name="contact_send_button">Enviar mensagem</string>
     <string name="contact_success_title">Mensagem enviada com sucesso!</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">Город на английском (напр. Moscow, Rome, Paris)</string>
     <string name="church_finder_search_button">Искать</string>
     <string name="church_finder_location_hint">Используйте названия городов на английском</string>
+    <string name="church_finder_location_required">Пожалуйста, введите город или местоположение</string>
     <string name="church_finder_enter_location">Введите местоположение для поиска</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">Найдена %d церковь</item>
@@ -200,6 +201,7 @@
     <string name="contact_email_placeholder">вы@пример.ру</string>
     <string name="contact_message_label">Сообщение</string>
     <string name="contact_message_placeholder">Поделитесь мыслями, сообщите о проблеме или предложите улучшение…</string>
+    <string name="contact_message_required">Пожалуйста, введите сообщение</string>
     <string name="contact_privacy_note">Ваше сообщение будет сохранено для улучшения сервиса.</string>
     <string name="contact_send_button">Отправить сообщение</string>
     <string name="contact_success_title">Сообщение успешно отправлено!</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -173,6 +173,7 @@
     <string name="church_finder_search_placeholder">城市（英文名，如 Beijing, Shanghai）</string>
     <string name="church_finder_search_button">搜索</string>
     <string name="church_finder_location_hint">请使用城市的英文名称</string>
+    <string name="church_finder_location_required">请输入城市或位置</string>
     <string name="church_finder_enter_location">输入位置以搜索</string>
     <plurals name="church_finder_found_count">
         <item quantity="other">找到 %d 个教会</item>
@@ -197,6 +198,7 @@
     <string name="contact_email_placeholder">you@example.com</string>
     <string name="contact_message_label">消息</string>
     <string name="contact_message_placeholder">分享您的想法、报告问题或建议改进…</string>
+    <string name="contact_message_required">请输入消息</string>
     <string name="contact_privacy_note">您的消息将被存储以帮助我们改进服务。</string>
     <string name="contact_send_button">发送消息</string>
     <string name="contact_success_title">消息发送成功！</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="church_finder_search_placeholder">City in English (e.g., Rome, Munich, Zurich)</string>
     <string name="church_finder_search_button">Search</string>
     <string name="church_finder_location_hint">Use English city names (e.g., Rome, Munich, Vienna)</string>
+    <string name="church_finder_location_required">Please enter a city or location</string>
     <string name="church_finder_enter_location">Enter a location to search</string>
     <plurals name="church_finder_found_count">
         <item quantity="one">Found %d church</item>
@@ -208,6 +209,7 @@
     <string name="contact_email_placeholder">you@example.com</string>
     <string name="contact_message_label">Message</string>
     <string name="contact_message_placeholder">Share your thoughts, report an issue, or suggest an improvement…</string>
+    <string name="contact_message_required">Please enter a message</string>
     <string name="contact_privacy_note">Your message will be stored to help us improve the service.</string>
     <string name="contact_send_button">Send Message</string>
     <string name="contact_success_title">Message sent successfully!</string>


### PR DESCRIPTION
Adds touched-state tracking and inline error feedback to both forms. The message field (ContactForm) and location field (ChurchFinder) now show an inline `supportingText` error with `isError` outline styling when the user has interacted with the field but left it blank. Tapping the submit/search button while blank also triggers the error. Submit buttons remain disabled until required fields are filled.