### PR TITLE
feat(frontend): add changelog page and what's-new modal

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -365,7 +365,7 @@ jobs:
             cp CHANGELOG.md frontend/CHANGELOG.md
             echo "Staged $(wc -l < CHANGELOG.md) lines from CHANGELOG.md into frontend/"
           else
-            echo "::notice::No CHANGELOG.md at repo root — /changelog page will render empty state until release-please produces one"
+            echo "::notice::No CHANGELOG.md at repo root — /changelog will render the empty state"
           fi
 
       - name: Build and push frontend

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -353,6 +353,21 @@ jobs:
           echo "url=$BACKEND_URL" >> $GITHUB_OUTPUT
           echo "✅ Building frontend with NEXT_PUBLIC_API_URL=$BACKEND_URL"
 
+      - name: Stage CHANGELOG.md into frontend/ for docker build context
+        # The frontend Dockerfile uses `context: ./frontend`, so the repo-root
+        # CHANGELOG.md is otherwise invisible to `next build` inside the
+        # container. The prebuild script (extract-latest-changelog.mjs) looks
+        # in ./CHANGELOG.md as a fallback when the repo-root copy is missing,
+        # so this step makes the file reachable. Without it, the /changelog
+        # page renders the empty state in production.
+        run: |
+          if [ -f CHANGELOG.md ]; then
+            cp CHANGELOG.md frontend/CHANGELOG.md
+            echo "Staged $(wc -l < CHANGELOG.md) lines from CHANGELOG.md into frontend/"
+          else
+            echo "::notice::No CHANGELOG.md at repo root — /changelog page will render empty state until release-please produces one"
+          fi
+
       - name: Build and push frontend
         uses: docker/build-push-action@v7
         with:

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -233,5 +233,19 @@
     "lastUpdated": "آخر تحديث: {date}",
     "navPrivacy": "الخصوصية",
     "navTerms": "الشروط"
+  },
+  "Changelog": {
+    "title": "ملاحظات الإصدار",
+    "description": "اكتشف ما هو جديد في Vox Quieta — سجل كامل بالإصدارات والتحسينات.",
+    "empty": "لا توجد إصدارات بعد."
+  },
+  "WhatsNew": {
+    "title": "ما الجديد",
+    "versionLabel": "الإصدار {version}",
+    "dismiss": "حسناً",
+    "viewFullChangelog": "عرض سجل التغييرات الكامل"
+  },
+  "Footer": {
+    "changelog": "سجل التغييرات"
   }
 }

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Zuletzt aktualisiert: {date}",
     "navPrivacy": "Datenschutz",
     "navTerms": "Nutzungsbedingungen"
+  },
+  "Changelog": {
+    "title": "Versionshinweise",
+    "description": "Erfahren Sie, was neu ist in Vox Quieta — eine vollständige Versionshistorie.",
+    "empty": "Noch keine Veröffentlichungen."
+  },
+  "WhatsNew": {
+    "title": "Was ist neu",
+    "versionLabel": "Version {version}",
+    "dismiss": "Verstanden",
+    "viewFullChangelog": "Vollständiges Changelog ansehen"
+  },
+  "Footer": {
+    "changelog": "Changelog"
   }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Last updated: {date}",
     "navPrivacy": "Privacy",
     "navTerms": "Terms"
+  },
+  "Changelog": {
+    "title": "Release notes",
+    "description": "See what's new in Vox Quieta — a full history of releases and improvements.",
+    "empty": "No releases yet."
+  },
+  "WhatsNew": {
+    "title": "What's new",
+    "versionLabel": "Version {version}",
+    "dismiss": "Got it",
+    "viewFullChangelog": "View full changelog"
+  },
+  "Footer": {
+    "changelog": "Changelog"
   }
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Última actualización: {date}",
     "navPrivacy": "Privacidad",
     "navTerms": "Términos"
