### PR TITLE
docs(release): clarify single-branch model and stale --release-notes

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -145,6 +145,15 @@ input (`internal` | `beta` | `production`). To promote a build:
 The Release PR is the manual review surface — you are not expected to merge
 it blindly.
 
+> **Only one branch is created by release-please.** It is named
+> `release-please--branches--main` (no suffix). It modifies exactly two
+> files: `CHANGELOG.md` and `.release-please-manifest.json`. There is no
+> `--release-notes` branch and no `release-notes.md` file in this repo —
+> if you see either, they are stale and should be deleted, not opened as a
+> PR. To read formatted notes for a single release, look at the GitHub
+> Release body created when the Release PR merges (or the corresponding
+> `## [vX.Y.Z]` section of `CHANGELOG.md`).
+
 1. A push to `main` triggers `.github/workflows/release-please.yml`. It
    opens or updates a single PR on branch `release-please--branches--main`
    (titled like `chore(main): release X.Y.Z`) that touches


### PR DESCRIPTION
## Summary

Adds one paragraph to `docs/RELEASE_PROCESS.md` clarifying that release-please only ever creates the `release-please--branches--main` branch (no suffix) and only touches `CHANGELOG.md` + `.release-please-manifest.json`. There is no `--release-notes` branch or `release-notes.md` file; any seen are stale.

## Why

PRs #510 and #514 were both opened from a stale `release-please--branches--main--release-notes` branch under the (incorrect) assumption that it was bot-created. They both failed `Lint Commit Messages` and `Pre-Commit Hooks` for the same reasons. Closing them and adding this paragraph makes the misconception hard to repeat.

## Test plan

- [ ] `Pre-Commit Validation` and `Lint Commit Messages` pass on this PR (docs-only, lints clean locally).
- [ ] Manual: delete the stale branch `release-please--branches--main--release-notes` from origin (sandbox can't — HTTP 403). Confirm with `git ls-remote origin 'refs/heads/release-please*'` returns only `release-please--branches--main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF1jkHBFu7NC6YR5XNPMf9)_