### PR TITLE
fix(android): exclude play-services-ads-identifier from firebase-analytics

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -206,7 +206,12 @@ dependencies {
     // Firebase (BOM ensures all Firebase libraries use compatible versions)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
-    implementation(libs.firebase.analytics)
+    // Exclude play-services-ads-identifier so the AD_ID permission is not
+    // pulled into the merged manifest. App does not use advertising ID; this
+    // prevents Play Console from gating uploads on ad-ID declaration.
+    implementation(libs.firebase.analytics) {
+        exclude(group = "com.google.android.gms", module = "play-services-ads-identifier")
+    }
 
     // --- Testing ---
     testImplementation(libs.junit)


### PR DESCRIPTION
## Summary

Follow-up to #489 — that PR added `tools:node="remove"` to strip `AD_ID` from the merged manifest, but Play Console still rejects uploads with:

> Your manifest file includes the `com.google.android.gms.permission.AD_ID` permission. This means your app declares the use of advertising ID. Answer 'yes' or remove this permission from your manifest.

The permission is declared inside `play-services-ads-identifier`, a transitive dependency of `firebase-analytics`. The manifest-merger `remove` directive isn't reliably stripping it (likely because the analytics module re-injects via its own dependency chain), so this PR excludes the offending module at the Gradle level — it can't be merged in if it's not on the classpath.

`firebase-analytics` works fine without `play-services-ads-identifier`; the only thing it loses is ad-ID-keyed analytics, which we explicitly don't want.

The `tools:node="remove"` from #489 stays as defense-in-depth.

## Test plan

- [ ] CI green.
- [ ] Verify the merged release manifest no longer contains `AD_ID`:
  ```
  cd android && ./gradlew :app:assembleRelease
  grep -r "AD_ID" app/build/intermediates/merged_manifest/release/   # expect: no matches
  ```
- [ ] Re-run the `internal` Fastlane lane; upload succeeds.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_