### PR TITLE
fix(ops): remove stray (?i) flag from KQL level-filter regex (SYN0002)

### DIFF
--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -261,7 +261,7 @@ jobs:
           query="ContainerAppConsoleLogs_CL
             | where TimeGenerated > ago(10m)
             | where ContainerAppName_s == \"bible-app-backend\"
-            | where Log_s matches regex \"(?i)\\\\| (ERROR|WARNING|CRITICAL)\\\\s*\\\\|\"
+            | where Log_s matches regex \"\\\\| (ERROR|WARNING|CRITICAL)\\\\s*\\\\|\"
             | where Log_s matches regex \"${err_re}\"
             | summarize cnt = count(), sample_log = any(Log_s)
             | project cnt, sample_log"


### PR DESCRIPTION
The previous fix (8181690) replaced the invalid `!matches regex` operator (which caused SYN0002 at '!' on line [4,17]) with a positive level filter using `matches regex "(?i)\\| (ERROR|WARNING|CRITICAL)\\s*\\|"`.

The `(?i)` inline flag is unnecessary here — ERROR/WARNING/CRITICAL are always emitted in upper case by structlog — and risks triggering a second SYN0002 or regex-engine rejection in some Azure KQL RE2 builds. Remove it, leaving the unambiguous literal-pipe regex:

  matches regex "\\| (ERROR|WARNING|CRITICAL)\\s*\\|"

The err_re pattern (which matches lower-cased error strings) retains its `(?i)` prefix since user-facing error messages may be mixed case.

Locally-verified: bash expansion renders line 4 of the KQL query as:
  | where Log_s matches regex "\\| (ERROR|WARNING|CRITICAL)\\s*\\|"
with no `!` token present at any position.

https://claude.ai/code/session_01WZ2b2VTNrr2rpiNCwcBhMv