### PR TITLE
fix(ci): escape ${{...}} in android-debug.yml comment

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -126,9 +126,9 @@ jobs:
         run: |
           # Pass via env var (not interpolated into the script body) so the
           # snippet can't break out of the YAML quoting and there's no risk
-          # of a stray ${{ ... }} expression being evaluated in a script
-          # context. Captures stdout+stderr and never fails the job — the
-          # exit code is recorded for inspection.
+          # of a stray expression being evaluated in a script context.
+          # Captures stdout+stderr and never fails the job — the exit code
+          # is recorded for inspection.
           {
             echo "=== custom_command ==="
             printf '%s\n' "$CUSTOM_COMMAND"


### PR DESCRIPTION
## Summary

Hotfix for the Android Debug Dump workflow added in #492. Triggering it failed with:

```
failed to parse workflow: (Line: 126, Col: 14): Unexpected symbol: '...'.
Located at position 1 within expression: ...
```

The cause: a literal `${{ ... }}` inside an explanatory comment in a `run:` block. Actions scans the full block (comments included) for expression substitution, so `...` was parsed as an invalid expression token at workflow-load time. Rewrote the comment to drop the expression delimiters.

## Test plan

- [ ] CI green.
- [ ] Trigger Actions → "Android Debug Dump" → Run workflow on `main`; the run queues successfully and produces an `android-debug-<run id>` artifact.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_