### PR TITLE
ci: auto-close PRs from stale --release-notes branches

### DIFF
--- a/.github/workflows/close-stale-release-notes-pr.yml
+++ b/.github/workflows/close-stale-release-notes-pr.yml
@@ -1,0 +1,55 @@
+name: Close stale release-notes PRs
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close-release-notes-pr:
+    name: Close stale release-notes PR
+    runs-on: ubuntu-latest
+    if: endsWith(github.head_ref, '--release-notes')
+
+    steps:
+      - name: Close PR and explain
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                "## Stale branch — closing automatically",
+                "",
+                "This PR was opened from a branch ending in `--release-notes`.",
+                "That branch is **not** created by release-please automation.",
+                "",
+                "release-please only ever creates one branch:",
+                "`release-please--branches--main` (no suffix).",
+                "It modifies exactly two files: `CHANGELOG.md` and",
+                "`.release-please-manifest.json`.",
+                "",
+                "There is no `release-notes.md` file in this repo — if you see one,",
+                "it was created by a Copilot session or another tool and should be",
+                "discarded. The authoritative release notes are in:",
+                "- `CHANGELOG.md` (updated by release-please when the Release PR merges)",
+                "- The GitHub Release body (created automatically on tag push)",
+                "",
+                "See `docs/RELEASE_PROCESS.md` for the full release flow.",
+                "",
+                "Please delete the `" + context.payload.pull_request.head.ref + "` branch.",
+              ].join("\n"),
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: "closed",
+            });

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,10 +29,14 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          # RELEASE_PLEASE_TOKEN must be a PAT with `contents: write` and `workflows: write`
-          # so that the tag it creates can trigger the `on: push: tags` in android-publish.yml.
-          # GITHUB_TOKEN-created tags do NOT trigger downstream tag-based workflows.
-          # See docs/RELEASE_PROCESS.md for setup instructions.
+          # RELEASE_PLEASE_TOKEN must be a fine-grained PAT with:
+          #   contents: write     — push tags, update manifest
+          #   pull-requests: write — open/update the Release PR
+          #   issues: write       — add autorelease labels (GitHub routes PR
+          #                         label writes through the Issues API)
+          #   workflows: write    — tag push triggers android-publish.yml
+          # GITHUB_TOKEN-created tags do NOT trigger downstream tag-based
+          # workflows (GitHub security restriction). See docs/RELEASE_PROCESS.md.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -83,6 +83,9 @@ as a repository secret:
 2. Create a token scoped to `zioalex/getinspiredbythebible` with:
    - **Contents:** Read and write (to push tags and update the manifest)
    - **Pull requests:** Read and write (to open/update the Release PR)
+   - **Issues:** Read and write (to add `autorelease: pending/tagged` labels —
+     GitHub routes PR label writes through the Issues API even though no
+     issue tracker is used)
    - **Workflows:** Read and write (so the tag push can trigger workflow runs)
 3. Copy the token value.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/close-stale-release-notes-pr.yml` — a workflow that fires whenever a PR is opened or reopened from a branch ending in `--release-notes`
- Posts an explanatory comment on the PR and closes it automatically
- Prevents CI failures from accumulating on these phantom PRs

## Root cause

GitHub Copilot (SWE agent or Workspace) periodically reads PR #479's body (the release-please changelog) and saves it as `release-notes.md` on a branch named `release-please--branches--main--release-notes`, then opens a PR from it. The commits are attributed to the repo owner's account because Copilot uses their token.

release-please only ever creates **one** branch: `release-please--branches--main` (no suffix). It only modifies `CHANGELOG.md` and `.release-please-manifest.json`. The `--release-notes` branch and `release-notes.md` file are not part of the release flow.

## Test plan

- [ ] Merge this PR
- [ ] Delete the stale `release-please--branches--main--release-notes` branch (GitHub UI: Branches → trash icon)
- [ ] Cancel any active Copilot Workspace/SWE-agent session that references release notes
- [ ] Next time a `--release-notes` PR is opened, verify the workflow closes it within seconds with the explanatory comment

https://claude.ai/code/session_01CF1jkHBFu7NC6YR5XNPMf9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF1jkHBFu7NC6YR5XNPMf9)_