### PR TITLE
fix(android): fix version grep in publish workflow, improve signing config, document Play Store process

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -54,7 +54,8 @@ jobs:
             IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION_NAME"
             VERSION_CODE=$(( MAJOR * 10000 + MINOR * 100 + PATCH ))
           else
-            VERSION_NAME="$(grep versionName android/app/build.gradle.kts | head -1 | grep -oP '[\d.]+')"
+            VERSION_NAME="$(grep versionName android/app/build.gradle.kts \
+              | head -1 | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
             VERSION_CODE="$(grep versionCode android/app/build.gradle.kts | head -1 | grep -oP '\d+')"
           fi
           echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"

--- a/android/README.md
+++ b/android/README.md
@@ -179,9 +179,74 @@ To build a production AAB for Play Store submission, pass both properties:
 
 The resulting AAB is at `app/build/outputs/bundle/release/app-release.aab`.
 
-In CI the same flags are injected automatically by
-`.github/workflows/android-ci.yml` via the `VERSION_CODE` and `VERSION_NAME`
-repository variables (or secrets) — no manual step needed for tagged releases.
+---
+
+## Publishing to the Play Store
+
+Publishing is fully automated via GitHub Actions
+(`.github/workflows/android-publish.yml`) and Fastlane.
+
+### Required GitHub secrets
+
+These must be set under **Settings → Secrets and variables → Actions** in the
+repository before the workflow can run:
+
+| Secret | Description |
+|---|---|
+| `KEYSTORE_FILE` | Base64-encoded release keystore: `base64 -w 0 release.keystore` |
+| `KEYSTORE_PASSWORD` | Password for the keystore |
+| `KEY_ALIAS` | Key alias inside the keystore (e.g. `release`) |
+| `KEY_PASSWORD` | Password for the key |
+| `GOOGLE_PLAY_JSON_KEY` | Base64-encoded Google Play service account JSON: `base64 -w 0 play-key.json` |
+
+> The Google Play service account needs the **Release manager** role (or at minimum
+> the **Releases** permission) in Google Play Console.
+
+### Track promotion flow
+
+```
+internal  →  beta  →  production
+```
+
+- **internal**: new AAB is uploaded and assigned to internal testers
+- **beta** / **production**: the existing internal build is _promoted_ — no new
+  AAB is built or uploaded
+
+### Step 1 — Upload a new build to internal testing
+
+Push a tag following the `vX.Y.Z` format. The workflow triggers automatically:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow will:
+
+1. Build a signed AAB
+2. Set `versionName=1.2.3` and `versionCode=10203` (computed as
+   `MAJOR×10000 + MINOR×100 + PATCH`)
+3. Upload the AAB to the **internal** track on Google Play
+
+### Step 2 — Promote to closed beta
+
+Once the internal build has been reviewed and approved, go to
+GitHub → Actions → Android Publish → Run workflow.
+
+Select track: `beta`, then click _Run workflow_.
+
+Fastlane will promote the current internal build to the **beta** (closed
+testing) track without re-uploading the AAB.
+
+### Step 3 — Promote to production
+
+When the beta build is ready for general availability, go to
+GitHub → Actions → Android Publish → Run workflow.
+
+Select track: `production`, then click _Run workflow_.
+
+Fastlane promotes the beta build to production with an initial 10% rollout
+(`rollout: "0.1"`). Full rollout can be managed from the Google Play Console.
 
 ---
 

--- a/android/README.md
+++ b/android/README.md
@@ -186,6 +186,84 @@ The resulting AAB is at `app/build/outputs/bundle/release/app-release.aab`.
 Publishing is fully automated via GitHub Actions
 (`.github/workflows/android-publish.yml`) and Fastlane.
 
