### PR TITLE
fix(ops): strengthen prod monitor — search probe, frontend probe, re-alerts

### DIFF
--- a/.github/actions/notify-telegram/action.yml
+++ b/.github/actions/notify-telegram/action.yml
@@ -62,23 +62,49 @@ runs:
             ;;
         esac
 
-        prev=""
+        # --- Restore and parse previous state ---
+        prev_raw=""
         if [ -f monitor-state.txt ]; then
-          prev=$(head -c 16 monitor-state.txt | tr -d '[:space:]' || true)
+            prev_raw=$(head -c 32 monitor-state.txt | tr -d '[:space:]' || true)
         fi
 
-        # Decide message
+        # Parse state token and optional timestamp
+        prev_token="${prev_raw%%:*}"   # "pass", "fail", or ""
+        prev_ts=""
+        if [[ "$prev_raw" == *:* ]]; then
+            prev_ts="${prev_raw#*:}"   # unix timestamp of first failure
+        fi
+
+        # --- Decide message ---
         msg=""
+        now=$(date +%s)
+
         if [ "$FORCE_ALERT" = "true" ]; then
-          msg="🧪 *prod-monitor* test alert from \`${JOB_NAME}\` on \`${GITHUB_SHA::7}\` (status=${curr})"
-        elif [ "$prev" = "" ] && [ "$curr" = "fail" ]; then
-          msg="🚨 *prod-monitor / ${JOB_NAME}* failed (no prior state)"
-        elif [ "$prev" = "pass" ] && [ "$curr" = "fail" ]; then
-          msg="🚨 *prod-monitor / ${JOB_NAME}* failed"
-        elif [ "$prev" = "fail" ] && [ "$curr" = "pass" ]; then
-          msg="✅ *prod-monitor / ${JOB_NAME}* recovered"
+            msg="🧪 *prod-monitor* test alert from \`${JOB_NAME}\` (status=${curr})"
+        elif [ "$prev_token" = "" ] && [ "$curr" = "fail" ]; then
+            msg="🚨 *prod-monitor / ${JOB_NAME}* DOWN (no prior state)"
+        elif [ "$prev_token" = "pass" ] && [ "$curr" = "fail" ]; then
+            msg="🚨 *prod-monitor / ${JOB_NAME}* DOWN"
+        elif [ "$prev_token" = "fail" ] && [ "$curr" = "pass" ]; then
+            # Compute how long it was down
+            if [ -n "$prev_ts" ]; then
+                down_for=$(( now - prev_ts ))
+                down_min=$(( down_for / 60 ))
+                msg="✅ *prod-monitor / ${JOB_NAME}* RECOVERED (was down ~${down_min}m)"
+            else
+                msg="✅ *prod-monitor / ${JOB_NAME}* RECOVERED"
+            fi
+        elif [ "$prev_token" = "fail" ] && [ "$curr" = "fail" ]; then
+            # Still failing — re-alert every 30 minutes
+            if [ -n "$prev_ts" ]; then
+                elapsed=$(( now - prev_ts ))
+                if [ "$elapsed" -ge 1800 ]; then
+                    down_min=$(( elapsed / 60 ))
+                    msg="🔴 *prod-monitor / ${JOB_NAME}* still DOWN (${down_min}m)"
+                fi
+            fi
         else
-          echo "no transition (prev=${prev:-none} → curr=${curr}); not alerting"
+            echo "no transition (prev=${prev_token:-none} → curr=${curr}); not alerting"
         fi
 
         if [ -n "$msg" ]; then
@@ -102,21 +128,37 @@ runs:
             echo "::warning::TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID not set; would send: $msg"
           else
             # Use --data-urlencode for text so newlines/markdown survive
