### PR TITLE
fix(ci): skip processReleaseGoogleServices in debug workflow

### DIFF
--- a/.github/workflows/android-debug.yml
+++ b/.github/workflows/android-debug.yml
@@ -78,8 +78,10 @@ jobs:
           # processReleaseManifest produces the merged manifest without
           # triggering the release-signing gate that bundleRelease/assembleRelease
           # require. We don't need a signed AAB to inspect what permissions
-          # would ship — only the merged manifest.
-          ./gradlew :app:processReleaseManifest --no-daemon
+          # would ship — only the merged manifest. Skip the google-services
+          # plugin's processReleaseGoogleServices task so the workflow doesn't
+          # need the secret-restored google-services.json (it's in .gitignore).
+          ./gradlew :app:processReleaseManifest --no-daemon -x processReleaseGoogleServices
 
       - name: Collect merged release manifest
         if: ${{ inputs.skip_standard_dumps != true }}


### PR DESCRIPTION
## Summary

Follow-up to #496. After switching to `processReleaseManifest`, the workflow still fails because that task transitively pulls in `processReleaseGoogleServices`:

```
File google-services.json is missing.
The Google Services Plugin cannot function without it.
```

`google-services.json` is in `.gitignore` and only restored from a base64 secret by the publish workflow (`android-publish.yml:64`). The debug workflow doesn't need Firebase config — it just needs the merged manifest — so exclude the task with `-x processReleaseGoogleServices`. No new secrets required, the workflow stays runnable from any PR/branch.

## Test plan

- [ ] CI green.
- [ ] Re-trigger Actions → "Android Debug Dump" → Run workflow on `main`; the artifact contains the merged release `AndroidManifest.xml`.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_