### PR TITLE
revert(android): restore manifest + build.gradle.kts to pre-AD_ID-fix state

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -206,12 +206,7 @@ dependencies {
     // Firebase (BOM ensures all Firebase libraries use compatible versions)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
-    // Exclude play-services-ads-identifier so the AD_ID permission is not
-    // pulled into the merged manifest. App does not use advertising ID; this
-    // prevents Play Console from gating uploads on ad-ID declaration.
-    implementation(libs.firebase.analytics) {
-        exclude(group = "com.google.android.gms", module = "play-services-ads-identifier")
-    }
+    implementation(libs.firebase.analytics)
 
     // --- Testing ---
     testImplementation(libs.junit)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,13 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <!-- App does not use advertising ID. Strip the permission auto-merged by Play
-         Services / Firebase so Play Console doesn't gate publishing on ad-ID
-         declaration (targetSdk 33+). -->
-    <uses-permission
-        android:name="com.google.android.gms.permission.AD_ID"
-        tools:node="remove" />
-
     <application
         android:name=".VoxQuietaApp"
         android:allowBackup="false"


### PR DESCRIPTION
## Summary

Reverts the AD_ID work from #489 and #490. They did not unblock Play Store uploads, and the last commit confirmed to publish successfully (`2991e95`) had neither change — strong evidence that the gate is Play Console policy state, not the merged manifest.

This PR restores `android/app/src/main/AndroidManifest.xml` and `android/app/build.gradle.kts` to **byte-identical** copies of `2991e95`. All other commits since `2991e95` (the language fix in #488) are kept untouched.

## Test plan

- [ ] CI green.
- [ ] After merge, run the `internal` Fastlane lane.
  - If publish succeeds → AD_ID gate cleared at 2991e95, our changes were noise.
  - If publish still fails → confirms the issue is not in our diff at all; next step is the Gradle/manifest diagnostics in `android/`:
    ```
    ./gradlew :app:dependencies --configuration releaseRuntimeClasspath
    ./gradlew :app:bundleRelease
    grep -RH "AD_ID" app/build/intermediates/merged_manifest/release/
    ```

Refs #489 #490

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_