### PR TITLE
feat(frontend): surface privacy policy and terms of service pages

### DIFF
--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "استلهم يومياً من كلمة الله"
+  },
+  "Legal": {
+    "privacyTitle": "سياسة الخصوصية",
+    "privacyDescription": "تعرّف على كيفية جمع Vox Quieta لبياناتك واستخدامها.",
+    "termsTitle": "شروط الخدمة",
+    "termsDescription": "شروط وأحكام استخدام Vox Quieta.",
+    "lastUpdated": "آخر تحديث: {date}",
+    "navPrivacy": "الخصوصية",
+    "navTerms": "الشروط"
   }
 }

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Lass dich täglich von Gottes Wort inspirieren"
+  },
+  "Legal": {
+    "privacyTitle": "Datenschutzrichtlinie",
+    "privacyDescription": "Erfahren Sie, wie Vox Quieta Ihre Daten erfasst und verwendet.",
+    "termsTitle": "Nutzungsbedingungen",
+    "termsDescription": "Nutzungsbedingungen für Vox Quieta.",
+    "lastUpdated": "Zuletzt aktualisiert: {date}",
+    "navPrivacy": "Datenschutz",
+    "navTerms": "Nutzungsbedingungen"
   }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Get inspired daily by God's Word"
+  },
+  "Legal": {
+    "privacyTitle": "Privacy Policy",
+    "privacyDescription": "Learn how Vox Quieta collects and uses your data.",
+    "termsTitle": "Terms of Service",
+    "termsDescription": "Terms and conditions for using Vox Quieta.",
+    "lastUpdated": "Last updated: {date}",
+    "navPrivacy": "Privacy",
+    "navTerms": "Terms"
   }
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Inspírate cada día con la Palabra de Dios"
+  },
+  "Legal": {
+    "privacyTitle": "Política de Privacidad",
+    "privacyDescription": "Conoce cómo Vox Quieta recopila y utiliza tus datos.",
+    "termsTitle": "Términos de Servicio",
+    "termsDescription": "Términos y condiciones para el uso de Vox Quieta.",
+    "lastUpdated": "Última actualización: {date}",
+    "navPrivacy": "Privacidad",
+    "navTerms": "Términos"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Laisse-toi inspirer chaque jour par la Parole de Dieu"
+  },
+  "Legal": {
+    "privacyTitle": "Politique de Confidentialité",
+    "privacyDescription": "Découvrez comment Vox Quieta collecte et utilise vos données.",
+    "termsTitle": "Conditions d'Utilisation",
+    "termsDescription": "Conditions générales d'utilisation de Vox Quieta.",
+    "lastUpdated": "Dernière mise à jour : {date}",
+    "navPrivacy": "Confidentialité",
+    "navTerms": "Conditions"
   }
 }

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "परमेश्वर के वचन से हर दिन प्रेरित हों"
+  },
+  "Legal": {
+    "privacyTitle": "गोपनीयता नीति",
+    "privacyDescription": "जानें कि Vox Quieta आपका डेटा कैसे एकत्र और उपयोग करता है।",
+    "termsTitle": "सेवा की शर्तें",
+    "termsDescription": "Vox Quieta के उपयोग के लिए नियम और शर्तें।",
+    "lastUpdated": "अंतिम अपडेट: {date}",
+    "navPrivacy": "गोपनीयता",
+    "navTerms": "शर्तें"
   }
 }

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Lasciati ispirare ogni giorno dalla Parola di Dio"
+  },
+  "Legal": {
+    "privacyTitle": "Informativa sulla Privacy",
+    "privacyDescription": "Scopri come Vox Quieta raccoglie e utilizza i tuoi dati.",
+    "termsTitle": "Termini di Servizio",
+    "termsDescription": "Termini e condizioni per l'utilizzo di Vox Quieta.",
+    "lastUpdated": "Ultimo aggiornamento: {date}",
+    "navPrivacy": "Privacy",
+    "navTerms": "Termini"
   }
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "매일 하나님의 말씀에서 영감을 받으세요"
+  },
+  "Legal": {
+    "privacyTitle": "개인정보 처리방침",
+    "privacyDescription": "Vox Quieta가 귀하의 데이터를 수집하고 사용하는 방법을 알아보세요.",
+    "termsTitle": "서비스 약관",
+    "termsDescription": "Vox Quieta 이용약관 및 조건.",
+    "lastUpdated": "최종 업데이트: {date}",
+    "navPrivacy": "개인정보",
+    "navTerms": "약관"
   }
 }

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Inspire-se diariamente pela Palavra de Deus"
+  },
+  "Legal": {
+    "privacyTitle": "Política de Privacidade",
+    "privacyDescription": "Saiba como a Vox Quieta coleta e usa seus dados.",
+    "termsTitle": "Termos de Serviço",
+    "termsDescription": "Termos e condições para uso da Vox Quieta.",
+    "lastUpdated": "Última atualização: {date}",
+    "navPrivacy": "Privacidade",
+    "navTerms": "Termos"
   }
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "Вдохновляйся каждый день Словом Божьим"
+  },
+  "Legal": {
+    "privacyTitle": "Политика конфиденциальности",
+    "privacyDescription": "Узнайте, как Vox Quieta собирает и использует ваши данные.",
+    "termsTitle": "Условия использования",
+    "termsDescription": "Условия и положения использования Vox Quieta.",
+    "lastUpdated": "Последнее обновление: {date}",
+    "navPrivacy": "Конфиденциальность",
+    "navTerms": "Условия"
   }
 }

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -224,5 +224,14 @@
   "Splash": {
     "title": "Vox Quieta",
     "motto": "每天从上帝的话语中获得灵感"
+  },
+  "Legal": {
+    "privacyTitle": "隐私政策",
+    "privacyDescription": "了解 Vox Quieta 如何收集和使用您的数据。",
+    "termsTitle": "服务条款",
+    "termsDescription": "使用 Vox Quieta 的条款和条件。",
+    "lastUpdated": "最后更新：{date}",
+    "navPrivacy": "隐私",
+    "navTerms": "条款"
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "next-intl": "^4.9.1",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "react-markdown": "^9.0.1"
+        "react-markdown": "^9.0.1",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -5722,6 +5723,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5730,8 +5732,7 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      },
-      "dev": true
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -7024,6 +7025,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7032,6 +7043,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -7052,6 +7091,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7264,6 +7404,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -7905,6 +8166,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -8792,6 +9064,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -8819,6 +9109,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10729,17 +11034,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "next-intl": "^4.9.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-markdown": "^9.0.1"
+    "react-markdown": "^9.0.1",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { hasLocale } from "next-intl";
 import { routing } from "@/i18n/routing";
 import { Providers } from "./providers";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import Footer from "@/components/Footer";
 
 export async function generateMetadata({
   params,
@@ -95,8 +96,9 @@ export default async function LocaleLayout({
         <NextIntlClientProvider messages={messages}>
           <Providers>
             <ErrorBoundary>
-              <div className="min-h-screen bg-gradient-to-b from-primary-50 to-white">
-                {children}
+              <div className="min-h-screen bg-gradient-to-b from-primary-50 to-white flex flex-col">
+                <div className="flex-1">{children}</div>
+                <Footer />
               </div>
             </ErrorBoundary>
           </Providers>

--- a/frontend/src/app/[locale]/privacy/page.tsx
+++ b/frontend/src/app/[locale]/privacy/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { getLegalDocContent, getLegalDocDate } from "@/lib/legalDocs";
+import { routing } from "@/i18n/routing";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Legal" });
+
+  return {
+    title: t("privacyTitle"),
+    description: t("privacyDescription"),
+  };
+}
+
+export default async function PrivacyPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations({ locale, namespace: "Legal" });
+  const content = getLegalDocContent("privacy-policy", locale);
+  const lastUpdatedDate = getLegalDocDate("privacy-policy");
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(lastUpdatedDate);
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold text-primary-900 mb-2">
+        {t("privacyTitle")}
+      </h1>
+      <p className="text-sm text-gray-500 mb-8">
+        {t("lastUpdated", { date: formattedDate })}
+      </p>
+      <article className="prose prose-slate max-w-none">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </article>
+    </main>
+  );
+}

--- a/frontend/src/app/[locale]/terms/page.tsx
+++ b/frontend/src/app/[locale]/terms/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { getLegalDocContent, getLegalDocDate } from "@/lib/legalDocs";
+import { routing } from "@/i18n/routing";
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Legal" });
+
+  return {
+    title: t("termsTitle"),
+    description: t("termsDescription"),
+  };
+}
+
+export default async function TermsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations({ locale, namespace: "Legal" });
+  const content = getLegalDocContent("terms-of-service", locale);
+  const lastUpdatedDate = getLegalDocDate("terms-of-service");
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(lastUpdatedDate);
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-12">
+      <h1 className="text-3xl font-bold text-primary-900 mb-2">
+        {t("termsTitle")}
+      </h1>
+      <p className="text-sm text-gray-500 mb-8">
+        {t("lastUpdated", { date: formattedDate })}
+      </p>
+      <article className="prose prose-slate max-w-none">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </article>
+    </main>
+  );
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,25 @@
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+
+export default function Footer() {
+  const t = useTranslations("Legal");
+
+  return (
+    <footer className="border-t border-gray-200 bg-white py-6 mt-8">
+      <div className="max-w-3xl mx-auto px-4 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-500">
+        <Link
+          href="/privacy"
+          className="hover:text-primary-700 transition-colors"
+        >
+          {t("navPrivacy")}
+        </Link>
+        <Link
+          href="/terms"
+          className="hover:text-primary-700 transition-colors"
+        >
+          {t("navTerms")}
+        </Link>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/lib/legalDocs.ts
+++ b/frontend/src/lib/legalDocs.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { execSync } from "child_process";
+
+// Docs directory is one level above the Next.js project root (frontend/)
+const docsDir = join(process.cwd(), "..", "docs");
+
+/**
+ * Returns the content of a legal markdown document.
+ * Looks for a locale-specific file first (e.g. privacy-policy.it.md),
+ * then falls back to the base file (privacy-policy.md).
+ */
+export function getLegalDocContent(basename: string, locale: string): string {
+  const localePath = join(docsDir, `${basename}.${locale}.md`);
+  const defaultPath = join(docsDir, `${basename}.md`);
+
+  const filePath = existsSync(localePath) ? localePath : defaultPath;
+
+  if (!existsSync(filePath)) {
+    return `# Document not found\n\nThe requested document (${basename}) could not be found.`;
+  }
+
+  return readFileSync(filePath, "utf-8");
+}
+
+/**
+ * Returns the last git commit date for a legal markdown document.
+ * Falls back to the file's mtime if git is unavailable.
+ */
+export function getLegalDocDate(basename: string): Date {
+  const filePath = join(docsDir, `${basename}.md`);
+
+  try {
+    const output = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
+      encoding: "utf-8",
+      cwd: join(process.cwd(), ".."),
+    }).trim();
+    if (output) return new Date(output);
+  } catch {
+    // ignore — fall through to mtime
+  }
+
+  if (existsSync(filePath)) {
+    return statSync(filePath).mtime;
+  }
+
+  return new Date();
+}