+  },
+  "Changelog": {
+    "title": "Notas de versión",
+    "description": "Descubre las novedades de Vox Quieta — historial completo de versiones y mejoras.",
+    "empty": "Aún no hay versiones publicadas."
+  },
+  "WhatsNew": {
+    "title": "Novedades",
+    "versionLabel": "Versión {version}",
+    "dismiss": "Entendido",
+    "viewFullChangelog": "Ver historial completo"
+  },
+  "Footer": {
+    "changelog": "Historial"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Dernière mise à jour : {date}",
     "navPrivacy": "Confidentialité",
     "navTerms": "Conditions"
+  },
+  "Changelog": {
+    "title": "Notes de version",
+    "description": "Découvrez les nouveautés de Vox Quieta — historique complet des versions et améliorations.",
+    "empty": "Aucune version publiée pour l'instant."
+  },
+  "WhatsNew": {
+    "title": "Quoi de neuf",
+    "versionLabel": "Version {version}",
+    "dismiss": "Compris",
+    "viewFullChangelog": "Voir le changelog complet"
+  },
+  "Footer": {
+    "changelog": "Changelog"
   }
 }

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -233,5 +233,19 @@
     "lastUpdated": "अंतिम अपडेट: {date}",
     "navPrivacy": "गोपनीयता",
     "navTerms": "शर्तें"
+  },
+  "Changelog": {
+    "title": "रिलीज़ नोट्स",
+    "description": "Vox Quieta में क्या नया है — संस्करणों और सुधारों का पूरा इतिहास देखें।",
+    "empty": "अभी तक कोई रिलीज़ नहीं हुई है।"
+  },
+  "WhatsNew": {
+    "title": "क्या नया है",
+    "versionLabel": "संस्करण {version}",
+    "dismiss": "समझ गया",
+    "viewFullChangelog": "पूरा चेंजलॉग देखें"
+  },
+  "Footer": {
+    "changelog": "चेंजलॉग"
   }
 }

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Ultimo aggiornamento: {date}",
     "navPrivacy": "Privacy",
     "navTerms": "Termini"
+  },
+  "Changelog": {
+    "title": "Note di rilascio",
+    "description": "Scopri le novità di Vox Quieta — tutta la cronologia delle versioni e miglioramenti.",
+    "empty": "Nessuna versione disponibile ancora."
+  },
+  "WhatsNew": {
+    "title": "Novità",
+    "versionLabel": "Versione {version}",
+    "dismiss": "Capito",
+    "viewFullChangelog": "Vedi il changelog completo"
+  },
+  "Footer": {
+    "changelog": "Changelog"
   }
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -233,5 +233,19 @@
     "lastUpdated": "최종 업데이트: {date}",
     "navPrivacy": "개인정보",
     "navTerms": "약관"
+  },
+  "Changelog": {
+    "title": "릴리즈 노트",
+    "description": "Vox Quieta의 새로운 기능을 확인하세요 — 전체 릴리즈 및 개선 사항 기록.",
+    "empty": "아직 릴리즈가 없습니다."
+  },
+  "WhatsNew": {
+    "title": "새로운 기능",
+    "versionLabel": "버전 {version}",
+    "dismiss": "확인",
+    "viewFullChangelog": "전체 변경 로그 보기"
+  },
+  "Footer": {
+    "changelog": "변경 로그"
   }
 }

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Última atualização: {date}",
     "navPrivacy": "Privacidade",
     "navTerms": "Termos"
+  },
+  "Changelog": {
+    "title": "Notas de lançamento",
+    "description": "Veja as novidades do Vox Quieta — histórico completo de versões e melhorias.",
+    "empty": "Ainda não há versões publicadas."
+  },
+  "WhatsNew": {
+    "title": "O que há de novo",
+    "versionLabel": "Versão {version}",
+    "dismiss": "Entendi",
+    "viewFullChangelog": "Ver changelog completo"
+  },
+  "Footer": {
+    "changelog": "Changelog"
   }
 }

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -233,5 +233,19 @@
     "lastUpdated": "Последнее обновление: {date}",
     "navPrivacy": "Конфиденциальность",
     "navTerms": "Условия"
