### PR TITLE
feat(android): switch language picker to AppCompatDelegate.setApplicationLocales

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -153,6 +153,7 @@ ksp {
 dependencies {
     // Core
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         tools:ignore="DataExtractionRules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -1,9 +1,6 @@
 package org.voxquieta.app
 
-import android.annotation.SuppressLint
 import android.content.Context
-import android.content.ContextWrapper
-import android.content.res.Configuration
 import android.os.Bundle
 import android.os.SystemClock
 import androidx.activity.ComponentActivity
@@ -12,18 +9,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -37,10 +29,7 @@ import org.voxquieta.app.presentation.screens.SplashScreen
 import org.voxquieta.app.presentation.theme.VoxQuietaTheme
 import org.voxquieta.app.presentation.viewmodels.ChatViewModel
 import org.voxquieta.app.security.TurnstileManager
-import org.voxquieta.app.utils.LocaleHelper
 import dagger.hilt.android.AndroidEntryPoint
-import timber.log.Timber
-import java.util.Locale
 import javax.inject.Inject
 
 private fun Context.hasSplashBeenSeen(): Boolean =
@@ -92,9 +81,6 @@ class MainActivity : ComponentActivity() {
         setContent {
             val viewModel: ChatViewModel = hiltViewModel()
             val uiState by viewModel.uiState.collectAsState()
-            val languageCode by viewModel.selectedLanguage.collectAsStateWithLifecycle()
-
-            val layoutDirection = LocaleHelper.layoutDirectionFor(languageCode)
 
             val darkTheme = when (uiState.themeMode) {
                 "dark" -> true
@@ -102,124 +88,75 @@ class MainActivity : ComponentActivity() {
                 else -> isSystemInDarkTheme()
             }
 
-            // Build a locale-aware Configuration AND a locale-aware Context so that all
-            // stringResource() calls inside the composition tree resolve strings from the
-            // correct locale's strings.xml without requiring an Activity restart.
-            //
-            // We provide BOTH LocalConfiguration and LocalContext:
-            //   - LocalConfiguration: used by Material3 / Compose internals for layout metrics.
-            //   - LocalContext: used by stringResource() to look up string resources; we wrap
-            //     it with createConfigurationContext() so the Resources object uses the new locale.
-            //
-            // IMPORTANT — Activity context preservation:
-            // hiltViewModel() (via hilt-navigation-compose) calls LocalContext.current and then
-            // walks the ContextWrapper chain looking for a ComponentActivity via findActivity().
-            // createConfigurationContext() wraps the Activity's *baseContext* (not the Activity
-            // itself), which breaks that walk.  We therefore create the localized context by
-            // wrapping the Activity directly, so the chain is:
-            //   LocalizedActivityContext → Activity → ...
-            // This keeps hiltViewModel() working in every NavHost destination.
-            val activity = LocalContext.current
-            @SuppressLint("AppBundleLocaleChanges")
-            val localizedConfiguration = remember(languageCode) {
-                val locale = Locale(languageCode)
-                Configuration(activity.resources.configuration).also { cfg ->
-                    cfg.setLocale(locale)
-                }
-            }
-            // Wrap the Activity (not its baseContext) so the ContextWrapper chain still
-            // contains the ComponentActivity that hiltViewModel() needs.
-            val localizedContext: Context = remember(languageCode) {
-                object : ContextWrapper(activity) {
-                    private val localizedResources = activity.createConfigurationContext(localizedConfiguration).resources
-                    override fun getResources() = localizedResources
-                }
-            }
-
-            // DIAGNOSTIC: confirm StateFlow propagation + localized resources.
-            // Logs once per languageCode change. Read with `adb logcat -s VoxLocale:V`.
-            LaunchedEffect(languageCode) {
-                val sample = R.string.app_name
-                val viaWrapper = localizedContext.resources.getString(sample)
-                val viaActivity = activity.resources.getString(sample)
-                Timber.tag("VoxLocale").i(
-                    "languageCode=%s wrapper.app_name=%s activity.app_name=%s wrapperResLocales=%s",
-                    languageCode,
-                    viaWrapper,
-                    viaActivity,
-                    localizedContext.resources.configuration.locales.toLanguageTags(),
-                )
-            }
-
+            // Locale handling lives at the system level: the picker calls
+            // ChatViewModel.setLocale(...) -> LocaleApplier.apply(...) ->
+            // AppCompatDelegate.setApplicationLocales(...). The platform recreates this
+            // Activity with the new Configuration, so stringResource() and the layout
+            // direction (RTL for Arabic) just work without per-composition wrapping.
             VoxQuietaTheme(darkTheme = darkTheme) {
-                CompositionLocalProvider(
-                    LocalLayoutDirection provides layoutDirection,
-                    LocalConfiguration provides localizedConfiguration,
-                    LocalContext provides localizedContext,
-                ) {
-                    val navController = rememberNavController()
+                val navController = rememberNavController()
+                val context = LocalContext.current
 
-                    // Track screen views every time the user navigates to a new destination.
-                    DisposableEffect(navController) {
-                        val listener = NavController.OnDestinationChangedListener { _, destination, _ ->
-                            // Strip route args so "chat/{conversationId}" → "chat"
-                            val screenName = destination.route
-                                ?.substringBefore("/")
-                                ?: "unknown"
-                            analyticsHelper.setCurrentScreen(screenName)
+                // Track screen views every time the user navigates to a new destination.
+                DisposableEffect(navController) {
+                    val listener = NavController.OnDestinationChangedListener { _, destination, _ ->
+                        // Strip route args so "chat/{conversationId}" → "chat"
+                        val screenName = destination.route
+                            ?.substringBefore("/")
+                            ?: "unknown"
+                        analyticsHelper.setCurrentScreen(screenName)
+                    }
+                    navController.addOnDestinationChangedListener(listener)
+                    onDispose {
+                        navController.removeOnDestinationChangedListener(listener)
+                    }
+                }
+
+                val startDestination = remember {
+                    if (context.hasSplashBeenSeen()) "conversations" else "splash"
+                }
+
+                Box {
+                    NavHost(
+                        navController = navController,
+                        startDestination = startDestination,
+                    ) {
+                        composable("splash") {
+                            SplashScreen(
+                                onComplete = {
+                                    context.markSplashSeen()
+                                    navController.navigate("conversations") {
+                                        popUpTo("splash") { inclusive = true }
+                                    }
+                                },
+                            )
                         }
-                        navController.addOnDestinationChangedListener(listener)
-                        onDispose {
-                            navController.removeOnDestinationChangedListener(listener)
+                        composable("conversations") {
+                            ConversationsScreen(
+                                onNewConversation = { navController.navigate("chat/new") },
+                                onSelectConversation = { id -> navController.navigate("chat/$id") },
+                                onOpenSettings = { navController.navigate("settings") },
+                            )
+                        }
+                        composable("chat/{conversationId}") { backStackEntry ->
+                            val conversationId = backStackEntry.arguments?.getString("conversationId")
+                            ChatScreen(
+                                conversationId = conversationId,
+                                onOpenSettings = { navController.navigate("settings") },
+                            )
+                        }
+                        composable("settings") {
+                            SettingsScreen(
+                                onNavigateBack = { navController.popBackStack() },
+                            )
                         }
                     }
 
-                    val startDestination = remember {
-                        if (localizedContext.hasSplashBeenSeen()) "conversations" else "splash"
-                    }
-
-                    Box {
-                        NavHost(
-                            navController = navController,
-                            startDestination = startDestination,
-                        ) {
-                            composable("splash") {
-                                SplashScreen(
-                                    onComplete = {
-                                        localizedContext.markSplashSeen()
-                                        navController.navigate("conversations") {
-                                            popUpTo("splash") { inclusive = true }
-                                        }
-                                    },
-                                )
-                            }
-                            composable("conversations") {
-                                ConversationsScreen(
-                                    onNewConversation = { navController.navigate("chat/new") },
-                                    onSelectConversation = { id -> navController.navigate("chat/$id") },
-                                    onOpenSettings = { navController.navigate("settings") },
-                                )
-                            }
-                            composable("chat/{conversationId}") { backStackEntry ->
-                                val conversationId = backStackEntry.arguments?.getString("conversationId")
-                                ChatScreen(
-                                    conversationId = conversationId,
-                                    onOpenSettings = { navController.navigate("settings") },
-                                )
-                            }
-                            composable("settings") {
-                                SettingsScreen(
-                                    onNavigateBack = { navController.popBackStack() },
-                                )
-                            }
-                        }
-
-                        // Activity-scoped Turnstile widget. Stays mounted for the
-                        // life of the activity so any first POST request (regardless
-                        // of which screen the user navigates to first) finds a fresh
-                        // token already cached. The widget itself is 1.dp / invisible.
-                        TurnstileWebView(turnstileManager = turnstileManager)
-                    }
+                    // Activity-scoped Turnstile widget. Stays mounted for the
+                    // life of the activity so any first POST request (regardless
+                    // of which screen the user navigates to first) finds a fresh
+                    // token already cached. The widget itself is 1.dp / invisible.
+                    TurnstileWebView(turnstileManager = turnstileManager)
                 }
             }
         }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -24,6 +24,7 @@ import org.voxquieta.app.domain.repositories.ChurchRepository
 import org.voxquieta.app.domain.repositories.ContactRepository
 import org.voxquieta.app.presentation.components.ContactFormState
 import org.voxquieta.app.security.TurnstileManager
+import org.voxquieta.app.utils.LocaleApplier
 import org.voxquieta.app.utils.LogCollector
 import org.voxquieta.app.utils.NetworkMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -135,6 +136,7 @@ class ChatViewModel @Inject constructor(
     private val sessionPreferences: SessionPreferences,
     private val bibleApiService: BibleApiService,
     private val networkMonitor: NetworkMonitor,
+    private val localeApplier: LocaleApplier,
 ) : ViewModel() {
 
     companion object {
@@ -602,10 +604,13 @@ class ChatViewModel @Inject constructor(
     }
 
     /**
-     * Updates the language locale in-memory and persists it via DataStore.
+     * Updates the language locale in-memory, persists it via DataStore, and applies
+     * it system-wide so every stringResource() reflects the new locale after the
+     * Activity recreate that AppCompatDelegate.setApplicationLocales triggers.
      */
     fun setLocale(locale: String) {
         _uiState.update { it.copy(currentLocale = locale) }
+        localeApplier.apply(locale)
         viewModelScope.launch {
             languagePreferences.setLanguage(locale)
         }

--- a/android/app/src/main/kotlin/org/voxquieta/app/utils/LocaleApplier.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/utils/LocaleApplier.kt
@@ -1,0 +1,40 @@
+package org.voxquieta.app.utils
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Applies a per-app locale at the system level. The implementation uses
+ * AppCompatDelegate.setApplicationLocales which:
+ *   - Triggers a single Activity recreate so every stringResource() reflects the choice.
+ *   - Persists the choice via the platform LocaleManager (API 33+) or AndroidX backport (API 21–32).
+ *   - Surfaces the app in the system Settings -> App languages screen.
+ *
+ * Abstracted behind an interface so unit tests can substitute a no-op implementation
+ * (AppCompatDelegate is part of the Android runtime and not present on the JVM test classpath).
+ */
+interface LocaleApplier {
+    fun apply(languageTag: String)
+}
+
+@Singleton
+class AppCompatLocaleApplier @Inject constructor() : LocaleApplier {
+    override fun apply(languageTag: String) {
+        AppCompatDelegate.setApplicationLocales(
+            LocaleListCompat.forLanguageTags(languageTag)
+        )
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LocaleApplierModule {
+    @Binds
+    abstract fun bindLocaleApplier(impl: AppCompatLocaleApplier): LocaleApplier
+}

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en"/>
+    <locale android:name="ar"/>
+    <locale android:name="de"/>
+    <locale android:name="es"/>
+    <locale android:name="fr"/>
+    <locale android:name="hi"/>
+    <locale android:name="it"/>
+    <locale android:name="ko"/>
+    <locale android:name="pt"/>
+    <locale android:name="ru"/>
+    <locale android:name="zh"/>
+</locale-config>

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -26,6 +26,7 @@ import org.voxquieta.app.presentation.viewmodels.ChapterSheetState
 import org.voxquieta.app.presentation.viewmodels.ChurchFinderSheetState
 import org.voxquieta.app.presentation.viewmodels.ChatViewModel
 import org.voxquieta.app.security.TurnstileManager
+import org.voxquieta.app.utils.LocaleApplier
 import org.voxquieta.app.utils.NetworkMonitor
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -72,6 +73,9 @@ class ChatViewModelTest {
     private lateinit var sessionPreferences: SessionPreferences
     private lateinit var bibleApiService: BibleApiService
     private lateinit var networkMonitor: NetworkMonitor
+    private val localeApplier: LocaleApplier = object : LocaleApplier {
+        override fun apply(languageTag: String) { /* no-op for unit tests */ }
+    }
     private lateinit var viewModel: ChatViewModel
 
     private val stubConversation = Conversation(
@@ -126,6 +130,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
     }
 
@@ -460,6 +465,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -484,6 +490,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -514,6 +521,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -548,6 +556,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(vm.availableTranslations.value.isEmpty())
@@ -587,6 +596,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -616,6 +626,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -1419,6 +1430,7 @@ class ChatViewModelTest {
             sessionPreferences,
             bibleApiService,
             networkMonitor,
+            localeApplier,
         )
         assertEquals("de", vm.uiState.value.currentLocale)
     }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -29,10 +29,12 @@ owaspDepCheck = "12.1.0"
 hiltTesting = "2.51.1"          # same as hilt version
 androidxTestRunner = "1.6.2"
 composeMarkdown = "0.5.0"
+appcompat = "1.7.0"
 
 [libraries]
 # AndroidX Core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
**Draft / parallel option** — opened so it's ready to merge if the diagnostic in #501 confirms the manual Compose-only path can't be salvaged. Don't merge until that decision is made.

## Why

Multiple attempts (PRs #485, #487, #488, #499, plus #501) to fix the language picker via Compose-only context wrapping (`createConfigurationContext` + `CompositionLocalProvider(LocalContext, LocalConfiguration)`) have all failed in practice: picker color changes, LLM responses are localized, but `stringResource()` strings on every screen stay in the system locale.

This PR pivots to the **officially supported** AndroidX per-app language API: `AppCompatDelegate.setApplicationLocales(...)`. It triggers a single Activity recreate so the entire UI re-resolves resources from the new locale's `strings.xml`. This is the path Google documents at [developer.android.com/guide/topics/resources/app-languages](https://developer.android.com/guide/topics/resources/app-languages).

## How it works

1. User taps language in picker → `ChatViewModel.setLocale(code)`.
2. `setLocale` writes `uiState.currentLocale = code` (used for the LLM `language` parameter), persists via `LanguagePreferences`, then calls `LocaleApplier.apply(code)`.
3. `AppCompatLocaleApplier` calls `AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code))`.
4. Platform recreates `MainActivity` with a `Configuration` reflecting the chosen locale.
5. Every `stringResource(...)` call resolves against the new `values-<lang>/strings.xml` automatically — no Compose plumbing needed.
6. Layout direction (RTL for Arabic) is also handled by the platform Configuration.
7. Persistence: platform `LocaleManager` (API 33+) or AndroidX backport (API 21–32). Our `LanguagePreferences` stays in sync because the LLM path still reads `uiState.currentLocale`.

## Files changed

| File | Change |
|---|---|
| `android/gradle/libs.versions.toml` | New `androidx-appcompat = 1.7.0` |
| `android/app/build.gradle.kts` | `implementation(libs.androidx.appcompat)` |
| `android/app/src/main/res/xml/locales_config.xml` (new) | Lists all 11 supported locales |
| `android/app/src/main/AndroidManifest.xml` | `android:localeConfig="@xml/locales_config"` |
| `android/app/src/main/kotlin/.../utils/LocaleApplier.kt` (new) | Interface + AppCompat impl + Hilt module |
| `android/app/src/main/kotlin/.../viewmodels/ChatViewModel.kt` | Inject `LocaleApplier`; call from `setLocale(...)` |
| `android/app/src/main/kotlin/.../MainActivity.kt` | Drop ~30 lines of `createConfigurationContext` + `CompositionLocalProvider` wrapping |
| `android/app/src/test/kotlin/.../ChatViewModelTest.kt` | No-op fake `LocaleApplier` passed to 8 constructor sites |

## Trade-offs

| | Manual Compose path (#501) | This PR |
|---|---|---|
| Activity recreate | No | Yes (single recreate, ~150ms flash) |
| Works with `stringResource()` | Doesn't, in practice | Yes (system handles it) |
| System Settings → App languages integration | No | Yes |
| Code volume | ~30 lines context wrapping | ~3 lines + manifest entry + locale-config XML |
| Test isolation | Direct | Requires `LocaleApplier` interface to mock |

## Known caveat — documented, not fixed

`AppCompatDelegate.setApplicationLocales(...)` recreates the Activity, which destroys `ChatViewModel`. If the user changes language **mid-conversation**, any in-flight LLM streaming response is cancelled and the messages list reloads from Room (existing behavior on rotation/cold-start). The picker is in Settings, so this is unlikely in practice. Acceptable given the alternative (broken language switching) is worse.

## Test plan

- [ ] CI green (compile, lint, unit tests).
- [ ] Install debug build → open in English → tap picker → choose Italian → entire UI flips to Italian after a brief flash → tap `+` → new chat screen is in Italian.
- [ ] Pick Arabic → layout flips RTL.
- [ ] Kill + reopen → still in chosen language (system-restored, plus our prefs seed `uiState.currentLocale` for the LLM call).
- [ ] Settings → System → Languages → "App languages" → Vox Quieta is listed and the chosen locale is shown there.
- [ ] LLM responses still arrive in the chosen language (`uiState.currentLocale` flow unchanged).

## Relationship to #501

#501 keeps the AD_ID decision doc and adds a diagnostic `LaunchedEffect`. If the diagnostic confirms `localizedContext.resources.getString(R.string.app_name)` returns the localized string but `stringResource()` callers don't see it, then the manual path is unsalvageable and we merge this PR instead.

https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJPm2SdEXZ8JoSBDQKbvqN)_