### PR TITLE
ci(release-please): lint-fix bot PR + serialize concurrent runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please
@@ -18,6 +22,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      pr: ${{ steps.release.outputs.pr }}
 
     steps:
       - name: Run Release Please
@@ -37,6 +42,69 @@ jobs:
           # secrets.GITHUB_TOKEN) and uncomment the step below. It dispatches the
           # android-publish workflow explicitly when a release is created, working
           # around the limitation that GITHUB_TOKEN-pushed tags don't trigger workflows.
+
+  lint-fix-release-pr:
+    name: Lint-fix Release PR
+    runs-on: ubuntu-latest
+    needs: release-please
+    # release-please-action v4 sets `pr` when it opens or updates a PR.
+    if: needs.release-please.outputs.pr != ''
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout release-please PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: release-please--branches--main
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.x"
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Determine changed files vs main
+        id: changed
+        run: |
+          git fetch origin main --depth=1
+          files=$(git diff --name-only origin/main...HEAD | tr '\n' ' ')
+          echo "files=${files}" >> "$GITHUB_OUTPUT"
+
+      - name: Run pre-commit on changed files (auto-fix)
+        if: steps.changed.outputs.files != ''
+        run: |
+          SKIP=hadolint-docker pre-commit run \
+            --files ${{ steps.changed.outputs.files }} || true
+
+      - name: Commit and push fixes if any
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "chore: lint-fix release-please output"
+            git push origin HEAD:release-please--branches--main
+          fi
 
 # yamllint disable rule:comments-indentation
 # ── Fallback job (approach b) — uncomment if not using a PAT ─────────────────────────────

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -140,6 +140,35 @@ input (`internal` | `beta` | `production`). To promote a build:
 
 ---
 
+## Reviewing a Release PR before merging
+
+The Release PR is the manual review surface — you are not expected to merge
+it blindly.
+
+1. A push to `main` triggers `.github/workflows/release-please.yml`. It
+   opens or updates a single PR on branch `release-please--branches--main`
+   (titled like `chore(main): release X.Y.Z`) that touches
+   `CHANGELOG.md` and `.release-please-manifest.json`.
+2. The follow-up `Lint-fix Release PR` job in the same workflow runs
+   pre-commit (`SKIP=hadolint-docker`) on the PR's changed files and
+   pushes back any auto-fixes (trailing whitespace, EOF, markdownlint
+   `--fix`) as a `chore: lint-fix release-please output` commit. Wait for
+   `Pre-Commit Validation` and `Lint Commit Messages` to go green on the
+   PR before merging.
+3. **To curate the notes**: check the PR branch out locally, edit
+   `CHANGELOG.md`, commit with a `chore:` or `docs:` prefix (so commitlint
+   passes), and push. Force-push is not needed because release-please
+   merges into the existing branch.
+4. Merge the PR. release-please then creates the `vX.Y.Z` tag and the
+   GitHub Release on the next workflow run, which fires
+   `android-publish.yml` (see Overview above).
+
+> ⚠️ **Do not retarget the Release PR's base** to a side branch. release-please
+> only creates tags when its PR merges into the configured release branch
+> (`main`). A staging branch in between silently breaks tagging.
+
+---
+
 ## Seeded version
 
 The manifest was seeded at **`0.1.0`** because no git tags existed in the


### PR DESCRIPTION
## Summary

- Adds a `Lint-fix Release PR` job to `.github/workflows/release-please.yml` that runs pre-commit on the bot's PR (`release-please--branches--main`) and pushes auto-fixes back, so CI's `Pre-Commit Validation` no longer fails on auto-fixable formatting (trailing whitespace, EOF newline, markdownlint MD003) that release-please writes into `CHANGELOG.md`.
- Exposes the action's `pr` output and gates the new job on it.
- Adds a workflow-level `concurrency:` block so two pushes to `main` can't race the lint-fix push.
- Documents the manual review path in `docs/RELEASE_PROCESS.md` and warns against retargeting the Release PR's base to a side branch (which silently breaks tag creation — the cause of PR #510).

## Context

PR #510 was failing both `Lint Commit Messages` and `Pre-Commit Hooks` because `release-please--branches--main--release-notes` was a manually-created staging branch with a non-conventional commit, and PR #479 had been retargeted to that branch — silently breaking release-please's tagging. PR #510 is now closed; PR #479's base is back on `main`.

## Test plan

- [ ] `Pre-Commit Validation` passes on this PR (both files lint-clean locally with `SKIP=hadolint-docker pre-commit run`).
- [ ] `Lint Commit Messages` passes (`ci(release-please): …` is conventional).
- [ ] After merge, next push to `main` triggers release-please: `Run Release Please` opens/updates the bot PR, then `Lint-fix Release PR` runs and either passes with no changes or commits a `chore: lint-fix release-please output` fix.
- [ ] On the bot PR, `Pre-Commit Validation` and `Lint Commit Messages` both go green.
- [ ] Release PR merge produces a `vX.Y.Z` tag and triggers `android-publish.yml`.
- [ ] Manual: delete remote branch `release-please--branches--main--release-notes` (the local sandbox couldn't — HTTP 403).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF1jkHBFu7NC6YR5XNPMf9)_