### PR TITLE
Add synchronous language preference reading for app startup

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.os.Bundle
 import android.os.SystemClock
+import org.voxquieta.app.data.preferences.LanguagePreferences
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -14,6 +15,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -65,6 +67,18 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var turnstileManager: TurnstileManager
 
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleHelper.wrapContext(newBase, LanguagePreferences.readSync(newBase)))
+    }
+
+    override fun applyOverrideConfiguration(overrideConfiguration: Configuration?) {
+        if (overrideConfiguration != null) {
+            val code = LanguagePreferences.readSync(baseContext)
+            overrideConfiguration.setLocale(java.util.Locale(code))
+        }
+        super.applyOverrideConfiguration(overrideConfiguration)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         // Capture the splash screen handle before super.onCreate() as required by the API.
         val splashScreen = installSplashScreen()
@@ -93,6 +107,13 @@ class MainActivity : ComponentActivity() {
             val languageCode by viewModel.selectedLanguage.collectAsStateWithLifecycle()
 
             val layoutDirection = LocaleHelper.layoutDirectionFor(languageCode)
+
+            LaunchedEffect(languageCode) {
+                val currentLang = resources.configuration.locales[0].language
+                if (languageCode != currentLang) {
+                    recreate()
+                }
+            }
 
             val darkTheme = when (uiState.themeMode) {
                 "dark" -> true

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/preferences/LanguagePreferences.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/preferences/LanguagePreferences.kt
@@ -1,9 +1,12 @@
 package org.voxquieta.app.data.preferences
 
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -17,10 +20,17 @@ import javax.inject.Singleton
 @Singleton
 class LanguagePreferences @Inject constructor(
     private val dataStore: DataStore<Preferences>,
+    @ApplicationContext private val context: Context,
 ) {
     companion object {
         private val LANGUAGE_CODE_KEY = stringPreferencesKey("language_code")
         const val DEFAULT_LANGUAGE = "en"
+        private const val SYNC_PREFS_FILE = "language_sync_prefs"
+        private const val SYNC_KEY = "language_code"
+
+        fun readSync(context: Context): String =
+            context.getSharedPreferences(SYNC_PREFS_FILE, MODE_PRIVATE)
+                .getString(SYNC_KEY, DEFAULT_LANGUAGE) ?: DEFAULT_LANGUAGE
     }
 
     /** A [Flow] that emits the currently persisted language code (default: "en"). */
@@ -28,8 +38,15 @@ class LanguagePreferences @Inject constructor(
         prefs[LANGUAGE_CODE_KEY] ?: DEFAULT_LANGUAGE
     }
 
+    /** Returns the persisted language code synchronously (reads from SharedPreferences). */
+    fun readInitial(): String = readSync(context)
+
     /** Persists [code] as the selected language. */
     suspend fun setLanguage(code: String) {
+        context.getSharedPreferences(SYNC_PREFS_FILE, MODE_PRIVATE)
+            .edit()
+            .putString(SYNC_KEY, code)
+            .apply()
         dataStore.edit { prefs ->
             prefs[LANGUAGE_CODE_KEY] = code
         }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -151,7 +151,10 @@ class ChatViewModel @Inject constructor(
     // first cold-start disk read.  Without this, the state starts as "system" and the
     // async collect in init{} arrives one frame late, causing a brief theme flash.
     private val _uiState = MutableStateFlow(
-        ChatUiState(themeMode = runBlocking { themePreferences.themeModeFlow.first() })
+        ChatUiState(
+            themeMode = runBlocking { themePreferences.themeModeFlow.first() },
+            currentLocale = languagePreferences.readInitial(),
+        )
     )
     val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
 

--- a/android/app/src/main/kotlin/org/voxquieta/app/utils/LocaleHelper.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/utils/LocaleHelper.kt
@@ -1,6 +1,8 @@
 package org.voxquieta.app.utils
 
+import android.content.res.Configuration
 import androidx.compose.ui.unit.LayoutDirection
+import java.util.Locale
 
 object LocaleHelper {
     /** Returns true if the given BCP-47 language tag requires RTL layout. */
@@ -9,4 +11,13 @@ object LocaleHelper {
     /** Maps a BCP-47 language code to the Compose [LayoutDirection]. */
     fun layoutDirectionFor(languageCode: String): LayoutDirection =
         if (isRtl(languageCode)) LayoutDirection.Rtl else LayoutDirection.Ltr
+
+    /** Wraps [base] with a configuration context for [code], updating the default locale. */
+    fun wrapContext(base: android.content.Context, code: String): android.content.Context {
+        val locale = Locale(code)
+        val config = Configuration(base.resources.configuration)
+        config.setLocale(locale)
+        Locale.setDefault(locale)
+        return base.createConfigurationContext(config)
+    }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/preferences/LanguagePreferencesTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/preferences/LanguagePreferencesTest.kt
@@ -1,9 +1,13 @@
 package org.voxquieta.app.preferences
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import org.voxquieta.app.data.preferences.LanguagePreferences
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
@@ -33,6 +37,25 @@ class LanguagePreferencesTest {
 
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var languagePreferences: LanguagePreferences
+    private lateinit var fakeCtx: Context
+    private val sharedStorage = mutableMapOf<String, String?>()
+
+    private fun fakeContext(storage: MutableMap<String, String?> = mutableMapOf()): Context {
+        val editor = mockk<SharedPreferences.Editor>(relaxed = true)
+        val prefs = mockk<SharedPreferences>(relaxed = true)
+        every { prefs.getString(any(), any()) } answers {
+            storage[firstArg<String>()] ?: secondArg<String?>()
+        }
+        every { prefs.edit() } returns editor
+        every { editor.putString(any(), any<String>()) } answers {
+            storage[firstArg<String>()] = secondArg<String>()
+            editor
+        }
+        every { editor.apply() } returns Unit
+        val ctx = mockk<Context>()
+        every { ctx.getSharedPreferences(any(), any()) } returns prefs
+        return ctx
+    }
 
     @Before
     fun setUp() {
@@ -40,7 +63,8 @@ class LanguagePreferencesTest {
             scope = testScope,
             produceFile = { tmpFolder.newFile("test_language_prefs.preferences_pb") },
         )
-        languagePreferences = LanguagePreferences(dataStore)
+        fakeCtx = fakeContext(sharedStorage)
+        languagePreferences = LanguagePreferences(dataStore, fakeCtx)
     }
 
     @After
@@ -156,10 +180,37 @@ class LanguagePreferencesTest {
             languagePreferences.setLanguage("ko")
 
             // Simulate a new instance reusing the same DataStore (e.g. after DI re-creation).
-            val anotherInstance = LanguagePreferences(dataStore)
+            val anotherInstance = LanguagePreferences(dataStore, fakeCtx)
             assertEquals(
                 "ko",
                 anotherInstance.languageFlow.first(),
             )
+        }
+
+    // ── SharedPreferences sync (new) ──────────────────────────────────────────
+
+    @Test
+    fun `readSync returns DEFAULT_LANGUAGE when SharedPreferences is empty`() {
+        assertEquals(LanguagePreferences.DEFAULT_LANGUAGE, LanguagePreferences.readSync(fakeCtx))
+    }
+
+    @Test
+    fun `setLanguage mirrors code to SharedPreferences synchronously`() = runTest(testDispatcher) {
+        languagePreferences.setLanguage("de")
+        assertEquals("de", LanguagePreferences.readSync(fakeCtx))
+    }
+
+    @Test
+    fun `readInitial returns code previously written by setLanguage`() = runTest(testDispatcher) {
+        languagePreferences.setLanguage("fr")
+        assertEquals("fr", languagePreferences.readInitial())
+    }
+
+    @Test
+    fun `readSync returns persisted value across LanguagePreferences instances sharing context`() =
+        runTest(testDispatcher) {
+            languagePreferences.setLanguage("ko")
+            val anotherInstance = LanguagePreferences(dataStore, fakeCtx)
+            assertEquals("ko", anotherInstance.readInitial())
         }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -95,6 +95,7 @@ class ChatViewModelTest {
         turnstileManager = TurnstileManager()
         languagePreferences = mockk(relaxed = true)
         every { languagePreferences.languageFlow } returns flowOf("en")
+        every { languagePreferences.readInitial() } returns "en"
         context = mockk {
             every { getString(R.string.error_network) } returns "Network error. Please check your connection."
             every { getString(R.string.error_timeout) } returns "Request timed out. Please try again."
@@ -1398,5 +1399,27 @@ class ChatViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.allVerses.isEmpty())
+    }
+
+    // ── Language seeding (new) ────────────────────────────────────────────────
+
+    @Test
+    fun `initial currentLocale is seeded synchronously from languagePreferences readInitial`() {
+        every { languagePreferences.readInitial() } returns "de"
+        every { languagePreferences.languageFlow } returns flowOf("de")
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            bibleApiService,
+            networkMonitor,
+        )
+        assertEquals("de", vm.uiState.value.currentLocale)
     }
 }


### PR DESCRIPTION
## Summary
This PR adds synchronous language preference reading to enable proper locale configuration during app startup, before async DataStore operations complete. The implementation uses SharedPreferences for fast synchronous access while maintaining DataStore as the primary async storage.

## Key Changes

- **LanguagePreferences**: 
  - Added `Context` dependency injection to access SharedPreferences
  - Implemented `readSync()` static method for synchronous language code retrieval from SharedPreferences
  - Added `readInitial()` instance method to read persisted language synchronously
  - Modified `setLanguage()` to mirror writes to SharedPreferences for immediate availability

- **MainActivity**:
  - Implemented `attachBaseContext()` to wrap context with correct locale before activity creation
  - Implemented `applyOverrideConfiguration()` to apply locale configuration overrides
  - Added `LaunchedEffect` to detect language changes and trigger activity recreation when needed

- **ChatViewModel**:
  - Seeded initial `currentLocale` state with `languagePreferences.readInitial()` to avoid locale flash on startup

- **LocaleHelper**:
  - Added `wrapContext()` utility to create a configuration context with a specific locale

- **Tests**:
  - Enhanced `LanguagePreferencesTest` with mock SharedPreferences and comprehensive sync tests
  - Updated `ChatViewModelTest` to mock `readInitial()` and verify initial locale seeding

## Implementation Details

The solution uses a dual-storage approach:
- **SharedPreferences** (`language_sync_prefs`): Fast synchronous access for app startup and configuration
- **DataStore**: Primary async storage for normal app operation

This ensures the correct locale is applied before the first frame is rendered, preventing locale/theme flashes during cold starts.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN