### PR TITLE
fix(android): raise splash duration to 700 ms and dismiss early when backend responds

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -5,9 +5,11 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.os.Bundle
+import android.os.SystemClock
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -50,12 +52,28 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var analyticsHelper: AnalyticsHelper
 
+    // Accessed before setContent{} to drive setKeepOnScreenCondition.
+    // hiltViewModel() inside setContent{} returns the same Activity-scoped instance.
+    private val viewModel: ChatViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
-        // Install the AndroidX Splash Screen before super.onCreate() so the
-        // splash window is shown immediately from the very first frame.
-        installSplashScreen()
+        // Capture the splash screen handle before super.onCreate() as required by the API.
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        // Keep the system splash on screen until the backend has responded (translations
+        // loaded) OR the device is offline, but cap at 700 ms so fast devices get a
+        // deliberate beat rather than an instant flash.  The 700 ms windowSplashScreen-
+        // AnimationDuration in themes.xml is the minimum; this condition can dismiss
+        // earlier once the backend is ready.
+        val splashStartMs = SystemClock.elapsedRealtime()
+        splashScreen.setKeepOnScreenCondition {
+            val elapsed = SystemClock.elapsedRealtime() - splashStartMs
+            val backendReady = viewModel.availableTranslations.value.isNotEmpty()
+                    || viewModel.uiState.value.isOffline
+            elapsed < 700L && !backendReady
+        }
 
         // Log the app_open event on every cold start.
         analyticsHelper.logEvent(AnalyticsHelper.EVENT_APP_OPEN)

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -8,7 +8,7 @@
     <style name="Theme.VoxQuieta.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">#5B3427</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_icon</item>
-        <item name="windowSplashScreenAnimationDuration">300</item>
+        <item name="windowSplashScreenAnimationDuration">700</item>
         <item name="windowSplashScreenIconBackgroundColor">#5B3427</item>
         <item name="postSplashScreenTheme">@style/Theme.VoxQuieta</item>
     </style>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -20,8 +20,10 @@
         <!-- Animated / static icon shown in the centre of the screen -->
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash_icon</item>
 
-        <!-- Duration to show the splash (milliseconds) — 0 means "show until ready" -->
-        <item name="windowSplashScreenAnimationDuration">300</item>
+        <!-- Duration hint for the splash animation (ms). setKeepOnScreenCondition in
+             MainActivity may dismiss earlier if the backend responds fast, or hold longer
+             on a cold start. 700 ms gives a deliberate, perceptible beat at typical speed. -->
+        <item name="windowSplashScreenAnimationDuration">700</item>
 
         <!--
           Brand icon background colour (API 31+).  Setting it to the same warm brown as


### PR DESCRIPTION
The 300 ms splash was shorter than the Compose+Hilt cold-start frame time, making it effectively a flash rather than a deliberate beat.

**Changes:**
- `themes.xml` + `themes-night/themes.xml`: `windowSplashScreenAnimationDuration` 300 → 700 ms
- `MainActivity`: capture `installSplashScreen()` and call `setKeepOnScreenCondition` — splash dismisses as soon as the backend responds (translations loaded) or the device is offline, capped at 700 ms otherwise

The `by viewModels()` Activity property and `hiltViewModel()` inside `setContent{}` both resolve to the same Activity-scoped ViewModel.