+> **Before the automated workflow can run**, you must complete the one-time
+> Play Console setup described below. Fastlane can only upload builds to an
+> _existing_ app — it cannot create one.
+
+### One-time Play Console setup
+
+These steps must be done once by a human with a Google Play developer account.
+
+#### 1. Create the app in Play Console
+
+1. Go to [play.google.com/console](https://play.google.com/console) and sign
+   in with the developer account.
+2. Click **Create app**.
+3. Fill in the required fields: app name, default language, app/game type,
+   free/paid status.
+4. Accept the content guidelines and US export laws declarations.
+5. Click **Create app**.
+
+#### 2. Complete the Store listing
+
+Most metadata is already prepared under
+`android/fastlane/metadata/android/en-US/` and will be uploaded automatically
+by Fastlane. However, Play Console requires you to fill in at least the
+following before a build can be published:
+
+- Short description and full description
+- App icon (512×512 PNG)
+- Feature graphic (1024×500 PNG)
+- At least two phone screenshots
+- Privacy policy URL
+
+These assets are in `android/fastlane/metadata/android/en-US/images/`.
+
+#### 3. Complete mandatory app content declarations
+
+In Play Console, under **Policy → App content**, complete:
+
+- **Privacy policy** — provide a URL to your privacy policy
+- **Content rating** — complete the IARC questionnaire
+- **Target audience** — specify target age group
+- **News apps** — confirm whether the app is a news app
+
+#### 4. Set up a Google Play service account for Fastlane
+
+This allows Fastlane (and the CI workflow) to upload builds via the API.
+
+1. In Play Console, go to **Setup → API access**.
+2. Link your Play Console to a Google Cloud project (create one if needed).
+3. Click **Create new service account** → follow the link to Google Cloud
+   Console.
+4. In Google Cloud Console:
+   - Create a service account (e.g. `fastlane-deploy`)
+   - Grant it no Cloud IAM roles (permissions are managed in Play Console)
+   - Create a JSON key and download it
+5. Back in Play Console, click **Grant access** next to the new service account.
+6. Assign the **Release manager** role (or at minimum the **Releases**
+   permission under a custom role).
+7. Base64-encode the JSON key and store it as the `GOOGLE_PLAY_JSON_KEY`
+   GitHub secret:
+
+```bash
+base64 -w 0 play-key.json
+```
+
+#### 5. Upload the first build manually
+
+Google Play requires at least one build to be uploaded manually via the Play
+Console UI before the API (and therefore Fastlane) can be used.
+
+1. Build a signed AAB locally (see [Signing a release build](#signing-a-release-build)).
+2. In Play Console, go to **Testing → Internal testing → Create new release**.
+3. Upload the `.aab` file, add release notes, and save the release.
+
+After this first manual upload, all subsequent releases can be fully automated
+by pushing a `vX.Y.Z` tag.
+
+---
+
 ### Required GitHub secrets
 
 These must be set under **Settings → Secrets and variables → Actions** in the

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,21 +17,25 @@ android {
     fun gradleProp(name: String, default: String): String =
         (project.findProperty(name) as String?)?.takeIf { it.isNotBlank() } ?: default
 
+    // Resolve release signing inputs once, treating blanks as absent.
+    val releaseKeystorePath = (System.getenv("KEYSTORE_PATH")
+        ?: (project.findProperty("KEYSTORE_PATH") as String?))?.takeIf { it.isNotBlank() }
+    val releaseKeystorePassword = (System.getenv("KEYSTORE_PASSWORD")
+        ?: (project.findProperty("KEYSTORE_PASSWORD") as String?))?.takeIf { it.isNotBlank() }
+    val releaseKeyAlias = (System.getenv("KEY_ALIAS")
+        ?: (project.findProperty("KEY_ALIAS") as String?))?.takeIf { it.isNotBlank() } ?: "release"
+    val releaseKeyPassword = (System.getenv("KEY_PASSWORD")
+        ?: (project.findProperty("KEY_PASSWORD") as String?))?.takeIf { it.isNotBlank() }
+    val releaseSigningConfigured =
+        releaseKeystorePath != null && releaseKeystorePassword != null && releaseKeyPassword != null
+
     signingConfigs {
-        create("release") {
-            val keystorePath = System.getenv("KEYSTORE_PATH")
-                ?: (project.findProperty("KEYSTORE_PATH") as String?)
-            val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
-                ?: (project.findProperty("KEYSTORE_PASSWORD") as String?)
-            val keyAlias = System.getenv("KEY_ALIAS")
-                ?: (project.findProperty("KEY_ALIAS") as String?) ?: "release"
-            val keyPassword = System.getenv("KEY_PASSWORD")
-                ?: (project.findProperty("KEY_PASSWORD") as String?)
-            if (keystorePath != null && keystorePassword != null && keyPassword != null) {
-                storeFile = file(keystorePath)
-                storePassword = keystorePassword
-                this.keyAlias = keyAlias
-                this.keyPassword = keyPassword
+        if (releaseSigningConfigured) {
+            create("release") {
+                storeFile = file(releaseKeystorePath!!)
+                storePassword = releaseKeystorePassword
+                this.keyAlias = releaseKeyAlias
+                this.keyPassword = releaseKeyPassword
             }
         }
     }
@@ -64,7 +68,30 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-            signingConfig = signingConfigs.getByName("release")
+            if (releaseSigningConfigured) {
+                signingConfig = signingConfigs.getByName("release")
+            } else {
+                // Fail only when a release signing task is actually requested, so non-signing
+                // tasks (assembleDebug, lint, unit tests, ./gradlew tasks) keep working.
+                gradle.taskGraph.whenReady {
+                    val needsSigning = allTasks.any { task ->
+                        task.project.path == project.path &&
+                            (task.name == "signReleaseBundle" ||
+                                task.name == "packageReleaseBundle" ||
+                                task.name == "signReleaseApk" ||
+                                task.name == "packageRelease" ||
+                                task.name == "bundleRelease" ||
+                                task.name == "assembleRelease")
+                    }
+                    if (needsSigning) {
+                        throw GradleException(
+                            "Release signing is not configured. Set KEYSTORE_PATH, KEYSTORE_PASSWORD, " +
+                                "KEY_ALIAS and KEY_PASSWORD (env vars or Gradle properties) before " +
+                                "running release tasks (e.g. bundleRelease)."
+                        )
+                    }
+                }
+            }
             // BASE_URL injected via CI — override with -PbaseUrl=... or env var
             buildConfigField("String", "BASE_URL", "\"${gradleProp("baseUrl", "https://api.voxquieta.org/")}\"")
             // Firebase is enabled only in release builds.


### PR DESCRIPTION
## Summary

### Bug fix — `android-publish.yml` version grep

The `grep -oP '[\d.]+'` pattern matched bare dots inside the Kotlin property name (e.g. `project.findProperty("versionName")`) before matching `1.0.0`, producing a two-line `VERSION_NAME`. The second line (`1.0.0`) was written as a raw line to `$GITHUB_OUTPUT`, causing:

```
Error: Invalid format '1.0.0'
```

**Fix:** use `grep -oP '[0-9]+\.[0-9]+\.[0-9]+'` so only a proper `X.Y.Z` version string is matched.

### Refactor — `build.gradle.kts` signing config

- Resolve all signing inputs once (outside `signingConfigs`) so the block reads cleanly
- Skip creating the `release` signing config entirely when signing inputs are absent, instead of silently creating an empty one
- Guard release tasks via `gradle.taskGraph.whenReady` with a descriptive `GradleException` if signing is not configured — avoids cryptic build failures on developer machines

### Docs — Play Store publishing process

Added a **"Publishing to the Play Store"** section to `android/README.md` covering:
- Required GitHub secrets and how to encode them (`base64 -w 0`)
- Track promotion flow: `internal → beta → production`
- Step-by-step instructions for each stage