### PR TITLE
feat(android): link privacy and terms to hosted web pages

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -42,6 +43,8 @@ import org.voxquieta.app.R
 import org.voxquieta.app.presentation.components.ContactFormBottomSheet
 import org.voxquieta.app.presentation.components.ContactFormState
 import org.voxquieta.app.presentation.viewmodels.ChatViewModel
+import org.voxquieta.app.utils.privacyUrl
+import org.voxquieta.app.utils.termsUrl
 
 /** Theme option shown in the settings section. */
 private data class ThemeOption(
@@ -67,6 +70,7 @@ fun SettingsScreen(
     val preferredTranslation by viewModel.preferredTranslation.collectAsState()
     val contactFormState by viewModel.contactFormState.collectAsState()
     val context = LocalContext.current
+    val currentLanguage = LocalConfiguration.current.locales[0].language
     var showContactSheet by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
@@ -209,13 +213,25 @@ fun SettingsScreen(
             }
             TextButton(
                 onClick = {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.PRIVACY_POLICY_URL))
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(privacyUrl(currentLanguage)))
                     context.startActivity(intent)
                 },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
                     text = stringResource(R.string.settings_privacy_policy),
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+            }
+            TextButton(
+                onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(termsUrl(currentLanguage)))
+                    context.startActivity(intent)
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_terms_of_service),
                     style = MaterialTheme.typography.bodyLarge,
                 )
             }

--- a/android/app/src/main/kotlin/org/voxquieta/app/utils/LegalUrls.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/utils/LegalUrls.kt
@@ -1,0 +1,32 @@
+package org.voxquieta.app.utils
+
+import org.voxquieta.app.BuildConfig
+
+/**
+ * Supported web locales for the voxquieta.org frontend.
+ * Sourced from frontend/src/i18n/routing.ts.
+ */
+private val SUPPORTED_WEB_LOCALES =
+    setOf("en", "it", "de", "es", "fr", "pt", "ar", "ru", "zh", "hi", "ko")
+
+/**
+ * Maps an Android BCP-47 language tag to the corresponding web locale segment.
+ *
+ * - Region tags are dropped (e.g. "en-US" → "en").
+ * - Chinese variants zh-Hans / zh-Hant both map to "zh".
+ * - Any code not in [SUPPORTED_WEB_LOCALES] falls back to "en".
+ */
+fun webLocaleFor(languageCode: String): String {
+    val base = languageCode.lowercase().split("-", "_").first()
+    return if (base in SUPPORTED_WEB_LOCALES) base else "en"
+}
+
+private fun frontendBase(base: String): String = base.trimEnd('/')
+
+/** Locale-aware Privacy Policy URL for the voxquieta.org web app. */
+fun privacyUrl(languageCode: String, base: String = BuildConfig.FRONTEND_URL): String =
+    "${frontendBase(base)}/${webLocaleFor(languageCode)}/privacy"
+
+/** Locale-aware Terms of Service URL for the voxquieta.org web app. */
+fun termsUrl(languageCode: String, base: String = BuildConfig.FRONTEND_URL): String =
+    "${frontendBase(base)}/${webLocaleFor(languageCode)}/terms"

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">حول</string>
     <string name="settings_version">الإصدار</string>
     <string name="settings_privacy_policy">سياسة الخصوصية</string>
+    <string name="settings_terms_of_service">شروط الخدمة</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">لقد أجريت 10 رسائل في هذه الجلسة! لماذا لا تأخذ استراحة وتستمتع بخليقة الله في الهواء الطلق؟ 🌳</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">Über</string>
     <string name="settings_version">Version</string>
     <string name="settings_privacy_policy">Datenschutzrichtlinie</string>
+    <string name="settings_terms_of_service">Nutzungsbedingungen</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">Du hast 10 Nachrichten in dieser Sitzung gehabt! Warum machst du nicht eine Pause und genießt Gottes Schöpfung draußen? 🌳</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">Acerca de</string>
     <string name="settings_version">Versión</string>
     <string name="settings_privacy_policy">Política de privacidad</string>
+    <string name="settings_terms_of_service">Términos de servicio</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">¡Has tenido 10 mensajes en esta sesión! ¿Por qué no tomar un descanso y disfrutar de la creación de Dios al aire libre? 🌳</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">À propos</string>
     <string name="settings_version">Version</string>
     <string name="settings_privacy_policy">Politique de confidentialité</string>
+    <string name="settings_terms_of_service">Conditions d\'utilisation</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">Vous avez eu 10 messages dans cette session ! Pourquoi ne pas faire une pause et profiter de la création de Dieu en plein air ? 🌳</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">के बारे में</string>
     <string name="settings_version">संस्करण</string>
     <string name="settings_privacy_policy">गोपनीयता नीति</string>
+    <string name="settings_terms_of_service">सेवा की शर्तें</string>
 
     <!-- Errors -->
     <string name="error_session_limit">इस सत्र में आपके 10 संदेश हो चुके हैं! क्यों न एक ब्रेक लें और परमेश्वर की सृष्टि का आनंद लें? 🌳</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">Informazioni</string>
     <string name="settings_version">Versione</string>
     <string name="settings_privacy_policy">Informativa sulla privacy</string>
+    <string name="settings_terms_of_service">Termini di servizio</string>
 
     <!-- Errors -->
     <string name="error_session_limit">Hai avuto 10 messaggi in questa sessione! Perché non fare una pausa e goderti il creato di Dio all\'aria aperta? 🌳</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">정보</string>
     <string name="settings_version">버전</string>
     <string name="settings_privacy_policy">개인정보 처리방침</string>