--- a/frontend/src/test/legal-pages.test.tsx
+++ b/frontend/src/test/legal-pages.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import enMessages from "../../messages/en.json";
+
+// Mock next-intl server functions used in server components
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn().mockImplementation(({ namespace }) => {
+    const ns = enMessages[namespace as keyof typeof enMessages] as Record<
+      string,
+      string
+    >;
+    return Promise.resolve((key: string, params?: Record<string, string>) => {
+      let value = ns?.[key] ?? key;
+      if (params) {
+        Object.entries(params).forEach(([k, v]) => {
+          value = value.replace(`{${k}}`, v);
+        });
+      }
+      return value;
+    });
+  }),
+  setRequestLocale: vi.fn(),
+}));
+
+// Mock legalDocs to avoid fs/git calls in tests
+vi.mock("@/lib/legalDocs", () => ({
+  getLegalDocContent: vi.fn(
+    (basename: string) =>
+      `# ${basename === "privacy-policy" ? "Privacy Policy" : "Terms of Service"}\n\nTest content.`,
+  ),
+  getLegalDocDate: vi.fn(() => new Date("2026-04-20")),
+}));
+
+// Mock remark-gfm
+vi.mock("remark-gfm", () => ({ default: () => {} }));
+
+// Mock react-markdown to render children as plain text
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
+
+// Mock next-intl navigation
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// Minimal wrapper to provide intl context
+function IntlWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+
+describe("Privacy page", () => {
+  it("renders the Privacy Policy heading from i18n", async () => {
+    const { default: PrivacyPage } =
+      await import("@/app/[locale]/privacy/page");
+    const jsx = await PrivacyPage({
+      params: Promise.resolve({ locale: "en" }),
+    });
+    render(<IntlWrapper>{jsx}</IntlWrapper>);
+    expect(
+      screen.getByRole("heading", { name: /privacy policy/i }),
+    ).toBeTruthy();
+  });
+});
+
+describe("Terms page", () => {
+  it("renders the Terms of Service heading from i18n", async () => {
+    const { default: TermsPage } = await import("@/app/[locale]/terms/page");
+    const jsx = await TermsPage({ params: Promise.resolve({ locale: "en" }) });
+    render(<IntlWrapper>{jsx}</IntlWrapper>);
+    expect(
+      screen.getByRole("heading", { name: /terms of service/i }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `docs/privacy-policy.md` and `docs/terms-of-service.md` as localized Next.js App Router pages, with footer links and full i18n support across all 11 locales.

## What changed

### New routes
- `/[locale]/privacy` — Privacy Policy page (SSG, 11 locale variants)
- `/[locale]/terms` — Terms of Service page (SSG, 11 locale variants)

### New files
| File | Purpose |
|------|---------|
| `frontend/src/lib/legalDocs.ts` | Server-side helper: locale-aware markdown file resolution with English fallback; git-log last-updated date with mtime fallback |
| `frontend/src/app/[locale]/privacy/page.tsx` | Privacy Policy server component with `generateMetadata` and `generateStaticParams` |
| `frontend/src/app/[locale]/terms/page.tsx` | Terms of Service server component with `generateMetadata` and `generateStaticParams` |
| `frontend/src/components/Footer.tsx` | Minimal footer with locale-aware Privacy and Terms links |
| `frontend/src/test/legal-pages.test.tsx` | Vitest smoke tests (2 tests — one per page) |

### Modified files
- `frontend/src/app/[locale]/layout.tsx` — Adds `<Footer />` inside a flex column wrapper; existing `{children}` moved to `flex-1` div
- `frontend/messages/*.json` (all 11 locales) — Added `Legal` namespace
- `frontend/package.json` — Added `remark-gfm ^4.0.1` (react-markdown was already present at v9)
- `frontend/package-lock.json` — Regenerated with Node 20.19.4 / npm 10.8.2 (closest available; CI target is Node 22 / npm 10.9.7; both produce lockfileVersion 3 — no format difference expected)

## i18n approach

- All UI strings live in a new `Legal` namespace (PascalCase, matching project convention) in each locale file.
- Keys: `privacyTitle`, `privacyDescription`, `termsTitle`, `termsDescription`, `lastUpdated` (with `{date}` placeholder), `navPrivacy`, `navTerms`.
- The `lastUpdated` value is formatted via `Intl.DateTimeFormat(locale, { year, month, day })` so dates render in the reader's native calendar format.

## Per-locale fallback

`getLegalDocContent(basename, locale)` checks for `docs/..md` first, then falls back to `docs/.md`. No locale-specific files exist today so English is always served, but the mechanism is ready.

## Markdown rendering

`react-markdown` (already in `dependencies`) renders on the server. `remark-gfm` adds GitHub Flavored Markdown support (autolinks, strikethrough, tables). Raw HTML is **not** enabled, so the output is XSS-safe.

## Translations — confidence notes

All translations were produced from first principles. High-confidence: **it, de, es, fr, pt, ru, zh** (widely documented standard legal phrasing). Lower-confidence (flag for native-speaker review):

- **ar** — Standard Arabic legal phrasing used; RTL layout is handled by the existing `dir=rtl` on `<html>` for Arabic locale. **⚠️ Recommend review by a native Arabic speaker.**
- **hi** — Standard Hindi used; `{date}` placeholder position follows Hindi sentence order. **⚠️ Recommend review by a native Hindi speaker.**
- **ko** — Standard Korean terms used. **⚠️ Recommend review by a native Korean speaker.**

## Quality gates (all passed locally)

| Gate | Result |
|------|--------|
| `npm run lint` | ✅ 0 errors (2 pre-existing warnings in `turnstile.tsx`) |
| `npx tsc --noEmit` | ✅ No errors |
| `npx vitest run` | ✅ 471/471 tests pass |
| `npm run build` | ✅ 36 static pages generated (including 11×2 legal routes) |
| pre-commit hooks | ✅ All passed (Prettier auto-fixed test file) |

## Pre-existing issues (not introduced by this PR)

The 2 lint warnings in `frontend/src/lib/turnstile.tsx` (`react-hooks/exhaustive-deps`) were present on `main` before this PR.

## Testing

`frontend/src/test/legal-pages.test.tsx` — smoke tests that both pages render their i18n headings correctly, with fs/git calls and react-markdown mocked.