### PR TITLE
fix(ci): use processReleaseManifest in debug workflow (no signing)

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -74,7 +74,12 @@ jobs:
       - name: Build release AAB (produces merged manifest + exploded AARs)
         if: ${{ inputs.skip_standard_dumps != true }}
         working-directory: android
-        run: ./gradlew :app:bundleRelease --no-daemon
+        run: |
+          # processReleaseManifest produces the merged manifest without
+          # triggering the release-signing gate that bundleRelease/assembleRelease
+          # require. We don't need a signed AAB to inspect what permissions
+          # would ship — only the merged manifest.
+          ./gradlew :app:processReleaseManifest --no-daemon
 
       - name: Collect merged release manifest
         if: ${{ inputs.skip_standard_dumps != true }}


### PR DESCRIPTION
## Summary

The debug workflow ran `:app:bundleRelease`, which trips the keystore-required gate at `android/app/build.gradle.kts:79-92`:

```
Release signing is not configured. Set KEYSTORE_PATH, KEYSTORE_PASSWORD,
KEY_ALIAS and KEY_PASSWORD ...
```

We don't actually need a signed AAB — we only want the **merged release `AndroidManifest.xml`** and the **exploded library manifests**. `:app:processReleaseManifest` produces both without invoking signing, so swap the task. All downstream collection steps already work because they read from `app/build/intermediates/...`, which `processReleaseManifest` populates the same way.

## Test plan

- [ ] CI (lint/etc.) green.
- [ ] Trigger Actions → "Android Debug Dump" → Run workflow on `main`; the run completes and the `android-debug-<run id>` artifact contains a non-empty merged `AndroidManifest.xml`.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_