+  },
+  "Changelog": {
+    "title": "Примечания к выпуску",
+    "description": "Узнайте, что нового в Vox Quieta — полная история версий и улучшений.",
+    "empty": "Пока нет опубликованных версий."
+  },
+  "WhatsNew": {
+    "title": "Что нового",
+    "versionLabel": "Версия {version}",
+    "dismiss": "Понятно",
+    "viewFullChangelog": "Смотреть полный журнал изменений"
+  },
+  "Footer": {
+    "changelog": "Журнал изменений"
   }
 }

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -233,5 +233,19 @@
     "lastUpdated": "最后更新：{date}",
     "navPrivacy": "隐私",
     "navTerms": "条款"
+  },
+  "Changelog": {
+    "title": "发行说明",
+    "description": "了解 Vox Quieta 的最新动态——完整的版本历史和改进记录。",
+    "empty": "暂无发布版本。"
+  },
+  "WhatsNew": {
+    "title": "新功能",
+    "versionLabel": "版本 {version}",
+    "dismiss": "知道了",
+    "viewFullChangelog": "查看完整更新日志"
+  },
+  "Footer": {
+    "changelog": "更新日志"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node scripts/extract-latest-changelog.mjs",
     "dev": "next dev",
+    "prebuild": "node scripts/extract-latest-changelog.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",

--- a/frontend/public/changelog.json
+++ b/frontend/public/changelog.json
@@ -1,0 +1,3 @@
+{
+  "version": null
+}

--- a/frontend/scripts/extract-latest-changelog.mjs
+++ b/frontend/scripts/extract-latest-changelog.mjs
@@ -1,12 +1,23 @@
 #!/usr/bin/env node
 /**
- * Reads the root CHANGELOG.md and extracts the topmost release entry.
+ * Reads the CHANGELOG.md and extracts the topmost release entry.
  * Writes frontend/public/changelog.json with:
  *   { "version": "X.Y.Z", "date": "YYYY-MM-DD", "body": "..." }
- * If CHANGELOG.md is missing or has no entries, writes { "version": null }.
+ * Also copies the full CHANGELOG.md verbatim to frontend/public/CHANGELOG.md
+ * so /[locale]/changelog can read it at build time. The file is shipped via
+ * the standalone Docker image's `public/` folder.
+ *
+ * Looks first in the repo root (local dev), then in the frontend dir
+ * (Docker build: CI is expected to stage CHANGELOG.md into ./frontend
+ * before `docker build` because the build context is ./frontend and the
+ * repo-root CHANGELOG.md is otherwise invisible inside the container).
+ *
+ * If CHANGELOG.md is missing or has no entries, writes { "version": null }
+ * and does not create public/CHANGELOG.md (the page falls back to its
+ * empty state).
  *
  * Run via `prebuild` / `predev` in package.json so next build always has
- * a fresh public/changelog.json.
+ * fresh artifacts in public/.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
@@ -15,9 +26,15 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "../../");
-const changelogPath = resolve(repoRoot, "CHANGELOG.md");
+const candidatePaths = [
+  resolve(repoRoot, "CHANGELOG.md"),
+  resolve(__dirname, "../CHANGELOG.md"),
+];
+const changelogPath =
+  candidatePaths.find((p) => existsSync(p)) ?? candidatePaths[0];
 const outputDir = resolve(__dirname, "../public");
 const outputPath = resolve(outputDir, "changelog.json");
+const outputMarkdownPath = resolve(outputDir, "CHANGELOG.md");
 
 /** Parse topmost ## [X.Y.Z] or ## X.Y.Z entry from a CHANGELOG string. */
 export function parseLatestEntry(content) {
@@ -74,8 +91,10 @@ function main() {
   };
   mkdirSync(outputDir, { recursive: true });
   writeFileSync(outputPath, JSON.stringify(payload, null, 2));
+  // Also ship the full CHANGELOG.md so /[locale]/changelog can render it.
+  writeFileSync(outputMarkdownPath, content);
   console.log(
-    `[extract-latest-changelog] Wrote v${entry.version} to public/changelog.json`,
+    `[extract-latest-changelog] Wrote v${entry.version} to public/changelog.json + full CHANGELOG.md`,
   );
 }
 

--- a/frontend/scripts/extract-latest-changelog.mjs
+++ b/frontend/scripts/extract-latest-changelog.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * Reads the root CHANGELOG.md and extracts the topmost release entry.
+ * Writes frontend/public/changelog.json with:
+ *   { "version": "X.Y.Z", "date": "YYYY-MM-DD", "body": "..." }
+ * If CHANGELOG.md is missing or has no entries, writes { "version": null }.
+ *
+ * Run via `prebuild` / `predev` in package.json so next build always has
+ * a fresh public/changelog.json.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../../");
+const changelogPath = resolve(repoRoot, "CHANGELOG.md");
+const outputDir = resolve(__dirname, "../public");
+const outputPath = resolve(outputDir, "changelog.json");
+
+/** Parse topmost ## [X.Y.Z] or ## X.Y.Z entry from a CHANGELOG string. */
+export function parseLatestEntry(content) {
+  // Match headers like:
+  //   ## [1.2.3](url) (2024-06-01)   ← release-please format
+  //   ## [1.2.3] — 2024-06-01
+  //   ## 1.2.3
+  const headerRe =
+    /^##\s+\[?([\d]+\.[\d]+\.[\d]+[^\]\s]*)\]?(?:\([^)]*\))?(?:\s*[-–—]\s*(\d{4}-\d{2}-\d{2})|\s+\((\d{4}-\d{2}-\d{2})\))?/m;
+
+  const match = headerRe.exec(content);
+  if (!match) return null;
+
+  const version = match[1];
+  // date can be in group 2 (dash syntax) or group 3 (paren syntax)
+  const date = match[2] ?? match[3] ?? null;
+  const headerEnd = match.index + match[0].length;
+
+  // Everything from end of this header until the next ## header (or EOF)
+  const rest = content.slice(headerEnd);
+  const nextHeaderIdx = rest.search(/^##\s/m);
+  const body =
+    nextHeaderIdx === -1 ? rest.trim() : rest.slice(0, nextHeaderIdx).trim();
+
+  return { version, date, body };
+}
+
+function main() {
+  if (!existsSync(changelogPath)) {
+    console.log(
+      "[extract-latest-changelog] CHANGELOG.md not found — writing empty sentinel.",
+    );
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(outputPath, JSON.stringify({ version: null }, null, 2));
+    return;
+  }
+
+  const content = readFileSync(changelogPath, "utf8");
+  const entry = parseLatestEntry(content);
+
+  if (!entry) {
+    console.log(
+      "[extract-latest-changelog] No versioned entries found — writing empty sentinel.",
+    );
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(outputPath, JSON.stringify({ version: null }, null, 2));
+    return;
+  }
+
+  const payload = {
+    version: entry.version,
+    date: entry.date,
+    body: entry.body,
+  };
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(payload, null, 2));
+  console.log(
+    `[extract-latest-changelog] Wrote v${entry.version} to public/changelog.json`,
+  );
+}
+
+main();

--- a/frontend/scripts/extract-latest-changelog.test.mjs
+++ b/frontend/scripts/extract-latest-changelog.test.mjs
@@ -1,0 +1,56 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { parseLatestEntry } from "./extract-latest-changelog.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe("parseLatestEntry", () => {
+  it("extracts version, date, and body from a standard release-please CHANGELOG", () => {
+    const changelog = `# Changelog
+
+## [1.2.3](https://github.com/example/repo/compare/v1.2.2...v1.2.3) (2024-06-01)
+
+### Features
+
+* add changelog page ([#100](https://github.com/example/repo/issues/100))
+
+### Bug Fixes
+
+* fix typo in footer
+
+## [1.2.2](https://github.com/example/repo/compare/v1.2.1...v1.2.2) (2024-05-15)
+
+### Bug Fixes
+
+* older fix
+`;
+    const result = parseLatestEntry(changelog);
+    expect(result).not.toBeNull();
+    expect(result?.version).toBe("1.2.3");
+    expect(result?.date).toBe("2024-06-01");
+    expect(result?.body).toContain("add changelog page");
+    expect(result?.body).not.toContain("older fix");
+  });
+
+  it("extracts version without date", () => {
+    const changelog = `## 2.0.0\n\n### Features\n\n* new stuff\n`;
+    const result = parseLatestEntry(changelog);
+    expect(result?.version).toBe("2.0.0");
+    expect(result?.date).toBeNull();
+    expect(result?.body).toContain("new stuff");
+  });
+
+  it("returns null for empty / no-version content", () => {
+    expect(parseLatestEntry("# Changelog\n\nNothing here.\n")).toBeNull();
+    expect(parseLatestEntry("")).toBeNull();
+  });
+
+  it("handles a single release entry (no next header)", () => {
+    const changelog = `## [0.1.0] (2024-01-01)\n\n* initial release\n`;
+    const result = parseLatestEntry(changelog);
+    expect(result?.version).toBe("0.1.0");
+    expect(result?.body).toContain("initial release");
+  });
+});

