### PR TITLE
fix(ops): KQL log-scan: replace invalid !matches with positive level filter

### DIFF
--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -254,12 +254,14 @@ jobs:
           err_re="${err_re}|unhandled exception|critical error|fatal)"
           # `sample` is a KQL operator; using it as a column name causes
           # SYN0002. Use `sample_log` instead.
-          # Exclude INFO-level lines: the monitor probe emits INFO logs that
-          # mention "rate limit" (bypassing it), which would cause false alerts.
+          # KQL has no !matches operator — it only supports ! for scalar
+          # string operators (!contains, !startswith). Use a positive level
+          # filter so only ERROR/WARNING/CRITICAL lines are scanned; INFO
+          # logs like "Monitor probe — bypassing rate limit" are excluded.
           query="ContainerAppConsoleLogs_CL
             | where TimeGenerated > ago(10m)
             | where ContainerAppName_s == \"bible-app-backend\"
-            | where Log_s !matches regex \"\\\\| INFO\\\\s*\\\\|\"
+            | where Log_s matches regex \"(?i)\\\\| (ERROR|WARNING|CRITICAL)\\\\s*\\\\|\"
             | where Log_s matches regex \"${err_re}\"
             | summarize cnt = count(), sample_log = any(Log_s)
             | project cnt, sample_log"


### PR DESCRIPTION
## Problem

PR #464 merged with a KQL syntax error:

```
SYN0002: Query could not be parsed at '!' on line [4,17]
```


## Fix

Replace:
```kql
```

With a **positive** log-level filter:
```kql
| where Log_s matches regex "(?i)\\| (ERROR|WARNING|CRITICAL)\\s*\\|"
```

This is semantically cleaner — we only want real error lines. INFO logs like `Monitor probe — bypassing rate limit` are naturally excluded without needing a negated regex.