### PR TITLE
fix(android): eliminate NetworkOnMainThreadException and HTTP 403 in chatStream

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptor.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptor.kt
@@ -27,8 +27,9 @@ class TurnstileInterceptor @Inject constructor(
         val needsToken = original.method.equals("POST", ignoreCase = true)
         val token = turnstileManager.currentToken()
             ?: if (needsToken) awaitTokenOrNull() else null
-        return if (token != null) {
-            val response = chain.proceed(
+
+        val response = if (token != null) {
+            val r = chain.proceed(
                 original.newBuilder()
                     .header("X-Turnstile-Token", token)
                     .build()
@@ -40,10 +41,29 @@ class TurnstileInterceptor @Inject constructor(
             // a fresh token next time without each repository having to
             // remember to call onTokenConsumed().
             turnstileManager.onTokenConsumed()
-            response
+            r
         } else {
             chain.proceed(original)
         }
+
+        // On 403 for any POST the token was missing or stale. The WebView reset
+        // was already triggered by onTokenConsumed() above (or was never needed).
+        // Wait for the fresh token and retry exactly once before surfacing the
+        // error — fail-open: if still no token after the wait, proceed without one.
+        if (response.code == 403 && needsToken) {
+            response.close()
+            val freshToken = awaitTokenOrNull()
+                ?: return chain.proceed(original)
+            val retried = chain.proceed(
+                original.newBuilder()
+                    .header("X-Turnstile-Token", freshToken)
+                    .build()
+            )
+            turnstileManager.onTokenConsumed()
+            return retried
+        }
+
+        return response
     }
 
     // Bounded wait for the Turnstile WebView to deliver a token. Returns null

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/repositories/ChatRepositoryImpl.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/repositories/ChatRepositoryImpl.kt
@@ -15,8 +15,10 @@ import org.voxquieta.app.domain.models.FeedbackRating
 import org.voxquieta.app.domain.models.Message
 import org.voxquieta.app.domain.models.StreamChunk
 import org.voxquieta.app.domain.repositories.ChatRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
@@ -33,7 +35,7 @@ class ChatRepositoryImpl @Inject constructor(
         // runs within a coroutine context, then forward each parsed chunk downstream.
         val responseBody = api.chatStream(request.toDto())
         responseBody.toChunkFlow().collect { emit(it.toDomain()) }
-    }
+    }.flowOn(Dispatchers.IO)
 
     // ── Persistence ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **`NetworkOnMainThreadException`**: Added `.flowOn(Dispatchers.IO)` to `ChatRepositoryImpl.chatStream()` so the entire SSE flow — including `ResponseBody.close()` / SSL socket teardown — unconditionally runs on the IO thread pool, never on the main thread.
- **HTTP 403**: Added a retry-on-403 block in `TurnstileInterceptor.intercept()`. When the backend rejects a POST with 403 (Turnstile token missing or stale), the interceptor closes the response, waits for the WebView to finish its Cloudflare challenge, and replays the request once with the fresh token. Fail-open behaviour is preserved if the second wait also times out.

## Root causes

Both errors were reported by a tester on a real device but not reproduced in development:

- The `NetworkOnMainThreadException` is a race: on a fast emulator OkHttp's own thread pool closes the SSL socket before the main-thread `body.close()` reaches the SSL layer. On a real device over cellular the main thread wins the race and StrictMode fires.
- The HTTP 403 occurs when the Turnstile WebView hasn't finished a Cloudflare round-trip before the next request fires. The original code timed out and sent the request tokenless; the server returned 403. Increasing the timeout alone doesn't fix this since Cloudflare can be arbitrarily slow — the retry approach handles it regardless.

## Test plan

- [ ] Build and install debug APK on a real device (not emulator)
- [ ] Send a chat message — confirm no `NetworkOnMainThreadException` in logcat
- [ ] Send a second message immediately after the first to race the Turnstile reset — confirm no HTTP 403 surfaces to the user
- [ ] Run unit tests: `./gradlew :app:testDebugUnitTest`

https://claude.ai/code/session_01MDCBwFvyZN5iwMEZezGUtQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDCBwFvyZN5iwMEZezGUtQ)_