+    <string name="settings_terms_of_service">서비스 약관</string>
 
     <!-- Errors -->
     <string name="error_session_limit">이 세션에서 10개의 메시지를 보내셨습니다! 잠시 쉬면서 하나님의 창조물을 즐겨보시는 건 어떨까요? 🌳</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">Sobre</string>
     <string name="settings_version">Versão</string>
     <string name="settings_privacy_policy">Política de Privacidade</string>
+    <string name="settings_terms_of_service">Termos de Serviço</string>
 
     <!-- Errors -->
     <string name="error_session_limit">Você teve 10 mensagens nesta sessão! Que tal fazer uma pausa e apreciar a criação de Deus ao ar livre? 🌳</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">О приложении</string>
     <string name="settings_version">Версия</string>
     <string name="settings_privacy_policy">Политика конфиденциальности</string>
+    <string name="settings_terms_of_service">Условия обслуживания</string>
 
     <!-- Errors -->
     <string name="error_session_limit">У вас было 10 сообщений в этой сессии! Почему бы не сделать перерыв и не насладиться творением Божьим на природе? 🌳</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -145,6 +145,7 @@
     <string name="settings_about_title">关于</string>
     <string name="settings_version">版本</string>
     <string name="settings_privacy_policy">隐私政策</string>
+    <string name="settings_terms_of_service">服务条款</string>
 
     <!-- Errors -->
     <string name="error_session_limit">您在本次会话中已有10条消息！何不休息一下，欣赏上帝的创造？🌳</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="settings_about_title">About</string>
     <string name="settings_version">Version</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
+    <string name="settings_terms_of_service">Terms of Service</string>
 
     <!-- Offline notice -->
     <string name="offline_notice">You\'re offline. You can read past messages, but sending new ones requires an internet connection.</string>

--- a/android/app/src/test/kotlin/org/voxquieta/app/utils/LegalUrlsTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/utils/LegalUrlsTest.kt
@@ -1,0 +1,40 @@
+package org.voxquieta.app.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LegalUrlsTest {
+
+    private val base = "https://voxquieta.org"
+
+    @Test
+    fun `webLocaleFor strips region tag`() {
+        assertEquals("en", webLocaleFor("en-US"))
+        assertEquals("pt", webLocaleFor("pt_BR"))
+    }
+
+    @Test
+    fun `webLocaleFor maps chinese variants to zh`() {
+        assertEquals("zh", webLocaleFor("zh-Hans"))
+        assertEquals("zh", webLocaleFor("zh-Hant"))
+        assertEquals("zh", webLocaleFor("zh"))
+    }
+
+    @Test
+    fun `webLocaleFor falls back to en for unsupported`() {
+        assertEquals("en", webLocaleFor("ja"))
+        assertEquals("en", webLocaleFor("xx-YY"))
+        assertEquals("en", webLocaleFor(""))
+    }
+
+    @Test
+    fun `privacy and terms urls include locale segment`() {
+        assertEquals("$base/it/privacy", privacyUrl("it", base))
+        assertEquals("$base/de/terms", termsUrl("de-AT", base))
+    }
+
+    @Test
+    fun `trailing slash on base is normalized`() {
+        assertEquals("$base/en/privacy", privacyUrl("en-US", "$base/"))
+    }
+}


### PR DESCRIPTION
## Summary

Repoints Android Settings screen to the new locale-aware web-hosted
Privacy Policy and Terms of Service pages introduced in #471.

## Changes

- **`utils/LegalUrls.kt`** — new helper:
  - `webLocaleFor(languageCode)` maps Android BCP-47 tags to the 11
    supported web locales. Region/script tags are stripped
    (`en-US` → `en`, `zh-Hans`/`zh-Hant` → `zh`). Unsupported codes
    fall back to `en`.
  - `privacyUrl(lang)` / `termsUrl(lang)` build
    `\${BuildConfig.FRONTEND_URL}/<locale>/privacy` and `…/terms`.
- **`SettingsScreen.kt`** — uses `LocalConfiguration.current.locales[0].language`
  to drive the helpers. New "Terms of Service" entry added next to the
  existing "Privacy Policy" entry.
- **String resources** — added `settings_terms_of_service` to
  `values/strings.xml` and all 10 locale files to satisfy the
  translation-validation CI job.
- **`LegalUrlsTest.kt`** — JVM unit tests for the locale mapping
  (region stripping, Chinese variants, fallback, trailing-slash
  normalization).

## URL examples

| Android locale | Resulting URL |
| --- | --- |
| `en-US` | `https://voxquieta.org/en/privacy` |
| `it-IT` | `https://voxquieta.org/it/privacy` |
| `zh-Hans` | `https://voxquieta.org/zh/terms` |
| `ja-JP` (unsupported) | `https://voxquieta.org/en/privacy` |

## Dependencies

- Depends on **PR #471** (web privacy/terms pages) being **merged and
  deployed** before these URLs return real content. Until then they 404.

## Quality gates

- `./gradlew testDebugUnitTest` — **not run locally**: this environment
  has JDK 21 only; AGENTS.md mandates JDK 17 for Android. CI
  (`android-ci.yml`) will run unit tests, lint, and the
  translation-validation job (which I verified locally by inspecting
  the workflow's grep-based check — all 11 locales now contain
  `settings_terms_of_service`).
- pre-commit hooks: passed on the changed files.

## Out of scope (follow-ups)

- `BuildConfig.PRIVACY_POLICY_URL` is left in `build.gradle.kts` as a
  backwards-compatible field but is no longer used by the app. Can be
  removed once this PR ships.
- Localized translations for "Terms of Service" used widely-accepted
  phrasing; native-speaker review welcome for ar / hi / ko.

Part of: release notes + auto-publish + legal pages initiative
(see PR #470 release-please, PR #471 web legal pages, and the
upcoming changelog page / What's-new modal PR).