--- a/frontend/src/app/[locale]/changelog/page.tsx
+++ b/frontend/src/app/[locale]/changelog/page.tsx
@@ -34,7 +34,10 @@ export default async function ChangelogPage({
 
   const t = await getTranslations({ locale, namespace: "Changelog" });
 
-  const changelogPath = resolve(process.cwd(), "../CHANGELOG.md");
+  // Read from public/CHANGELOG.md, which the prebuild script copies from
+  // the repo-root CHANGELOG.md. This works in both local dev and the
+  // production standalone Docker image (which ships the public/ folder).
+  const changelogPath = resolve(process.cwd(), "public", "CHANGELOG.md");
   const content = existsSync(changelogPath)
     ? readFileSync(changelogPath, "utf8")
     : null;

--- a/frontend/src/app/[locale]/changelog/page.tsx
+++ b/frontend/src/app/[locale]/changelog/page.tsx
@@ -1,0 +1,56 @@
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import type { Metadata } from "next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "Changelog" });
+  return {
+    title: t("title"),
+    description: t("description"),
+  };
+}
+
+export function generateStaticParams() {
+  return ["en", "it", "de", "es", "fr", "pt", "ar", "ru", "zh", "hi", "ko"].map(
+    (locale) => ({ locale }),
+  );
+}
+
+export default async function ChangelogPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations({ locale, namespace: "Changelog" });
+
+  const changelogPath = resolve(process.cwd(), "../CHANGELOG.md");
+  const content = existsSync(changelogPath)
+    ? readFileSync(changelogPath, "utf8")
+    : null;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-primary-50 to-white">
+      <div className="max-w-3xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">{t("title")}</h1>
+        {content ? (
+          <article className="prose prose-gray max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          </article>
+        ) : (
+          <p className="text-gray-500 italic">{t("empty")}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -11,6 +11,7 @@ import { routing } from "@/i18n/routing";
 import { Providers } from "./providers";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import Footer from "@/components/Footer";
+import WhatsNewModal from "@/components/WhatsNewModal";
 
 export async function generateMetadata({
   params,
@@ -100,6 +101,7 @@ export default async function LocaleLayout({
                 <div className="flex-1">{children}</div>
                 <Footer />
               </div>
+              <WhatsNewModal />
             </ErrorBoundary>
           </Providers>
         </NextIntlClientProvider>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -2,7 +2,8 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 
 export default function Footer() {
-  const t = useTranslations("Legal");
+  const tLegal = useTranslations("Legal");
+  const tFooter = useTranslations("Footer");
 
   return (
     <footer className="border-t border-gray-200 bg-white py-6 mt-8">
@@ -11,13 +12,19 @@ export default function Footer() {
           href="/privacy"
           className="hover:text-primary-700 transition-colors"
         >
-          {t("navPrivacy")}
+          {tLegal("navPrivacy")}
         </Link>
         <Link
           href="/terms"
           className="hover:text-primary-700 transition-colors"
         >
-          {t("navTerms")}
+          {tLegal("navTerms")}
+        </Link>
+        <Link
+          href="/changelog"
+          className="hover:text-primary-700 transition-colors"
+        >
+          {tFooter("changelog")}
         </Link>
       </div>
     </footer>

--- a/frontend/src/components/WhatsNewModal.test.tsx
+++ b/frontend/src/components/WhatsNewModal.test.tsx
@@ -3,15 +3,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import WhatsNewModal from "./WhatsNewModal";
 import { renderWithIntl } from "@/test/i18n-helpers";
 
-// Mock next-intl's useLocale
-vi.mock("next-intl", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("next-intl")>();
-  return {
-    ...actual,
-    useLocale: () => "en",
-  };
-});
-
 // Mock @/i18n/navigation Link
 vi.mock("@/i18n/navigation", () => ({
   Link: ({ children, href }: { children: React.ReactNode; href: string }) => (

--- a/frontend/src/components/WhatsNewModal.test.tsx
+++ b/frontend/src/components/WhatsNewModal.test.tsx
@@ -1,0 +1,97 @@
+import { screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import WhatsNewModal from "./WhatsNewModal";
+import { renderWithIntl } from "@/test/i18n-helpers";
+
+// Mock next-intl's useLocale
+vi.mock("next-intl", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next-intl")>();
+  return {
+    ...actual,
+    useLocale: () => "en",
+  };
+});
+
+// Mock @/i18n/navigation Link
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const STORAGE_KEY = "vq:lastSeenVersion";
+
+function mockFetch(payload: object) {
+  vi.spyOn(global, "fetch").mockResolvedValueOnce({
+    ok: true,
+    json: async () => payload,
+  } as Response);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("WhatsNewModal", () => {
+  it("renders nothing when version is null", async () => {
+    mockFetch({ version: null });
+    const { container } = renderWithIntl(<WhatsNewModal />);
+    // wait for effect
+    await act(async () => {});
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing on first visit and silently stores version", async () => {
+    mockFetch({ version: "1.0.0", body: "Initial release" });
+    const { container } = renderWithIntl(<WhatsNewModal />);
+    await act(async () => {});
+    // No modal shown — first-ever visit
+    expect(container.innerHTML).toBe("");
+    // Version silently stored
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1.0.0");
+  });
+
+  it("renders nothing when stored version matches current", async () => {
+    localStorage.setItem(STORAGE_KEY, "1.0.0");
+    mockFetch({ version: "1.0.0", body: "Nothing new" });
+    const { container } = renderWithIntl(<WhatsNewModal />);
+    await act(async () => {});
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders modal when stored version differs from current", async () => {
+    localStorage.setItem(STORAGE_KEY, "1.0.0");
+    mockFetch({ version: "1.1.0", body: "Something new in 1.1.0" });
+    renderWithIntl(<WhatsNewModal />);
+    await act(async () => {});
+    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(screen.getByText(/Something new in 1\.1\.0/i)).toBeDefined();
+  });
+
+  it("dismisses modal and stores new version on dismiss click", async () => {
+    localStorage.setItem(STORAGE_KEY, "1.0.0");
+    mockFetch({ version: "1.1.0", body: "New features" });
+    renderWithIntl(<WhatsNewModal />);
+    await act(async () => {});
+
+    const dismissBtn = screen.getAllByText("Got it")[0];
+    await act(async () => {
+      dismissBtn.click();
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1.1.0");
+  });
+
+  it("renders nothing when fetch fails", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("network error"));
+    const { container } = renderWithIntl(<WhatsNewModal />);
+    await act(async () => {});
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/frontend/src/components/WhatsNewModal.tsx
+++ b/frontend/src/components/WhatsNewModal.tsx
@@ -24,8 +24,12 @@ export default function WhatsNewModal() {
     if (typeof window === "undefined") return;
 
     fetch("/changelog.json")
-      .then((r) => r.json())
-      .then((data: ChangelogEntry) => {
+      .then((r) => {
+        if (!r.ok) return null;
+        return r.json();
+      })
+      .then((data: ChangelogEntry | null) => {
+        if (!data) return;
         if (!data.version) return;
 
         const lastSeen = localStorage.getItem(STORAGE_KEY);

--- a/frontend/src/components/WhatsNewModal.tsx
+++ b/frontend/src/components/WhatsNewModal.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Link } from "@/i18n/navigation";
+
+const STORAGE_KEY = "vq:lastSeenVersion";
+
+interface ChangelogEntry {
+  version: string | null;
+  date?: string | null;
+  body?: string;
+}
+
+export default function WhatsNewModal() {
+  const t = useTranslations("WhatsNew");
+  const [entry, setEntry] = useState<ChangelogEntry | null>(null);
+
+  useEffect(() => {
+    // Guard: only runs client-side
+    if (typeof window === "undefined") return;
+
+    fetch("/changelog.json")
+      .then((r) => r.json())
+      .then((data: ChangelogEntry) => {
+        if (!data.version) return;
+
+        const lastSeen = localStorage.getItem(STORAGE_KEY);
+
+        if (lastSeen === null) {
+          // First-ever visit: silently record current version so new users
+          // are not greeted with a "what's new" popup they have no context for.
+          localStorage.setItem(STORAGE_KEY, data.version);
+          return;
+        }
+
+        if (lastSeen !== data.version) {
+          setEntry(data);
+        }
+      })
+      .catch(() => {
+        // changelog.json is optional — ignore fetch errors silently
+      });
+  }, []);
+
+  if (!entry) return null;
+
+  function handleDismiss() {
+    if (entry?.version) {
+      localStorage.setItem(STORAGE_KEY, entry.version);
+    }
+    setEntry(null);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("title")}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="relative w-full max-w-lg rounded-2xl bg-white shadow-2xl p-6 max-h-[80vh] flex flex-col">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900">{t("title")}</h2>
+            {entry.version && (
+              <p className="text-sm text-gray-500 mt-0.5">
+                {t("versionLabel", { version: entry.version })}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={handleDismiss}
+            aria-label={t("dismiss")}
+            className="ml-4 p-1 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {entry.body && (
+          <div className="overflow-y-auto flex-1 prose prose-sm prose-gray max-w-none mb-4">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {entry.body}
+            </ReactMarkdown>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between pt-2 border-t border-gray-100">
+          <Link
+            href="/changelog"
+            className="text-sm text-blue-600 hover:underline"
+          >
+            {t("viewFullChangelog")}
+          </Link>
+          <button
+            onClick={handleDismiss}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+          >
+            {t("dismiss")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Phase B of the release-notes initiative — surfaces the auto-generated CHANGELOG.md to web users.

## What landed

- `/[locale]/changelog` server page reading root `CHANGELOG.md` via `fs`; empty state localized.
- `frontend/scripts/extract-latest-changelog.mjs` build-time parser that writes `public/changelog.json`; wired as `prebuild` + `predev`. Writes `{ version: null }` when no changelog exists (build never fails).
- `WhatsNewModal` client component: compares latest version against `localStorage['vq:lastSeenVersion']`, shows dismissable modal on mismatch. First-ever visit silently seeds the key so new users aren't greeted with a modal.
- Footer link to changelog.
- i18n keys (`Changelog.*`, `WhatsNew.*`, `Footer.changelog`) in all 11 locales.
- `remark-gfm` added (sanitized, no raw HTML).
- Vitest: 4 parser cases + 6 modal cases; **479 tests pass**.

## Quality gates

All gates passed per agent: `npm run lint`, `npx tsc --noEmit`, `npx vitest run`, `npm run build`.

## Dependencies / coordination

- Depends on **PR #470** (release-please) for `CHANGELOG.md` to be auto-generated. Until merged + a release lands, the page shows `Changelog.empty` and the modal stays silent.
- Possible footer/layout merge conflict with **PR #471**. Both edits are additive — easy to resolve.

## Notes

- Standard widely-used phrasing across all 11 locales. Native-speaker review welcome for ar / hi / ko.

Part of release-notes + auto-publish + legal-pages initiative (#470, #471, #473).