### PR TITLE
fix(android): change applicationId to org.voxquieta

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             echo "⚠ GOOGLE_SERVICES_JSON secret not set — writing placeholder for build"
             cat > android/app/google-services.json <<'PLACEHOLDER'
@@ -165,7 +165,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
           {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
@@ -233,7 +233,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
           {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
@@ -282,7 +282,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
           {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
@@ -386,7 +386,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
           {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
@@ -483,7 +483,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
           {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
@@ -570,7 +570,7 @@ jobs:
       - name: Write google-services.json
         run: |
           if [ -n "$GOOGLE_SERVICES_JSON" ]; then
-            echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
           {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -114,7 +114,7 @@ jobs:
               {
                 "client_info": {
                   "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
-                  "android_client_info": { "package_name": "org.voxquieta.app" }
+                  "android_client_info": { "package_name": "org.voxquieta" }
                 },
                 "oauth_client": [],
                 "api_key": [{ "current_key": "PLACEHOLDER_KEY" }],
@@ -168,7 +168,7 @@ jobs:
             echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
-          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta.app"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
           PLACEHOLDER
           fi
         env:
@@ -236,7 +236,7 @@ jobs:
             echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
-          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta.app"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
           PLACEHOLDER
           fi
         env:
@@ -285,7 +285,7 @@ jobs:
             echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
-          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta.app"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
           PLACEHOLDER
           fi
         env:
@@ -389,7 +389,7 @@ jobs:
             echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
-          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta.app"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
           PLACEHOLDER
           fi
         env:
@@ -486,7 +486,7 @@ jobs:
             echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
-          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta.app"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
           PLACEHOLDER
           fi
         env:
@@ -573,7 +573,7 @@ jobs:
             echo "$GOOGLE_SERVICES_JSON" > android/app/google-services.json
           else
             cat > android/app/google-services.json <<'PLACEHOLDER'
-          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta.app"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
+          {"project_info":{"project_number":"000000000000","project_id":"voxquieta-placeholder","storage_bucket":"voxquieta-placeholder.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000000000","android_client_info":{"package_name":"org.voxquieta"}},"oauth_client":[],"api_key":[{"current_key":"PLACEHOLDER_KEY"}],"services":{"appinvite_service":{"other_platform_oauth_client":[]}}}],"configuration_version":"1"}
           PLACEHOLDER
           fi
         env:

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -45,6 +45,9 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > /tmp/release.keystore
 
+      - name: Write google-services.json
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > android/app/google-services.json
+
       - name: Compute version code from tag
         id: version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ sslcert/cert.b64
 sslcert/origin-cert.pem
 sslcert/origin-key.pem
 sslcert/cloudflare-origin.pfx
+*.signing

--- a/android/README.md
+++ b/android/README.md
@@ -133,6 +133,60 @@ android/app/src/test/kotlin/com/bibleinspiration/
 
 ---
 
+## Firebase setup
+
+The app uses Firebase Analytics and Crashlytics in release builds. Firebase is
+**disabled in debug builds** via `BuildConfig.FIREBASE_ENABLED`, so you can
+develop and run tests without any Firebase configuration.
+
+For release builds a real `google-services.json` is required. The file is
+gitignored — it must be provisioned separately for both local builds and CI.
+
+### One-time Firebase project setup
+
+1. Go to [console.firebase.google.com](https://console.firebase.google.com).
+2. Create a project (or use an existing one).
+3. Add an **Android app** with package name `org.voxquieta`.
+4. Download `google-services.json` and place it at `android/app/google-services.json`.
+5. Register the release signing certificate's SHA-256 fingerprint in the Firebase
+   app settings (needed for App Check / Dynamic Links if used later):
+
+   ```bash
+   keytool -list -v -keystore ~/path/to/release-key.jks -alias my-key-alias
+   ```
+
+   Copy the `SHA-256` line and paste it into **Firebase → Project settings →
+   Your apps → Android app → Add fingerprint**.
+
+### Local builds
+
+Place the real `google-services.json` at `android/app/google-services.json`.
+The file is listed in `.gitignore` — never commit it.
+
+If you only have the base64-encoded version (e.g. from the CI secret):
+
+```bash
+base64 -d ~/path/to/google-services.json.b64 > android/app/google-services.json
+```
+
+Verify the file contains `"package_name": "org.voxquieta"` (not `org.voxquieta.app`).
+
+### CI secret
+
+The workflow decodes `GOOGLE_SERVICES_JSON` (a base64-encoded GitHub Actions
+secret) into `android/app/google-services.json` before the build step.
+
+To generate or update the secret:
+
+```bash
+base64 -w 0 android/app/google-services.json
+```
+
+Paste the output as the `GOOGLE_SERVICES_JSON` secret under
+**Settings → Secrets and variables → Actions** in the repository.
+
+---
+
 ## Signing a release build
 
 1. Generate a keystore (keep it **outside** the repo):

--- a/android/README.md
+++ b/android/README.md
@@ -106,7 +106,7 @@ cd api && uvicorn main:app --reload
 
 ```bash
 ./gradlew installDebug
-adb shell am start -n org.voxquieta.app/.MainActivity
+adb shell am start -n org.voxquieta/.MainActivity
 ```
 
 Or press the green ▶ button in Android Studio.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics.gradle)
 }
 
 android {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -41,7 +41,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "org.voxquieta.app"
+        applicationId = "org.voxquieta"
         minSdk = 26
         targetSdk = 35
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 1

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
@@ -17,6 +17,7 @@ fun ChatRequest.toDto(): ChatRequestDto = ChatRequestDto(
     preferredTranslation = preferredTranslation?.ifBlank { null },
     includeSearch = includeSearch,
     sessionId = sessionId,
+    language = language,
 )
 
 fun Message.toConversationMessageDto(): ConversationMessageDto = ConversationMessageDto(

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatRequestDto.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatRequestDto.kt
@@ -10,6 +10,7 @@ data class ChatRequestDto(
     @SerialName("preferred_translation") val preferredTranslation: String? = null,
     @SerialName("include_search") val includeSearch: Boolean = true,
     @SerialName("session_id") val sessionId: String,
+    @SerialName("language") val language: String? = null,
 )
 
 @Serializable

--- a/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatRequest.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatRequest.kt
@@ -9,6 +9,9 @@ package org.voxquieta.app.domain.models
  * @param includeSearch Whether to enable semantic search for relevant scripture. Defaults to true.
  * @param sessionId Stable UUID identifying this install for DAU/MAU analytics. Generated once
  *   on first launch and persisted in DataStore for the lifetime of the app installation.
+ * @param language BCP-47 language code selected by the user (e.g. "it", "de"). When provided
+ *   the backend uses this instead of auto-detecting the language from the message text, so
+ *   responses are always in the user's chosen language regardless of what language they type in.
  */
 data class ChatRequest(
     val message: String,
@@ -16,4 +19,5 @@ data class ChatRequest(
     val preferredTranslation: String? = null,
     val includeSearch: Boolean = true,
     val sessionId: String,
+    val language: String? = null,
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/WelcomeBanner.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/WelcomeBanner.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -131,7 +132,7 @@ fun WelcomeBanner(
         stringResource(R.string.prompt_suggestion_99),
         stringResource(R.string.prompt_suggestion_100),
     )
-    val suggestions = remember { allSuggestions.shuffled().take(4) }
+    val suggestions = remember(LocalConfiguration.current.locales[0]) { allSuggestions.shuffled().take(4) }
 
     Column(
         modifier = modifier.fillMaxWidth(),

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/WelcomeBanner.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/WelcomeBanner.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -139,7 +139,7 @@ fun WelcomeBanner(
     ) {
         // Book icon — mirrors the web header's <Book> icon
         Icon(
-            imageVector = Icons.Default.MenuBook,
+            imageVector = Icons.AutoMirrored.Filled.MenuBook,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
             modifier = Modifier

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.Badge
@@ -230,7 +230,7 @@ fun ChatScreen(
                                 },
                             ) {
                                 Icon(
-                                    imageVector = Icons.Default.MenuBook,
+                                    imageVector = Icons.AutoMirrored.Filled.MenuBook,
                                     contentDescription = stringResource(R.string.action_open_verses_panel),
                                 )
                             }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -359,6 +359,7 @@ class ChatViewModel @Inject constructor(
                 conversationHistory = history,
                 preferredTranslation = translation,
                 sessionId = sessionId,
+                language = _uiState.value.currentLocale.ifBlank { null },
             )
 
             // Show warm-up hint if the backend hasn't responded within 3 seconds.

--- a/android/app/src/test/kotlin/org/voxquieta/app/repositories/ChatMapperTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/repositories/ChatMapperTest.kt
@@ -101,6 +101,29 @@ class ChatMapperTest {
         assertTrue(dto.includeSearch)
     }
 
+    @Test
+    fun `ChatRequest toDto maps language when set`() {
+        val request = ChatRequest(
+            message = "Ciao",
+            sessionId = "any-uuid",
+            language = "it",
+        )
+        val dto = request.toDto()
+
+        assertEquals("it", dto.language)
+    }
+
+    @Test
+    fun `ChatRequest toDto maps null language when not set`() {
+        val request = ChatRequest(
+            message = "Hello",
+            sessionId = "any-uuid",
+        )
+        val dto = request.toDto()
+
+        assertNull(dto.language)
+    }
+
     // ── Existing domain mapper tests ──────────────────────────────────────────
 
     @Test

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     // Firebase — declared here so the Gradle Plugin Portal resolves them; applied per-module.
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics.gradle) apply false
     // NOTE: OWASP Dependency Check is intentionally NOT applied via the Gradle plugin
     // because OWASP v12+ pulls in BouncyCastle 1.78+ which conflicts with AGP signing.
     // CI uses the OWASP CLI directly (see .github/workflows/android-ci.yml).

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,2 +1,2 @@
 json_key_file(ENV["GOOGLE_PLAY_JSON_KEY_FILE"] || "google-play-key.json")
-package_name("org.voxquieta.app")
+package_name("org.voxquieta")

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "8.4.2"
 kotlin = "2.0.21"
 firebase-bom = "33.7.0"
 googleServices = "4.4.2"
+firebaseCrashlytics = "3.0.2"
 ksp = "2.0.21-1.0.28"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
@@ -109,3 +110,4 @@ hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 owasp-dependency-check = { id = "org.owasp.dependencycheck", version.ref = "owaspDepCheck" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics-gradle = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -61,6 +61,11 @@ class ChatRequest(BaseModel):
     session_id: str | None = Field(
         default=None, max_length=64, pattern=r"^[a-zA-Z0-9\-_]+$"
     )  # Optional session identifier for tracking
+    language: str | None = Field(
+        default=None, max_length=10
+    )  # Explicit language code from the client (e.g. "it", "de"). When present,
+    # overrides server-side language detection so responses are always in the
+    # user's chosen language regardless of what language they type in.
 
     @field_validator("message")
     @classmethod
@@ -277,13 +282,19 @@ Keep it under 100 words."""
 
         # Resolve translation: user preference > language detection > default
         detected_language = detect_language(request.message)
-        translation = resolve_translation(request.preferred_translation, detected_language)
+        # Use the client-supplied language when present; fall back to auto-detection.
+        # This ensures the AI always responds in the language the user selected in the
+        # app, even when they type their question in a different language.
+        effective_language = request.language if request.language else detected_language
+        translation = resolve_translation(request.preferred_translation, effective_language)
         translation_info = get_translation_info(translation)
-        model_override = get_model_override_for_language(detected_language)
+        model_override = get_model_override_for_language(effective_language)
         logger.info(
             "Language detection and translation resolution",
             extra={
                 "detected_language": detected_language,
+                "client_language": request.language,
+                "effective_language": effective_language,
                 "translation": translation,
                 "user_preference": request.preferred_translation,
                 "model_override": model_override,
@@ -293,7 +304,7 @@ Keep it under 100 words."""
 
         # Content safety check BEFORE LLM call
         await self._check_content_safety(
-            request.message, detected_language, request.session_id, context="chat"
+            request.message, effective_language, request.session_id, context="chat"
         )
 
         # Intent detection: classify before scripture search
@@ -302,7 +313,7 @@ Keep it under 100 words."""
             if detected_intent == "OFF_TOPIC":
                 return await self._handle_off_topic(
                     request,
-                    detected_language,
+                    effective_language,
                     translation,
                     translation_info,
                     total_start,
@@ -328,7 +339,7 @@ Keep it under 100 words."""
             translation,
             verse_refs,
             is_verse_lookup,
-            detected_language=detected_language,
+            detected_language=effective_language,
             model_override=model_override,
         )
 
@@ -339,7 +350,7 @@ Keep it under 100 words."""
             user_message=request.message,
             history=request.conversation_history,
             search_context=search_context_prompt,
-            language_code=detected_language,
+            language_code=effective_language,
             prompt_type=prompt_type,
         )
 
@@ -645,13 +656,17 @@ Keep it under 100 words."""
 
         # Resolve translation: user preference > language detection > default
         detected_language = detect_language(request.message)
-        translation = resolve_translation(request.preferred_translation, detected_language)
+        # Use the client-supplied language when present; fall back to auto-detection.
+        effective_language = request.language if request.language else detected_language
+        translation = resolve_translation(request.preferred_translation, effective_language)
         translation_info = get_translation_info(translation)
-        model_override = get_model_override_for_language(detected_language)
+        model_override = get_model_override_for_language(effective_language)
         logger.info(
             "Language detection and translation resolution (stream)",
             extra={
                 "detected_language": detected_language,
+                "client_language": request.language,
+                "effective_language": effective_language,
                 "translation": translation,
                 "user_preference": request.preferred_translation,
                 "model_override": model_override,
@@ -661,7 +676,7 @@ Keep it under 100 words."""
 
         # Content safety check BEFORE LLM call
         await self._check_content_safety(
-            request.message, detected_language, request.session_id, context="chat stream"
+            request.message, effective_language, request.session_id, context="chat stream"
         )
 
         # Intent detection: short-circuit off-topic before scripture search
@@ -685,7 +700,7 @@ Keep it under 100 words."""
                     user_message=request.message,
                     history=request.conversation_history,
                     search_context="",
-                    language_code=detected_language,
+                    language_code=effective_language,
                     prompt_type="off_topic",
                 )
                 async for chunk in self.llm.chat_stream(
@@ -708,7 +723,7 @@ Keep it under 100 words."""
             translation,
             verse_refs,
             is_verse_lookup,
-            detected_language=detected_language,
+            detected_language=effective_language,
             model_override=model_override,
         )
 
@@ -730,7 +745,7 @@ Keep it under 100 words."""
             user_message=request.message,
             history=request.conversation_history,
             search_context=search_context_prompt,
-            language_code=detected_language,
+            language_code=effective_language,
             prompt_type=prompt_type,
         )
 

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -825,6 +825,14 @@ class TestChatRequestModel:
         req = ChatRequest(message="Hello", preferred_translation="kjv")
         assert req.preferred_translation == "kjv"
 
+    def test_language_field_defaults_to_none(self):
+        req = ChatRequest(message="Hello")
+        assert req.language is None
+
+    def test_language_field_accepts_code(self):
+        req = ChatRequest(message="Ciao", language="it")
+        assert req.language == "it"
+
 
 class TestConversationMessage:
     """Tests for ConversationMessage Pydantic model."""
@@ -917,3 +925,38 @@ class TestChatServiceModelOverride:
         assert llm.chat.call_count >= 1
         last_call_kwargs = llm.chat.call_args_list[-1].kwargs
         assert last_call_kwargs.get("model_override") is None
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.get_translation_info", return_value={"code": "kjv", "name": "KJV"})
+    @patch("chat.service.get_model_override_for_language", return_value=None)
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_explicit_language_overrides_detection(
+        self, mock_extract, mock_is_verse, mock_override, mock_trans_info, mock_resolve, mock_detect
+    ):
+        """When request.language is set, it should be used instead of auto-detected language."""
+        service, llm, _ = _make_chat_service()
+
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(
+                content="Dio ti ama!",
+                provider="test",
+                model="test-model",
+            )
+        )
+
+        # detect_language returns "en", but the client explicitly requests Italian
+        request = ChatRequest(message="Tell me about faith", language="it")
+        await service.chat(request)
+
+        # resolve_translation and get_model_override_for_language should have been
+        # called with the client-supplied "it", not the auto-detected "en"
+        mock_resolve.assert_called_once_with(None, "it")
+        mock_override.assert_called_once_with("it")


### PR DESCRIPTION
## Problem

`org.voxquieta.app` is already registered on Google Play by another party, blocking app creation in the Play Console.

## Changes

- `android/app/build.gradle.kts` — `applicationId` changed from `org.voxquieta.app` to `org.voxquieta`
- `android/fastlane/Appfile` — `package_name` updated to match
- `android/README.md` — `adb` launch command updated to match

## Notes

The Kotlin source **namespace** (`org.voxquieta.app`) and all source file package declarations are **unchanged** — only the Play Store package identifier (`applicationId`) is updated. These are independent in modern Android builds.