### PR TITLE
docs(release): add Issues:write scope to RELEASE_PLEASE_TOKEN requirements

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,10 +29,14 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # RELEASE_PLEASE_TOKEN must be a PAT with `contents: write` and `workflows: write`
-          # so that the tag it creates can trigger the `on: push: tags` in android-publish.yml.
-          # GITHUB_TOKEN-created tags do NOT trigger downstream tag-based workflows.
-          # See docs/RELEASE_PROCESS.md for setup instructions.
+          # RELEASE_PLEASE_TOKEN must be a fine-grained PAT with:
+          #   contents: write     — push tags, update manifest
+          #   pull-requests: write — open/update the Release PR
+          #   issues: write       — add autorelease labels (GitHub routes PR
+          #                         label writes through the Issues API)
+          #   workflows: write    — tag push triggers android-publish.yml
+          # GITHUB_TOKEN-created tags do NOT trigger downstream tag-based
+          # workflows (GitHub security restriction). See docs/RELEASE_PROCESS.md.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -83,6 +83,9 @@ as a repository secret:
 2. Create a token scoped to `zioalex/getinspiredbythebible` with:
    - **Contents:** Read and write (to push tags and update the manifest)
    - **Pull requests:** Read and write (to open/update the Release PR)
+   - **Issues:** Read and write (to add `autorelease: pending/tagged` labels —
+     GitHub routes PR label writes through the Issues API even though no
+     issue tracker is used)
    - **Workflows:** Read and write (so the tag push can trigger workflow runs)
 3. Copy the token value.
 


### PR DESCRIPTION
## Summary

- Adds `Issues: Read and write` to the `RELEASE_PLEASE_TOKEN` PAT requirements in `docs/RELEASE_PROCESS.md` — release-please adds `autorelease: pending/tagged` labels to the Release PR, and GitHub routes all PR label writes through the Issues API (even though no issue tracker is used). Without this scope the action fails with `Resource not accessible by personal access token` on the labels step, which is exactly what happened in the recent pipeline failure.
- Updates the inline comment in `.github/workflows/release-please.yml` to list all four required scopes with one-line explanations each.

## Context

After PR #513 merged, the Release Please pipeline failed with:
```
Error: release-please failed: Resource not accessible by personal access token
- https://docs.github.com/rest/issues/labels#add-labels-to-an-issue
```
The PAT was set up with `contents`, `pull-requests`, `workflows` — missing `issues`.

## Test plan

- [ ] `Pre-Commit Validation` and `Lint Commit Messages` pass (docs + workflow comment only, lints clean locally).
- [ ] After merge and token update, re-run Release Please workflow — should succeed through the labels step.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF1jkHBFu7NC6YR5XNPMf9)_