### PR TITLE
fix(android): lint hardening, plurals i18n, schema export + docs worktree pattern

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -93,6 +93,16 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {},
+  "results": {
+    "android/app/schemas/org.voxquieta.app.data.local.VoxQuietaDatabase/1.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "android/app/schemas/org.voxquieta.app.data.local.VoxQuietaDatabase/1.json",
+        "hashed_secret": "b10b7cbc137949bf932605838d3a829dc5564740",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ]
+  },
   "generated_at": "2026-01-18T00:00:00Z"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,36 @@ Deploys to Azure on push to `main`.
   - `docs: add BITB-025 backlog item`
 - **Branch naming:** `feature/description`, `fix/description`, or `claude/description`
 
+### Git Worktree Pattern
+
+When making code changes (especially for Android or any task that should not
+disturb the main working directory), always use `git worktree` under `/tmp/`:
+
+```bash
+# Create a new worktree from the latest remote main
+git fetch origin
+git worktree add /tmp/<short-name> -b <branch-name> origin/main
+
+# Or check out an existing branch
+git worktree add /tmp/<short-name> origin/<branch-name>
+
+# Work inside the worktree
+cd /tmp/<short-name>
+# … make changes, commit, push …
+
+# Clean up when done
+git worktree remove /tmp/<short-name>
+```
+
+**Why `/tmp/`?** The main working directory
+(`/home/asurace/github/getinspiredbythebible`) is shared and should not be
+modified directly by automated agents. `/tmp/` is writable by GitHub Copilot
+CLI and other agents without permission issues, and is cleaned up automatically
+on reboot.
+
+**Always clean up** worktrees with `git worktree remove` after pushing, to
+avoid stale entries accumulating in `.git/worktrees/`.
+
 ### Branch & PR Hygiene
 
 **Never push to a branch that has a closed or merged PR.** If the PR for

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -108,7 +108,7 @@ android {
         //   3. Set abortOnError = true here
         // Note: AGP 8.4.2 does not honour -Dlint.baselines.continue=true for ERROR-severity
         // issues in the same run; run the task twice if needed.
-        abortOnError = false
+        abortOnError = true
         warningsAsErrors = false   // Warnings (e.g. from compose-markdown) do not elevate to errors
         // Suppress rules that fire on generated/third-party code even with checkDependencies=false
         disable += setOf(

--- a/android/app/schemas/org.voxquieta.app.data.local.VoxQuietaDatabase/1.json
+++ b/android/app/schemas/org.voxquieta.app.data.local.VoxQuietaDatabase/1.json
@@ -1,0 +1,124 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "53a29ee7129be40885cb5731ecab3655",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationId` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `versesJson` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`conversationId`) REFERENCES `conversations`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versesJson",
+            "columnName": "versesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationId",
+            "unique": false,
+            "columnNames": [
+              "conversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationId` ON `${TABLE_NAME}` (`conversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '53a29ee7129be40885cb5731ecab3655')"
+    ]
+  }
+}

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -27,15 +27,20 @@
     <application>
 
         <!-- Disable Firebase core auto-init. -->
+        <!-- tools:ignore="MissingClass": class lives in the firebase-common library which is
+             not resolved during debug lint; the entry is only a manifest-merger removal
+             directive (tools:node="remove") so the class never needs to be present. -->
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"
             android:authorities="${applicationId}.firebaseinitprovider"
+            tools:ignore="MissingClass"
             tools:node="remove" />
 
         <!-- Disable Crashlytics auto-init. -->
         <provider
             android:name="com.google.firebase.crashlytics.internal.CrashlyticsInitProvider"
             android:authorities="${applicationId}.crashlyticsinitprovider"
+            tools:ignore="MissingClass"
             tools:node="remove" />
 
         <!-- Disable Google Analytics measurement provider (transitive via firebase-analytics-ktx
@@ -45,6 +50,7 @@
         <provider
             android:name="com.google.android.gms.measurement.AppMeasurementContentProvider"
             android:authorities="${applicationId}.google_measurement_service_provider"
+            tools:ignore="MissingClass"
             tools:node="remove" />
 
         <!-- Disable Firebase data-transport SQLite backend initializer (transitive via
@@ -52,6 +58,7 @@
         <provider
             android:name="com.google.android.datatransport.runtime.TransportRuntimeInitializer"
             android:authorities="${applicationId}.transportruntimeinitializer"
+            tools:ignore="MissingClass"
             tools:node="remove" />
 
     </application>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -7,6 +8,8 @@
     <application
         android:name=".VoxQuietaApp"
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        tools:ignore="DataExtractionRules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.voxquieta.app
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.Configuration
@@ -9,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -89,6 +91,7 @@ class MainActivity : ComponentActivity() {
             //   LocalizedActivityContext → Activity → ...
             // This keeps hiltViewModel() working in every NavHost destination.
             val activity = LocalContext.current
+            @SuppressLint("AppBundleLocaleChanges")
             val localizedConfiguration = remember(languageCode) {
                 val locale = Locale(languageCode)
                 Configuration(activity.resources.configuration).also { cfg ->
@@ -113,22 +116,18 @@ class MainActivity : ComponentActivity() {
                     val navController = rememberNavController()
 
                     // Track screen views every time the user navigates to a new destination.
-                    remember(navController) {
-                        navController.addOnDestinationChangedListener(
-                            object : NavController.OnDestinationChangedListener {
-                                override fun onDestinationChanged(
-                                    controller: NavController,
-                                    destination: androidx.navigation.NavDestination,
-                                    arguments: Bundle?,
-                                ) {
-                                    // Strip route args so "chat/{conversationId}" → "chat"
-                                    val screenName = destination.route
-                                        ?.substringBefore("/")
-                                        ?: destination.displayName
-                                    analyticsHelper.setCurrentScreen(screenName)
-                                }
-                            },
-                        )
+                    DisposableEffect(navController) {
+                        val listener = NavController.OnDestinationChangedListener { _, destination, _ ->
+                            // Strip route args so "chat/{conversationId}" → "chat"
+                            val screenName = destination.route
+                                ?.substringBefore("/")
+                                ?: "unknown"
+                            analyticsHelper.setCurrentScreen(screenName)
+                        }
+                        navController.addOnDestinationChangedListener(listener)
+                        onDispose {
+                            navController.removeOnDestinationChangedListener(listener)
+                        }
                     }
 
                     val startDestination = remember {

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatInputField.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatInputField.kt
@@ -28,10 +28,10 @@ fun ChatInputField(
     value: String,
     onValueChange: (String) -> Unit,
     onSend: (String) -> Unit,
+    modifier: Modifier = Modifier,
     isLoading: Boolean = false,
     isTurnstileReady: Boolean = true,
     isSessionLimitReached: Boolean = false,
-    modifier: Modifier = Modifier,
 ) {
     val isEnabled = !isLoading && isTurnstileReady && !isSessionLimitReached
 

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -297,12 +297,12 @@ internal fun handleVerseLink(
 @Composable
 fun ChatMessageItem(
     message: Message,
-    userMessage: String = "",
     chapterSheetState: ChapterSheetState,
     preferredTranslation: String?,
     onLoadChapter: (book: String, chapter: Int, translation: String?) -> Unit,
     onDismissSheet: () -> Unit,
     modifier: Modifier = Modifier,
+    userMessage: String = "",
     onRetry: (() -> Unit)? = null,
     onFeedback: ((messageLocalId: String, rating: String) -> Unit)? = null,
     feedbackGiven: String? = null,

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChurchFinderBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChurchFinderBottomSheet.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -201,8 +202,9 @@ fun ChurchFinderBottomSheet(
                         }
                     } else {
                         Text(
-                            text = stringResource(
-                                R.string.church_finder_found_count,
+                            text = pluralStringResource(
+                                R.plurals.church_finder_found_count,
+                                churches.size,
                                 churches.size,
                             ),
                             style = MaterialTheme.typography.labelMedium,

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SplashScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SplashScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -186,7 +187,7 @@ fun SplashScreen(onComplete: () -> Unit) {
             modifier = Modifier
                 .align(Alignment.Center)
                 .alpha(centerAlpha)
-                .absoluteOffset(y = centerOffsetY),
+                .absoluteOffset { IntOffset(0, centerOffsetY.roundToPx()) },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(

--- a/android/app/src/main/res/drawable/ic_splash_icon.xml
+++ b/android/app/src/main/res/drawable/ic_splash_icon.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Splash screen icon — open book with soft light rays, 240×240dp viewport -->
+<!-- Splash screen icon — open book with soft light rays, 200×200dp viewport -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="240dp"
-    android:height="240dp"
+    android:width="200dp"
+    android:height="200dp"
     android:viewportWidth="240"
     android:viewportHeight="240">
 

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -3,4 +3,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -3,4 +3,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">الإعدادات</string>
-    <string name="settings_language_title">اللغة</string>
-    <string name="settings_language_subtitle">اختر لغة آيات الكتاب المقدس</string>
     <string name="action_open_settings">الإعدادات</string>
     <string name="settings_theme_title">السمة</string>
     <string name="settings_theme_light">فاتح</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">تم النسخ</string>
     <string name="action_feedback_helpful">كان هذا مفيدًا</string>
     <string name="action_feedback_not_helpful">لم يكن هذا مفيدًا</string>
-    <string name="feedback_thank_you">شكرًا على تعليقك!</string>
     <string name="backend_warming_up">جارٍ الاتصال بالخادم… (قد يستغرق الطلب الأول حتى 30 ثانية)</string>
     <string name="action_scroll_to_bottom">التمرير إلى الأسفل</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">اقرأ الفصل الكامل</string>
-    <string name="loading_chapter">جارٍ تحميل الفصل…</string>
 
     <!-- Church Finder -->
     <string name="church_finder_banner_text">هل تبحث عن مجتمع إيماني؟</string>
@@ -178,12 +174,18 @@
     <string name="church_finder_search_button">بحث</string>
     <string name="church_finder_location_hint">استخدم أسماء المدن بالإنجليزية</string>
     <string name="church_finder_enter_location">أدخل موقعاً للبحث</string>
-    <string name="church_finder_found_count">تم العثور على %d كنيسة</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="zero">لم يتم العثور على أي كنيسة</item>
+        <item quantity="one">تم العثور على كنيسة واحدة</item>
+        <item quantity="two">تم العثور على كنيستين</item>
+        <item quantity="few">تم العثور على %d كنائس</item>
+        <item quantity="many">تم العثور على %d كنيسة</item>
+        <item quantity="other">تم العثور على %d كنيسة</item>
+    </plurals>
     <string name="church_finder_no_churches_found">لم يتم العثور على كنائس</string>
     <string name="church_finder_no_churches_hint">جرّب موقعاً مختلفاً أو مصطلح بحث أوسع.</string>
     <string name="church_finder_website">الموقع الإلكتروني</string>
     <string name="church_finder_email">البريد الإلكتروني</string>
-    <string name="church_finder_data_credit">بيانات الكنائس مقدمة من DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">تواصل</string>
@@ -204,7 +206,6 @@
     <string name="contact_send_button">إرسال الرسالة</string>
     <string name="contact_success_title">تم إرسال الرسالة بنجاح!</string>
     <string name="contact_success_description">شكراً لتواصلك معنا. سنراجع رسالتك قريباً.</string>
-    <string name="contact_error_send">فشل إرسال الرسالة. يرجى المحاولة مجدداً.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">آيات ذات صلة</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Einstellungen</string>
-    <string name="settings_language_title">Sprache</string>
-    <string name="settings_language_subtitle">Wähle die Sprache für Bibelverse</string>
     <string name="action_open_settings">Einstellungen</string>
     <string name="settings_theme_title">Design</string>
     <string name="settings_theme_light">Hell</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">Kopiert</string>
     <string name="action_feedback_helpful">Das war hilfreich</string>
     <string name="action_feedback_not_helpful">Das war nicht hilfreich</string>
-    <string name="feedback_thank_you">Danke für dein Feedback!</string>
     <string name="backend_warming_up">Verbindung zum Server wird hergestellt… (erste Anfrage kann bis zu 30 s dauern)</string>
     <string name="action_scroll_to_bottom">Nach unten scrollen</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Ganzes Kapitel lesen</string>
-    <string name="loading_chapter">Kapitel wird geladen…</string>
 
     <!-- Church Finder -->
     <string name="church_finder_banner_text">Suchen Sie eine Glaubensgemeinschaft?</string>
@@ -178,12 +174,14 @@
     <string name="church_finder_search_button">Suchen</string>
     <string name="church_finder_location_hint">Bitte englische Städtenamen verwenden</string>
     <string name="church_finder_enter_location">Ort für die Suche eingeben</string>
-    <string name="church_finder_found_count">%d Kirchen gefunden</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">%d Kirche gefunden</item>
+        <item quantity="other">%d Kirchen gefunden</item>
+    </plurals>
     <string name="church_finder_no_churches_found">Keine Kirchen gefunden</string>
     <string name="church_finder_no_churches_hint">Versuchen Sie einen anderen Ort oder einen allgemeineren Suchbegriff.</string>
     <string name="church_finder_website">Website</string>
     <string name="church_finder_email">E-Mail</string>
-    <string name="church_finder_data_credit">Kirchendaten bereitgestellt von DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Kontakt</string>
@@ -204,7 +202,6 @@
     <string name="contact_send_button">Nachricht senden</string>
     <string name="contact_success_title">Nachricht erfolgreich gesendet!</string>
     <string name="contact_success_description">Vielen Dank, dass du dich gemeldet hast. Wir werden deine Nachricht bald prüfen.</string>
-    <string name="contact_error_send">Nachricht konnte nicht gesendet werden. Bitte versuche es erneut.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Verwandte Verse</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Configuración</string>
-    <string name="settings_language_title">Idioma</string>
-    <string name="settings_language_subtitle">Selecciona el idioma para los versículos bíblicos</string>
     <string name="action_open_settings">Configuración</string>
     <string name="settings_theme_title">Tema</string>
     <string name="settings_theme_light">Claro</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">Copiado</string>
     <string name="action_feedback_helpful">Esto fue útil</string>
     <string name="action_feedback_not_helpful">Esto no fue útil</string>
-    <string name="feedback_thank_you">¡Gracias por tu comentario!</string>
     <string name="backend_warming_up">Conectando al servidor… (la primera solicitud puede tardar hasta 30 s)</string>
     <string name="action_scroll_to_bottom">Desplazarse hacia abajo</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Leer capítulo completo</string>
-    <string name="loading_chapter">Cargando capítulo…</string>
 
     <!-- Church Finder -->
     <string name="church_finder_banner_text">¿Buscas una comunidad de fe?</string>
@@ -178,12 +174,15 @@
     <string name="church_finder_search_button">Buscar</string>
     <string name="church_finder_location_hint">Usa nombres de ciudades en inglés</string>
     <string name="church_finder_enter_location">Ingresa una ubicación para buscar</string>
-    <string name="church_finder_found_count">Se encontraron %d iglesias</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">Se encontró %d iglesia</item>
+        <item quantity="many">Se encontraron %d iglesias</item>
+        <item quantity="other">Se encontraron %d iglesias</item>
+    </plurals>
     <string name="church_finder_no_churches_found">No se encontraron iglesias</string>
     <string name="church_finder_no_churches_hint">Prueba con una ubicación diferente o un término de búsqueda más amplio.</string>
     <string name="church_finder_website">Sitio web</string>
     <string name="church_finder_email">Correo electrónico</string>
-    <string name="church_finder_data_credit">Datos de iglesias proporcionados por DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Contacto</string>
@@ -204,7 +203,6 @@
     <string name="contact_send_button">Enviar mensaje</string>
     <string name="contact_success_title">¡Mensaje enviado con éxito!</string>
     <string name="contact_success_description">Gracias por contactarnos. Revisaremos tu mensaje pronto.</string>
-    <string name="contact_error_send">No se pudo enviar el mensaje. Por favor, inténtalo de nuevo.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Versículos relacionados</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Paramètres</string>
-    <string name="settings_language_title">Langue</string>
-    <string name="settings_language_subtitle">Sélectionnez la langue pour les versets bibliques</string>
     <string name="action_open_settings">Paramètres</string>
     <string name="settings_theme_title">Thème</string>
     <string name="settings_theme_light">Clair</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">Copié</string>
     <string name="action_feedback_helpful">C\'était utile</string>
     <string name="action_feedback_not_helpful">Ce n\'était pas utile</string>
-    <string name="feedback_thank_you">Merci pour votre avis !</string>
     <string name="backend_warming_up">Connexion au serveur… (la première requête peut prendre jusqu\'à 30 s)</string>
     <string name="action_scroll_to_bottom">Faire défiler vers le bas</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Lire le chapitre complet</string>
-    <string name="loading_chapter">Chargement du chapitre…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">Vous cherchez une communauté de foi ?</string>
@@ -178,12 +174,15 @@
     <string name="church_finder_search_button">Rechercher</string>
     <string name="church_finder_location_hint">Utilisez les noms de villes en anglais</string>
     <string name="church_finder_enter_location">Entrez un lieu pour rechercher</string>
-    <string name="church_finder_found_count">%d églises trouvées</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">%d église trouvée</item>
+        <item quantity="many">Se trouvèrent %d églises</item>
+        <item quantity="other">%d églises trouvées</item>
+    </plurals>
     <string name="church_finder_no_churches_found">Aucune église trouvée</string>
     <string name="church_finder_no_churches_hint">Essayez un autre lieu ou un terme de recherche plus large.</string>
     <string name="church_finder_website">Site web</string>
     <string name="church_finder_email">E-mail</string>
-    <string name="church_finder_data_credit">Données d\'église fournies par DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Contact</string>
@@ -204,7 +203,6 @@
     <string name="contact_send_button">Envoyer le message</string>
     <string name="contact_success_title">Message envoyé avec succès !</string>
     <string name="contact_success_description">Merci de nous avoir contactés. Nous examinerons votre message prochainement.</string>
-    <string name="contact_error_send">Échec de l\'envoi du message. Veuillez réessayer.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Versets associés</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">सेटिंग्स</string>
-    <string name="settings_language_title">भाषा</string>
-    <string name="settings_language_subtitle">बाइबिल पदों के लिए भाषा चुनें</string>
     <string name="action_open_settings">सेटिंग्स</string>
     <string name="settings_theme_title">थीम</string>
     <string name="settings_theme_light">हल्का</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">कॉपी किया गया</string>
     <string name="action_feedback_helpful">यह उपयोगी था</string>
     <string name="action_feedback_not_helpful">यह उपयोगी नहीं था</string>
-    <string name="feedback_thank_you">आपकी प्रतिक्रिया के लिए धन्यवाद!</string>
     <string name="backend_warming_up">सर्वर से जुड़ रहे हैं… (पहले अनुरोध में 30 सेकंड तक लग सकते हैं)</string>
     <string name="action_scroll_to_bottom">नीचे स्क्रॉल करें</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">पूरा अध्याय पढ़ें</string>
-    <string name="loading_chapter">अध्याय लोड हो रहा है…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">एक विश्वास समुदाय खोज रहे हैं?</string>
@@ -178,12 +174,14 @@
     <string name="church_finder_search_button">खोजें</string>
     <string name="church_finder_location_hint">शहरों के अंग्रेजी नामों का उपयोग करें</string>
     <string name="church_finder_enter_location">खोजने के लिए स्थान दर्ज करें</string>
-    <string name="church_finder_found_count">%d चर्च मिले</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">%d चर्च मिला</item>
+        <item quantity="other">%d चर्च मिले</item>
+    </plurals>
     <string name="church_finder_no_churches_found">कोई चर्च नहीं मिला</string>
     <string name="church_finder_no_churches_hint">कोई अन्य स्थान या व्यापक खोज शब्द आज़माएं।</string>
     <string name="church_finder_website">वेबसाइट</string>
     <string name="church_finder_email">ईमेल</string>
-    <string name="church_finder_data_credit">चर्च डेटा DisciplesToday.org द्वारा प्रदान किया गया</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">संपर्क</string>
@@ -204,7 +202,6 @@
     <string name="contact_send_button">संदेश भेजें</string>
     <string name="contact_success_title">संदेश सफलतापूर्वक भेजा गया!</string>
     <string name="contact_success_description">संपर्क करने के लिए धन्यवाद। हम जल्द ही आपके संदेश की समीक्षा करेंगे।</string>
-    <string name="contact_error_send">संदेश भेजने में विफल। पुनः प्रयास करें।</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">संबंधित पद</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Impostazioni</string>
-    <string name="settings_language_title">Lingua</string>
-    <string name="settings_language_subtitle">Seleziona la lingua per i versetti biblici</string>
     <string name="action_open_settings">Impostazioni</string>
     <string name="settings_theme_title">Tema</string>
     <string name="settings_theme_light">Chiaro</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">Copiato</string>
     <string name="action_feedback_helpful">È stato utile</string>
     <string name="action_feedback_not_helpful">Non è stato utile</string>
-    <string name="feedback_thank_you">Grazie per il tuo feedback!</string>
     <string name="backend_warming_up">Connessione al server… (la prima richiesta potrebbe richiedere fino a 30 s)</string>
     <string name="action_scroll_to_bottom">Scorri verso il basso</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Leggi il capitolo completo</string>
-    <string name="loading_chapter">Caricamento del capitolo…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">Cerchi una comunità di fede?</string>
@@ -178,12 +174,15 @@
     <string name="church_finder_search_button">Cerca</string>
     <string name="church_finder_location_hint">Usa i nomi delle città in inglese</string>
     <string name="church_finder_enter_location">Inserisci una posizione per cercare</string>
-    <string name="church_finder_found_count">%d chiese trovate</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">%d chiesa trovata</item>
+        <item quantity="many">%d milioni di chiese trovate</item>
+        <item quantity="other">%d chiese trovate</item>
+    </plurals>
     <string name="church_finder_no_churches_found">Nessuna chiesa trovata</string>
     <string name="church_finder_no_churches_hint">Prova un\'altra posizione o un termine di ricerca più ampio.</string>
     <string name="church_finder_website">Sito web</string>
     <string name="church_finder_email">E-mail</string>
-    <string name="church_finder_data_credit">Dati delle chiese forniti da DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Contatto</string>
@@ -204,7 +203,6 @@
     <string name="contact_send_button">Invia messaggio</string>
     <string name="contact_success_title">Messaggio inviato con successo!</string>
     <string name="contact_success_description">Grazie per averci contattato. Esamineremo il tuo messaggio a breve.</string>
-    <string name="contact_error_send">Invio del messaggio non riuscito. Riprova.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Versetti correlati</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">설정</string>
-    <string name="settings_language_title">언어</string>
-    <string name="settings_language_subtitle">성경 구절의 언어를 선택하세요</string>
     <string name="action_open_settings">설정</string>
     <string name="settings_theme_title">테마</string>
     <string name="settings_theme_light">라이트</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">복사됨</string>
     <string name="action_feedback_helpful">도움이 되었습니다</string>
     <string name="action_feedback_not_helpful">도움이 되지 않았습니다</string>
-    <string name="feedback_thank_you">피드백 감사합니다!</string>
     <string name="backend_warming_up">서버에 연결 중… (첫 번째 요청은 최대 30초가 걸릴 수 있습니다)</string>
     <string name="action_scroll_to_bottom">맨 아래로 스크롤</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">전체 챕터 읽기</string>
-    <string name="loading_chapter">챕터 로딩 중…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">신앙 공동체를 찾고 계신가요?</string>
@@ -178,12 +174,13 @@
     <string name="church_finder_search_button">검색</string>
     <string name="church_finder_location_hint">영문 도시명을 사용하세요</string>
     <string name="church_finder_enter_location">검색할 위치를 입력하세요</string>
-    <string name="church_finder_found_count">교회 %d개 발견</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="other">교회 %d개 발견</item>
+    </plurals>
     <string name="church_finder_no_churches_found">교회를 찾을 수 없습니다</string>
     <string name="church_finder_no_churches_hint">다른 위치나 더 넓은 검색어를 시도해 보세요.</string>
     <string name="church_finder_website">웹사이트</string>
     <string name="church_finder_email">이메일</string>
-    <string name="church_finder_data_credit">교회 데이터 제공: DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">문의</string>
@@ -204,7 +201,6 @@
     <string name="contact_send_button">메시지 보내기</string>
     <string name="contact_success_title">메시지가 성공적으로 전송되었습니다!</string>
     <string name="contact_success_description">문의해 주셔서 감사합니다. 곧 메시지를 검토하겠습니다.</string>
-    <string name="contact_error_send">메시지 전송에 실패했습니다. 다시 시도하세요.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">관련 구절</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Configurações</string>
-    <string name="settings_language_title">Idioma</string>
-    <string name="settings_language_subtitle">Selecione o idioma para os versículos bíblicos</string>
     <string name="action_open_settings">Configurações</string>
     <string name="settings_theme_title">Tema</string>
     <string name="settings_theme_light">Claro</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">Copiado</string>
     <string name="action_feedback_helpful">Isso foi útil</string>
     <string name="action_feedback_not_helpful">Isso não foi útil</string>
-    <string name="feedback_thank_you">Obrigado pelo seu feedback!</string>
     <string name="backend_warming_up">Conectando ao servidor… (a primeira solicitação pode levar até 30 s)</string>
     <string name="action_scroll_to_bottom">Rolar para baixo</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Leia o capítulo completo</string>
-    <string name="loading_chapter">Carregando capítulo…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">Procura uma comunidade de fé?</string>
@@ -178,12 +174,15 @@
     <string name="church_finder_search_button">Pesquisar</string>
     <string name="church_finder_location_hint">Use nomes de cidades em inglês</string>
     <string name="church_finder_enter_location">Insira um local para pesquisar</string>
-    <string name="church_finder_found_count">%d igrejas encontradas</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">%d igreja encontrada</item>
+        <item quantity="many">%d milhões de igrejas encontradas</item>
+        <item quantity="other">%d igrejas encontradas</item>
+    </plurals>
     <string name="church_finder_no_churches_found">Nenhuma igreja encontrada</string>
     <string name="church_finder_no_churches_hint">Tente um local diferente ou um termo de pesquisa mais amplo.</string>
     <string name="church_finder_website">Site</string>
     <string name="church_finder_email">E-mail</string>
-    <string name="church_finder_data_credit">Dados de igrejas fornecidos por DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Contato</string>
@@ -204,7 +203,6 @@
     <string name="contact_send_button">Enviar mensagem</string>
     <string name="contact_success_title">Mensagem enviada com sucesso!</string>
     <string name="contact_success_description">Obrigado por entrar em contato. Analisaremos sua mensagem em breve.</string>
-    <string name="contact_error_send">Falha ao enviar a mensagem. Por favor, tente novamente.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Versículos relacionados</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Настройки</string>
-    <string name="settings_language_title">Язык</string>
-    <string name="settings_language_subtitle">Выберите язык для библейских стихов</string>
     <string name="action_open_settings">Настройки</string>
     <string name="settings_theme_title">Тема</string>
     <string name="settings_theme_light">Светлая</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">Скопировано</string>
     <string name="action_feedback_helpful">Это было полезно</string>
     <string name="action_feedback_not_helpful">Это было бесполезно</string>
-    <string name="feedback_thank_you">Спасибо за ваш отзыв!</string>
     <string name="backend_warming_up">Подключение к серверу… (первый запрос может занять до 30 с)</string>
     <string name="action_scroll_to_bottom">Прокрутить вниз</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Читать всю главу</string>
-    <string name="loading_chapter">Загрузка главы…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">Ищете общину веры?</string>
@@ -178,12 +174,16 @@
     <string name="church_finder_search_button">Искать</string>
     <string name="church_finder_location_hint">Используйте названия городов на английском</string>
     <string name="church_finder_enter_location">Введите местоположение для поиска</string>
-    <string name="church_finder_found_count">Найдено церквей: %d</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">Найдена %d церковь</item>
+        <item quantity="few">Найдено %d церкви</item>
+        <item quantity="many">Найдено церквей: %d</item>
+        <item quantity="other">Найдено церквей: %d</item>
+    </plurals>
     <string name="church_finder_no_churches_found">Церкви не найдены</string>
     <string name="church_finder_no_churches_hint">Попробуйте другое место или более широкий поисковый запрос.</string>
     <string name="church_finder_website">Веб-сайт</string>
     <string name="church_finder_email">Эл. почта</string>
-    <string name="church_finder_data_credit">Данные о церквях предоставлены DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Контакт</string>
@@ -204,7 +204,6 @@
     <string name="contact_send_button">Отправить сообщение</string>
     <string name="contact_success_title">Сообщение успешно отправлено!</string>
     <string name="contact_success_description">Спасибо за обращение. Мы рассмотрим ваше сообщение в ближайшее время.</string>
-    <string name="contact_error_send">Не удалось отправить сообщение. Повторите попытку.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Связанные стихи</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -131,8 +131,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">设置</string>
-    <string name="settings_language_title">语言</string>
-    <string name="settings_language_subtitle">选择圣经经文的语言</string>
     <string name="action_open_settings">设置</string>
     <string name="settings_theme_title">主题</string>
     <string name="settings_theme_light">浅色</string>
@@ -160,13 +158,11 @@
     <string name="action_copied">已复制</string>
     <string name="action_feedback_helpful">这很有帮助</string>
     <string name="action_feedback_not_helpful">这没有帮助</string>
-    <string name="feedback_thank_you">感谢您的反馈！</string>
     <string name="backend_warming_up">正在连接服务器……（首次请求可能需要最多30秒）</string>
     <string name="action_scroll_to_bottom">滚动到底部</string>
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">阅读整章</string>
-    <string name="loading_chapter">正在加载章节…</string>
 
     <!-- Church finder -->
     <string name="church_finder_banner_text">正在寻找信仰团体？</string>
@@ -178,12 +174,13 @@
     <string name="church_finder_search_button">搜索</string>
     <string name="church_finder_location_hint">请使用城市的英文名称</string>
     <string name="church_finder_enter_location">输入位置以搜索</string>
-    <string name="church_finder_found_count">找到 %d 个教会</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="other">找到 %d 个教会</item>
+    </plurals>
     <string name="church_finder_no_churches_found">未找到教会</string>
     <string name="church_finder_no_churches_hint">尝试其他地点或更宽泛的搜索词。</string>
     <string name="church_finder_website">网站</string>
     <string name="church_finder_email">电子邮件</string>
-    <string name="church_finder_data_credit">教会数据由 DisciplesToday.org 提供</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">联系</string>
@@ -204,7 +201,6 @@
     <string name="contact_send_button">发送消息</string>
     <string name="contact_success_title">消息发送成功！</string>
     <string name="contact_success_description">感谢您的联系，我们将尽快查看您的消息。</string>
-    <string name="contact_error_send">消息发送失败，请重试。</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">相关经文</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -128,8 +128,6 @@
 
     <!-- Settings screen -->
     <string name="settings_title">Settings</string>
-    <string name="settings_language_title">Language</string>
-    <string name="settings_language_subtitle">Select the language for Bible verses</string>
     <string name="action_open_settings">Settings</string>
     <string name="settings_theme_title">Theme</string>
     <string name="settings_theme_light">Light</string>
@@ -166,7 +164,6 @@
     <!-- Feedback -->
     <string name="action_feedback_helpful">This was helpful</string>
     <string name="action_feedback_not_helpful">This was not helpful</string>
-    <string name="feedback_thank_you">Thank you for your feedback!</string>
 
     <!-- Backend warm-up -->
     <string name="backend_warming_up">Connecting to server… (first request may take up to 30 s)</string>
@@ -176,7 +173,6 @@
 
     <!-- Verse detail bottom sheet -->
     <string name="read_full_chapter">Read full chapter</string>
-    <string name="loading_chapter">Loading chapter…</string>
 
     <!-- Church Finder -->
     <string name="church_finder_banner_text">Looking for a faith community?</string>
@@ -188,12 +184,14 @@
     <string name="church_finder_search_button">Search</string>
     <string name="church_finder_location_hint">Use English city names (e.g., Rome, Munich, Vienna)</string>
     <string name="church_finder_enter_location">Enter a location to search</string>
-    <string name="church_finder_found_count">Found %d churches</string>
+    <plurals name="church_finder_found_count">
+        <item quantity="one">Found %d church</item>
+        <item quantity="other">Found %d churches</item>
+    </plurals>
     <string name="church_finder_no_churches_found">No churches found</string>
     <string name="church_finder_no_churches_hint">Try a different location or broader search term.</string>
     <string name="church_finder_website">Website</string>
     <string name="church_finder_email">Email</string>
-    <string name="church_finder_data_credit">Church data provided by DisciplesToday.org</string>
 
     <!-- Contact Form -->
     <string name="contact_section_title">Contact</string>
@@ -214,7 +212,6 @@
     <string name="contact_send_button">Send Message</string>
     <string name="contact_success_title">Message sent successfully!</string>
     <string name="contact_success_description">Thank you for reaching out. We\'ll review your message soon.</string>
-    <string name="contact_error_send">Failed to send message. Please try again.</string>
 
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Related verses</string>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Data extraction rules for Android 12+ (API 31+).
+    Backups and device transfers are disabled — the app holds no user data
+    that needs to be migrated (all data lives server-side).
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

- **AGENTS.md** — Adds a *Git Worktree Pattern* section instructing automated agents to do their work in a throwaway `git worktree` under `/tmp/` instead of modifying the shared main checkout directly.
- **Lint hardening** — Flips `abortOnError` to `true` in `build.gradle.kts` and fixes all previously hidden violations:
  - `MainActivity.kt`: replaces `remember { addOnDestinationChangedListener }` with a `DisposableEffect` that properly removes the listener on dispose; adds `@SuppressLint("AppBundleLocaleChanges")` on the per-locale `Configuration`.
  - Debug manifest: adds `tools:ignore="MissingClass"` to four `<provider tools:node="remove">` entries (Firebase init, Crashlytics, Google measurement, data-transport) whose classes don't resolve in debug builds.
  - Main manifest: declares `android:dataExtractionRules="@xml/data_extraction_rules"` + `tools:ignore`.
  - New `res/xml/data_extraction_rules.xml`: opts out of Android 12+ cloud backup and device transfer (all data is server-side).
  - Minor lint-driven tweaks in `ChatInputField`, `ChatMessageItem`, `SplashScreen`, splash drawable, launcher mipmaps.
- **i18n — plurals** — Replaces the singular `church_finder_found_count` `<string>` with a proper `<plurals>` (`one` / `other`) and updates `ChurchFinderBottomSheet.kt` to call `pluralStringResource(...)`. Propagated across all 11 locales (ar/de/es/fr/hi/it/ko/pt/ru/zh + default).
- **Dead string removal** — Removes unused strings: `settings_language_title`, `settings_language_subtitle`, `feedback_thank_you`, `loading_chapter`, `church_finder_data_credit`, `contact_error_send`.
- **Room schema export** — Commits `schemas/.../VoxQuietaDatabase/1.json` for migration testing.
- **`.secrets.baseline`** — Updated.

## Test plan

- [ ] `./gradlew :app:lintDebug` passes with zero errors
- [ ] `./gradlew :app:testDebugUnitTest` passes
- [ ] Church finder result count shows "Found 1 church" (singular) vs "Found N churches" (plural) on a real search
- [ ] App installs and navigates correctly (no listener-leak crash, no locale regression)
- [ ] Room schema file present and matches the compiled DB schema (`./gradlew :app:generateDebugRoomSchemas`)