### PR TITLE
fix(android): auto-detect language when user has not set an explicit preference

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/preferences/LanguagePreferences.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/preferences/LanguagePreferences.kt
@@ -24,7 +24,11 @@ class LanguagePreferences @Inject constructor(
 ) {
     companion object {
         private val LANGUAGE_CODE_KEY = stringPreferencesKey("language_code")
-        const val DEFAULT_LANGUAGE = "en"
+        // Empty string means "no explicit user preference — let the backend auto-detect
+        // language from the message text".  A blank value is mapped to null in the API
+        // request (ChatViewModel.sendMessage: currentLocale.ifBlank { null }), so the
+        // backend receives no language hint and auto-detects correctly.
+        const val DEFAULT_LANGUAGE = ""
         private const val SYNC_PREFS_FILE = "language_sync_prefs"
         private const val SYNC_KEY = "language_code"
 
@@ -33,7 +37,11 @@ class LanguagePreferences @Inject constructor(
                 .getString(SYNC_KEY, DEFAULT_LANGUAGE) ?: DEFAULT_LANGUAGE
     }
 
-    /** A [Flow] that emits the currently persisted language code (default: "en"). */
+    /**
+     * A [Flow] that emits the currently persisted language code.
+     * Default is empty string, meaning no explicit preference (backend auto-detects).
+     * A non-empty value (e.g. "it", "en") means the user explicitly chose that language.
+     */
     val languageFlow: Flow<String> = dataStore.data.map { prefs ->
         prefs[LANGUAGE_CODE_KEY] ?: DEFAULT_LANGUAGE
     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -76,7 +76,8 @@ data class ChatUiState(
     val messages: List<Message> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
-    val currentLocale: String = "en",
+    // Empty string = no explicit user preference; backend auto-detects from message text.
+    val currentLocale: String = "",
     val isTurnstileReady: Boolean = false,
     /** ID of the currently active conversation; null when no conversation has started. */
     val currentConversationId: String? = null,

--- a/android/app/src/test/kotlin/org/voxquieta/app/preferences/LanguagePreferencesTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/preferences/LanguagePreferencesTest.kt
@@ -75,14 +75,20 @@ class LanguagePreferencesTest {
     // ── Default value ─────────────────────────────────────────────────────────
 
     @Test
-    fun `default language code is en`() = runTest(testDispatcher) {
+    fun `default language code is empty string`() = runTest(testDispatcher) {
         val code = languagePreferences.languageFlow.first()
-        assertEquals("en", code)
+        assertEquals("", code)
     }
 
     @Test
-    fun `DEFAULT_LANGUAGE constant equals en`() {
-        assertEquals("en", LanguagePreferences.DEFAULT_LANGUAGE)
+    fun `DEFAULT_LANGUAGE constant is empty string`() {
+        assertEquals("", LanguagePreferences.DEFAULT_LANGUAGE)
+    }
+
+    @Test
+    fun `setLanguage can persist en as an explicit user choice`() = runTest(testDispatcher) {
+        languagePreferences.setLanguage("en")
+        assertEquals("en", languagePreferences.languageFlow.first())
     }
 
     // ── Single set ────────────────────────────────────────────────────────────

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -1446,4 +1446,68 @@ class ChatViewModelTest {
         )
         assertEquals("de", vm.uiState.value.currentLocale)
     }
+
+    @Test
+    fun `sendMessage omits language when currentLocale is empty`() = runTest {
+        every { languagePreferences.readInitial() } returns ""
+        every { languagePreferences.languageFlow } returns flowOf("")
+        val requestSlot = slot<ChatRequest>()
+        every { repository.chatStream(capture(requestSlot)) } returns flowOf(
+            StreamChunk(content = "Reply", done = true),
+        )
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.sendMessage("Ciao come stai?")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(requestSlot.captured.language)
+    }
+
+    @Test
+    fun `sendMessage sends language when user explicitly selected a code`() = runTest {
+        every { languagePreferences.readInitial() } returns "it"
+        every { languagePreferences.languageFlow } returns flowOf("it")
+        val requestSlot = slot<ChatRequest>()
+        every { repository.chatStream(capture(requestSlot)) } returns flowOf(
+            StreamChunk(content = "Reply", done = true),
+        )
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("it", requestSlot.captured.language)
+    }
 }


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `LanguagePreferences.DEFAULT_LANGUAGE` was hardcoded to `"en"`. On a fresh install (or when no language was explicitly chosen), every API request included `language="en"`, which told the backend to skip auto-detection and always respond in English — even when the user typed in Italian, Spanish, German, etc.
- **Fix:** Changed `DEFAULT_LANGUAGE` to `""` (empty string). `ChatViewModel.sendMessage` already maps blank locale to `null` via `.ifBlank { null }`, so requests now omit the `language` field and the backend auto-detects correctly.
- **ChatUiState.currentLocale** default also changed from `"en"` to `""` for consistency.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Fresh install, user types Italian | Backend receives `language="en"` → responds in English | Backend receives no language → auto-detects Italian → responds in Italian |
| User explicitly picks Italian in picker | Backend receives `language="it"` → responds in Italian | Unchanged |
| User explicitly picks English in picker | Backend receives `language="en"` → responds in English | Unchanged |
| Existing user with `"en"` in DataStore (stored by old default) | Backend receives `language="en"` | Unchanged (still sends `"en"`) — acceptable since English queries auto-detect as English anyway |

## Migration note

Existing users who had `"en"` written to DataStore by the old default will continue to send `language="en"` until they open the language picker. This is acceptable:  English speakers auto-detect as English regardless, and the fix targets the new-install path which is where the bug manifests.

A future follow-up can add an "Auto-detect" row to the language picker to let users explicitly reset to auto-detection.

## Files changed

| File | Change |
|---|---|
| `LanguagePreferences.kt` | `DEFAULT_LANGUAGE = ""` + updated KDoc |
| `ChatViewModel.kt` | `currentLocale` field default `""` + inline comment |
| `LanguagePreferencesTest.kt` | Fix 2 assertions for new default; add `setLanguage can persist en as explicit user choice` |
| `ChatViewModelTest.kt` | Add `sendMessage omits language when currentLocale is empty`; add `sendMessage sends language when user explicitly selected a code` |

## Test plan

- [ ] CI: Android unit tests pass (LanguagePreferencesTest + ChatViewModelTest)
- [ ] Manual: fresh-install → type "Ciao come stai?" → AI responds in Italian
- [ ] Manual: pick Italian in language picker → type "Hello" → AI responds in Italian
- [ ] Manual: pick English in language picker → type "Ciao" → AI responds in English (explicit override)

https://claude.ai/code/session_01SYEjSxxC7swJrzr8CrF3eZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYEjSxxC7swJrzr8CrF3eZ)_