### PR TITLE
fix(android): remove AD_ID permission auto-merged by Play Services

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- App does not use advertising ID. Strip the permission auto-merged by Play
+         Services / Firebase so Play Console doesn't gate publishing on ad-ID
+         declaration (targetSdk 33+). -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+
     <application
         android:name=".VoxQuietaApp"
         android:allowBackup="false"


### PR DESCRIPTION
## Summary

Unblocks the publish pipeline. Fastlane upload was failing with:

```
Google Api Error: Invalid request - Your app targets Android 13 (API 33) or above.
You must declare the use of advertising ID in Play Console.
```

The app doesn't use advertising ID, but Firebase / Play Services modules auto-merge `com.google.android.gms.permission.AD_ID` into the final manifest. On `targetSdk 33+` Play Console gates uploads on this. Stripping it with `tools:node="remove"` makes the merged manifest no longer request the permission.

## After this lands

In Play Console → **Policy** → **App content** → **Advertising ID**, answer **No** once. Then `bundle exec fastlane internal` should succeed.

## Test plan

- [ ] CI green (lint, unit, build).
- [ ] Verify the merged release manifest no longer contains `AD_ID`:
  ```
  ./gradlew :app:assembleRelease
  grep -r "AD_ID" android/app/build/intermediates/merged_manifest/release/  # expect: no matches
  ```
- [ ] Re-run the `internal` Fastlane lane; upload succeeds.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_