### PR TITLE
fix(android): declare AD_ID usage for Firebase Analytics

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,11 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <!-- Auto-merged from play-services-measurement-api; app does not use ad ID. -->
-    <uses-permission
-        android:name="com.google.android.gms.permission.AD_ID"
-        tools:node="remove" />
-
     <application
         android:name=".VoxQuietaApp"
         android:allowBackup="false"
@@ -21,12 +16,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.VoxQuieta">
-
-        <!-- Disable Firebase Analytics ad-ID collection at runtime, consistent
-             with the Play Console "does not use ad ID" declaration. -->
-        <meta-data
-            android:name="google_analytics_adid_collection_enabled"
-            android:value="false" />
 
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
## Summary

Reverses the Path 1 attempt (PR #499). The app uses Firebase Analytics for user-base analysis, so we declare ad-ID usage in Play Console instead of trying to strip the permission.

- Removes `<uses-permission ... AD_ID ... tools:node="remove" />`: lets `play-services-measurement-api` auto-merge the permission into the AAB.
- Removes the `google_analytics_adid_collection_enabled=false` meta-data: re-enables runtime ad-ID collection by Firebase Analytics.

No SDK code changes required — Firebase Analytics handles ad-ID acquisition automatically once the permission ships and runtime collection isn't disabled.

## Required Play Console action (must be done before merging/publishing)

1. **App content → Advertising ID → Manage** → **Yes** + tick **App functionality** and **Analytics** → **Save**.
2. **App content → Data safety** → ensure "Device or other IDs → Advertising ID" is listed with matching purposes → **Save**.
3. Confirm the privacy policy URL covers analytics-based ad-ID collection.

## Test plan

- [ ] Trigger the **Android Debug Dump** workflow against this branch.
- [ ] In the artifact, confirm `AndroidManifest.xml` contains `com.google.android.gms.permission.AD_ID` (auto-merged) and no `google_analytics_adid_collection_enabled` meta-data.
- [ ] Save the Play Console Advertising ID declaration as **Yes** with App functionality + Analytics.
- [ ] Merge and run the `internal` Fastlane lane — upload should succeed.
- [ ] After install, verify Firebase Analytics events appear in DebugView.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_