-            http=$(curl -sS -o /tmp/tg-resp -w "%{http_code}" \
+            http=$(curl -sS -o /dev/null -w "%{http_code}" \
               "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
               -d "chat_id=${TG_CHAT}" \
               -d "parse_mode=Markdown" \
               --data-urlencode "text=${msg}" || echo "000")
             if [ "$http" != "200" ]; then
-              echo "::warning::Telegram sendMessage returned HTTP ${http}: $(cat /tmp/tg-resp)"
+              echo "::warning::Telegram sendMessage returned HTTP ${http}"
             else
               echo "telegram alert sent (${#msg} chars)"
             fi
           fi
         fi
 
-        # Persist the new state for the next run (replace file content)
-        printf '%s' "$curr" > monitor-state.txt
+        # --- Save new state ---
+        if [ "$curr" = "fail" ]; then
+            if [ "$prev_token" = "fail" ] && [ -n "$prev_ts" ]; then
+                # Keep original failure timestamp — but reset if we just re-alerted
+                if [ -n "$msg" ]; then
+                    # re-alert was sent; reset the 30min window from now
+                    printf 'fail:%d' "$now" > monitor-state.txt
+                else
+                    # still failing, no re-alert yet — preserve original timestamp
+                    printf '%s' "$prev_raw" > monitor-state.txt
+                fi
+            else
+                # First failure — record timestamp
+                printf 'fail:%d' "$now" > monitor-state.txt
+            fi
+        else
+            printf '%s' "$curr" > monitor-state.txt
+        fi
 
     - name: Save new state
       uses: actions/cache/save@v4

--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -2,12 +2,15 @@ name: Prod Monitor
 
 # Production monitoring + alerting via Telegram.
 #
-# Three independent jobs run every 5 minutes:
+# Five independent jobs run every 5 minutes:
 #   - health        : cheap liveness check (/health/live, /health/ready)
 #   - synthetic-chat: real chat round-trip via /api/v1/chat/stream — catches
 #                     the failure mode where the backend returns HTTP 200 with
 #                     an in-band {"type":"error", ...} SSE chunk (e.g. a bad
 #                     OpenRouter API key).
+#   - verse-search  : semantic search probe via /api/v1/scripture/search —
+#                     validates DB + embedding provider + pgvector are healthy.
+#   - frontend      : checks that the frontend (voxquieta.org) serves HTML.
 #   - log-scan      : Azure Log Analytics KQL query against the backend's
 #                     ContainerAppConsoleLogs_CL for error patterns over the
 #                     last 10 minutes.
@@ -140,6 +143,72 @@ jobs:
           force_alert: ${{ github.event.inputs.force_alert }}
 
   # ---------------------------------------------------------------------------
+  verse-search:
+    name: Verse search probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install probe deps
+        run: pip install httpx
+
+      - name: Run verse search probe
+        id: probe
+        env:
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+          MONITOR_PROBE_SECRET: ${{ secrets.MONITOR_PROBE_SECRET }}
+          SEARCH_QUERY: "love"
+          SEARCH_TIMEOUT_SECONDS: "20"
+        run: python scripts/monitor/synthetic_search.py --detail-out "$RUNNER_TEMP/detail.txt"
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: verse-search
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}
+
+  # ---------------------------------------------------------------------------
+  frontend:
+    name: Frontend probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check frontend is serving HTML
+        id: check
+        env:
+          FRONTEND_URL: ${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
+        run: |
+          set -o pipefail
+          body=$(curl -fsS --max-time 15 "$FRONTEND_URL")
+          echo "$body" | grep -qi '<html\|<!DOCTYPE' || {
+            echo "frontend response does not look like HTML: ${body:0:200}" > "$RUNNER_TEMP/detail.txt"
+            exit 1
+          }
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: frontend
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}
+
+  # ---------------------------------------------------------------------------
   log-scan:
     name: Log scan
     runs-on: ubuntu-latest
@@ -177,7 +246,10 @@ jobs:
         run: |
           set -o pipefail
           err_re='(?i)(openrouter error|llm streaming error|anthropic error'
-          err_re="${err_re}|internal server error|traceback)"
+          err_re="${err_re}|internal server error|traceback"
+          err_re="${err_re}|rate.?limit|quota exceeded|api.?key"
+          err_re="${err_re}|embedding.*error|connection.*error|connection refused"
+          err_re="${err_re}|unhandled exception|critical|fatal)"
           # `sample` is a KQL operator; using it as a column name causes
           # SYN0002. Use `sample_log` instead.
           query="ContainerAppConsoleLogs_CL

--- a/scripts/monitor/synthetic_chat.py
+++ b/scripts/monitor/synthetic_chat.py
@@ -101,7 +101,12 @@ def main() -> int:
     last_chunk: dict | None = None
 
     try:
-        with httpx.Client(timeout=httpx.Timeout(overall_timeout, read=overall_timeout)) as client:
+        with httpx.Client(timeout=httpx.Timeout(
+            connect=10.0,
+            read=first_chunk_timeout,   # per-read socket timeout = first_chunk_timeout
+            write=10.0,
+            pool=5.0,
+        )) as client:
             with client.stream("POST", url, json=body, headers=headers) as response:
                 if response.status_code != 200:
                     text = response.read().decode("utf-8", errors="replace")[:500]
@@ -148,6 +153,12 @@ def main() -> int:
                         saw_content = True
                     elif chunk_type == "completion":
                         saw_completion = True
+    except httpx.ReadTimeout as e:
+        return fail(
+            f"server unresponsive: no data received within {first_chunk_timeout}s "
+            f"(saw_content={saw_content})",
+            args.detail_out,
+        )
     except httpx.TimeoutException as e:
         return fail(f"httpx timeout: {e}", args.detail_out)
     except httpx.HTTPError as e:

--- a/scripts/monitor/synthetic_search.py
+++ b/scripts/monitor/synthetic_search.py
@@ -1,0 +1,103 @@
+"""
+Synthetic scripture-search probe.
+
+GETs /api/v1/scripture/search?q=love&max_verses=2 and validates the response
+has at least one verse, exercising the full stack: DB + embedding provider +
+pgvector semantic search.
+
+Exit codes:
+    0 — probe passed
+    1 — probe failed
+
+Required environment variables:
+    BACKEND_URL              — backend ACA URL
+    MONITOR_PROBE_SECRET     — shared secret (same as synthetic_chat probe)
+
+Optional:
+    SEARCH_QUERY             — query to send (default: "love")
+    SEARCH_TIMEOUT_SECONDS   — overall timeout (default: 20)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+import httpx
+
+
+def fail(detail: str, detail_out: str | None) -> int:
+    print(f"PROBE FAIL: {detail}", file=sys.stderr)
+    if detail_out:
+        try:
+            with open(detail_out, "w", encoding="utf-8") as f:
+                f.write(detail)
+        except OSError as e:
+            print(f"could not write detail to {detail_out}: {e}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Synthetic scripture-search probe.")
+    parser.add_argument("--detail-out", default=None)
+    args = parser.parse_args()
+
+    backend_url = os.environ.get("BACKEND_URL", "").rstrip("/")
+    probe_secret = os.environ.get("MONITOR_PROBE_SECRET", "")
+    if not backend_url:
+        return fail("BACKEND_URL env var is required", args.detail_out)
+    if not probe_secret:
+        return fail("MONITOR_PROBE_SECRET env var is required", args.detail_out)
+
+    query = os.environ.get("SEARCH_QUERY", "love")
+    timeout = float(os.environ.get("SEARCH_TIMEOUT_SECONDS", "20"))
+
+    url = f"{backend_url}/api/v1/scripture/search"
+    params = {"q": query, "max_verses": 2, "max_passages": 1}
+    headers = {
+        "X-Monitor-Probe-Secret": probe_secret,
+        "Accept": "application/json",
+    }
+
+    started = time.monotonic()
+    try:
+        resp = httpx.get(
+            url,
+            params=params,
+            headers=headers,
+            timeout=httpx.Timeout(connect=10.0, read=timeout, write=10.0, pool=5.0),
+        )
+    except httpx.TimeoutException as e:
+        return fail(f"request timed out after {timeout}s: {e}", args.detail_out)
+    except httpx.HTTPError as e:
+        return fail(f"HTTP error: {e}", args.detail_out)
+
+    elapsed = time.monotonic() - started
+
+    if resp.status_code != 200:
+        text = resp.text[:500]
+        return fail(f"HTTP {resp.status_code} from {url}: {text}", args.detail_out)
+
+    try:
+        data = resp.json()
+    except Exception as e:
+        return fail(f"invalid JSON response: {e}\nbody: {resp.text[:300]}", args.detail_out)
+
+    verses = data.get("verses", [])
+    if not verses:
+        return fail(
+            f"search for '{query}' returned 0 verses — "
+            f"embedding provider or pgvector may be down.\nResponse: {str(data)[:500]}",
+            args.detail_out,
+        )
+
+    print(
+        f"PROBE OK: search '{query}' returned {len(verses)} verse(s) in {elapsed:.2f}s"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed

### Bug fixes
- **Fix `first_chunk_timeout`** in `synthetic_chat.py`: used `httpx.Timeout(read=first_chunk_timeout)` so a completely silent server (no bytes at all) now fails at 15s instead of waiting the full 30s overall timeout.

### New probes
- **Verse search probe** (`synthetic_search.py` + `verse-search` job): tests the full stack — DB + embedding provider + pgvector. Chat passing but verse search failing would have been invisible before.
- **Frontend probe** (`frontend` job): checks that `https://voxquieta.org` returns HTML. Catches CDN/deployment issues.

### Alerting
- **Re-alert every 30 min** during sustained outages (with down-duration in message). Recovery messages now include how long the service was down.

### Log scan
- **Expanded error patterns**: `rate limit`, `quota`, `api key`, `embedding error`, `connection error`, `unhandled exception`, `critical`, `fatal`.