### PR TITLE
ci: skip backend + frontend + integration tests on doc-only PRs (BITB-028)

### DIFF
--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -11,10 +11,22 @@ run-name: >-
     branches:
       - main
       - feature/**
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - "docker-compose*.yml"
+      - "scripts/**"
+      - ".github/workflows/test_update.yml"
   push:
     branches:
       - main
       - feature/initial-implementation
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - "docker-compose*.yml"
+      - "scripts/**"
+      - ".github/workflows/test_update.yml"
 
 jobs:
   # Backend API Tests

--- a/docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md
+++ b/docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md
@@ -1,0 +1,116 @@
+# BITB-028: Skip Irrelevant CI Pipelines on Doc-Only / Story-Only Changes
+
+## User Story
+
+As a contributor, I want CI to skip pipelines that have nothing to do with my change (e.g. backend + frontend + integration tests when I only added a story under `docs/BACKLOG_STORIES/`), so that PRs that touch only documentation don't burn ~15 minutes of runner time and don't show a wall of unrelated failed/queued checks.
+
+## Problem
+
+After scanning all workflows under `.github/workflows/`, the picture is mixed:
+
+| Workflow | Path filters? | Behaviour on a doc-only PR |
+|---|---|---|
+| `android-ci.yml` | ✅ `android/**` + own file | correctly skipped |
+| `azure-deploy.yml` | ✅ `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, own file | correctly skipped |
+| `test_update.yml` (Backend + Frontend + Integration tests) | ❌ none | **runs everything** — backend pytest, frontend Vitest matrix on Node 20 + 22, plus a full docker-compose integration suite with Postgres/Ollama |
+| `pre-commit.yml` | ❌ none | runs (acceptable — it lints `docs/**` too) |
+| `commitlint.yml` | ❌ none | runs (intentional — must lint commit messages on every PR) |
+| `release-please.yml` | n/a — push to main only | not affected |
+| `prod-monitor.yml` | n/a — schedule only | not affected |
+| `android-publish.yml`, `android-debug.yml` | `workflow_dispatch` only | not affected |
+
+So the real waste is **`test_update.yml`**. A PR that only adds a markdown file under `docs/BACKLOG_STORIES/` (the most common "low-risk" change) currently spins up:
+
+- a Postgres service container + backend pytest run,
+- a Node 20 *and* Node 22 frontend test matrix (two parallel jobs),
+- a full docker-compose integration test that pulls Ollama, builds the API and frontend images, and runs end-to-end checks.
+
+That's ~10–15 runner-minutes for a change that cannot affect any of those code paths.
+
+The user-reported symptom — "all the android tests run when only a story has been created" — is most likely conflating the heavy `test_update.yml` run with `android-ci.yml`. We should both verify the Android side is genuinely path-filtered (it is) and fix the bigger leak in `test_update.yml`.
+
+## Proposed Changes
+
+### 1. Add path filters to `test_update.yml`
+
+Restrict trigger paths to the directories the workflow actually exercises:
+
+```yaml
+on:
+  pull_request:
+    branches: [main, "feature/**"]
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - "docker-compose*.yml"
+      - "scripts/**"
+      - ".github/workflows/test_update.yml"
+  push:
+    branches: [main, feature/initial-implementation]
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - "docker-compose*.yml"
+      - "scripts/**"
+      - ".github/workflows/test_update.yml"
+```
+
+Notes:
+
+- `commitlint.config.cjs`, `release-please-config.json`, repo-level `*.md` files, and anything under `docs/`, `android/`, `multiple_embeddings/`, `data/`, `infra/` will then no longer trigger backend/frontend/integration tests.
+- Keep the workflow's own filename in the path list so a CI tweak still runs the suite once.
+- Verify by opening a draft PR that touches only `docs/BACKLOG_STORIES/foo.md` and confirming `test_update.yml` is skipped while `commitlint.yml` and `pre-commit.yml` still run.
+
+### 2. Split frontend-only vs backend-only triggers (optional, follow-up)
+
+The current `test_update.yml` is one workflow with three jobs. A frontend-only change still kicks off backend pytest (and vice-versa). A cleaner split — either two `paths` lists guarded per-job via `dorny/paths-filter`, or two separate workflow files — would let frontend-only PRs skip backend pytest and integration tests.
+
+If we go this route, mirror the pattern already used in `azure-deploy.yml` (line ~156, `dorny/paths-filter@v4` with named filters) so we don't introduce a new technique.
+
+### 3. Add a "required-checks" awareness section to `docs/CONTRIBUTING.md`
+
+If a PR's files match no path filter for a given workflow, GitHub records the workflow as **skipped**, not **success**. Branch-protection rules that require `Backend API Tests` to pass will then block doc-only PRs forever.
+
+Two options, document both:
+
+- **Recommended**: switch the required check to `Pre-Commit Hooks` (which always runs) and treat backend/frontend tests as advisory-on-skip. Document that a blocked check from a doc-only PR can be auto-resolved by re-requesting review.
+- Or use a tiny "required-status" aggregator job (`if: always()` + sums `needs.*.result`) that converts a skipped backend-tests job into a passing check for branch protection.
+
+### 4. Re-confirm Android path filters work
+
+Open a doc-only PR and confirm `android-ci.yml` shows as skipped (not as a failed check). The current filter `paths: ["android/**", ".github/workflows/android-ci.yml"]` should already do this — this is a verification step, not a code change.
+
+## Acceptance Criteria
+
+- [ ] A PR whose only change is `docs/BACKLOG_STORIES/<foo>.md` does **not** trigger `test_update.yml` (backend, frontend matrix, integration tests).
+- [ ] A PR whose only change is under `docs/` does **not** trigger `android-ci.yml` (already true — verified, not changed).
+- [ ] A PR that modifies `api/**` still runs backend pytest *and* the integration tests.
+- [ ] A PR that modifies `frontend/**` still runs the frontend matrix *and* the integration tests (because the integration suite covers both).
+- [ ] Branch-protection required-status configuration is documented so that doc-only PRs are not blocked by skipped jobs (see "Required-checks awareness" section in `docs/CONTRIBUTING.md`).
+- [ ] `pre-commit.yml` and `commitlint.yml` continue to run on every PR (no regression in linting).
+
+## Files to Modify / Add
+
+| File | Change |
+|---|---|
+| `.github/workflows/test_update.yml` | Add `paths:` lists to `pull_request` and `push` triggers |
+| `docs/CONTRIBUTING.md` (or new section) | Document branch-protection behaviour with skipped checks |
+| (Optional, follow-up) `.github/workflows/test_update.yml` | Per-job path filters via `dorny/paths-filter` |
+
+## Out of Scope
+
+- Reorganising the integration test stack itself (keeping the docker-compose run as-is).
+- Cost/runtime improvements to backend/frontend tests (separate optimisation work).
+- Enabling Android instrumented tests on more PR types.
+
+## Priority
+
+P2 – Medium (CI cost + signal-to-noise; no broken functionality).
+
+## Size
+
+S (< 4 hours) — primarily a YAML edit + a documentation note + a verification PR.
+
+## Assignee
+
+devops / repo-maintainer

--- a/docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md
+++ b/docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md
@@ -8,21 +8,21 @@ As a contributor, I want CI to skip pipelines that have nothing to do with my ch
 
 After scanning all workflows under `.github/workflows/`, the picture is mixed:
 
-| Workflow | Path filters? | Behaviour on a doc-only PR |
-|---|---|---|
-| `android-ci.yml` | ✅ `android/**` + own file | correctly skipped |
-| `azure-deploy.yml` | ✅ `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, own file | correctly skipped |
-| `test_update.yml` (Backend + Frontend + Integration tests) | ❌ none | **runs everything** — backend pytest, frontend Vitest matrix on Node 20 + 22, plus a full docker-compose integration suite with Postgres/Ollama |
-| `pre-commit.yml` | ❌ none | runs (acceptable — it lints `docs/**` too) |
-| `commitlint.yml` | ❌ none | runs (intentional — must lint commit messages on every PR) |
-| `release-please.yml` | n/a — push to main only | not affected |
-| `prod-monitor.yml` | n/a — schedule only | not affected |
-| `android-publish.yml`, `android-debug.yml` | `workflow_dispatch` only | not affected |
+| Workflow                                                   | Path filters?                                                       | Behaviour on a doc-only PR                                                                                                                      |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `android-ci.yml`                                           | ✅ `android/**` + own file                                          | correctly skipped                                                                                                                               |
+| `azure-deploy.yml`                                         | ✅ `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, own file | correctly skipped                                                                                                                               |
+| `test_update.yml` (Backend + Frontend + Integration tests) | ❌ none                                                             | **runs everything** — backend pytest, frontend Vitest matrix on Node 20 + 22, plus a full docker-compose integration suite with Postgres/Ollama |
+| `pre-commit.yml`                                           | ❌ none                                                             | runs (acceptable — it lints `docs/**` too)                                                                                                      |
+| `commitlint.yml`                                           | ❌ none                                                             | runs (intentional — must lint commit messages on every PR)                                                                                      |
+| `release-please.yml`                                       | n/a — push to main only                                             | not affected                                                                                                                                    |
+| `prod-monitor.yml`                                         | n/a — schedule only                                                 | not affected                                                                                                                                    |
+| `android-publish.yml`, `android-debug.yml`                 | `workflow_dispatch` only                                            | not affected                                                                                                                                    |
 
 So the real waste is **`test_update.yml`**. A PR that only adds a markdown file under `docs/BACKLOG_STORIES/` (the most common "low-risk" change) currently spins up:
 
 - a Postgres service container + backend pytest run,
-- a Node 20 *and* Node 22 frontend test matrix (two parallel jobs),
+- a Node 20 _and_ Node 22 frontend test matrix (two parallel jobs),
 - a full docker-compose integration test that pulls Ollama, builds the API and frontend images, and runs end-to-end checks.
 
 That's ~10–15 runner-minutes for a change that cannot affect any of those code paths.
@@ -84,18 +84,18 @@ Open a doc-only PR and confirm `android-ci.yml` shows as skipped (not as a faile
 
 - [ ] A PR whose only change is `docs/BACKLOG_STORIES/<foo>.md` does **not** trigger `test_update.yml` (backend, frontend matrix, integration tests).
 - [ ] A PR whose only change is under `docs/` does **not** trigger `android-ci.yml` (already true — verified, not changed).
-- [ ] A PR that modifies `api/**` still runs backend pytest *and* the integration tests.
-- [ ] A PR that modifies `frontend/**` still runs the frontend matrix *and* the integration tests (because the integration suite covers both).
+- [ ] A PR that modifies `api/**` still runs backend pytest _and_ the integration tests.
+- [ ] A PR that modifies `frontend/**` still runs the frontend matrix _and_ the integration tests (because the integration suite covers both).
 - [ ] Branch-protection required-status configuration is documented so that doc-only PRs are not blocked by skipped jobs (see "Required-checks awareness" section in `docs/CONTRIBUTING.md`).
 - [ ] `pre-commit.yml` and `commitlint.yml` continue to run on every PR (no regression in linting).
 
 ## Files to Modify / Add
 
-| File | Change |
-|---|---|
-| `.github/workflows/test_update.yml` | Add `paths:` lists to `pull_request` and `push` triggers |
-| `docs/CONTRIBUTING.md` (or new section) | Document branch-protection behaviour with skipped checks |
-| (Optional, follow-up) `.github/workflows/test_update.yml` | Per-job path filters via `dorny/paths-filter` |
+| File                                                      | Change                                                   |
+| --------------------------------------------------------- | -------------------------------------------------------- |
+| `.github/workflows/test_update.yml`                       | Add `paths:` lists to `pull_request` and `push` triggers |
+| `docs/CONTRIBUTING.md` (or new section)                   | Document branch-protection behaviour with skipped checks |
+| (Optional, follow-up) `.github/workflows/test_update.yml` | Per-job path filters via `dorny/paths-filter`            |
 
 ## Out of Scope
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+## CI pipelines and path filters
+
+Most workflows are path-filtered so they only run when relevant files change:
+
+| Workflow | Runs when these paths change |
+|---|---|
+| `android-ci.yml` | `android/**`, the workflow file itself |
+| `azure-deploy.yml` | `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, the workflow file |
+| `test_update.yml` | `api/**`, `frontend/**`, `docker-compose*.yml`, `scripts/**`, the workflow file |
+| `pre-commit.yml` | every PR (lints docs, configs, and code) |
+| `commitlint.yml` | every PR (lints commit messages) |
+
+A PR that changes **only** files under `docs/` (e.g. a backlog story) will skip
+`android-ci.yml`, `azure-deploy.yml`, and `test_update.yml`. Only
+`pre-commit.yml` and `commitlint.yml` will run.
+
+### Branch-protection and skipped checks
+
+When a workflow is skipped because no path matched, GitHub records its status
+as **skipped**, not **success**. If your branch-protection rule requires a
+specific check (e.g. `Backend API Tests`) to pass, a doc-only PR will be
+blocked forever because that check never transitions to success.
+
+**Fix options (choose one):**
+
+1. **Recommended — require a status that always runs.** Change the required
+   check from `Backend API Tests` to `Pre-Commit Hooks` (which runs on every
+   PR). Backend/frontend test jobs remain as advisory signals on doc-only PRs.
+
+2. **Aggregator job.** Add a tiny `ci-gate` job at the end of
+   `test_update.yml` that runs with `if: always()` and checks
+   `needs.*.result`. Map `skipped` → success and `failure` → failure. Require
+   only `ci-gate` in branch protection.
+
+Re-requesting a review on a doc-only PR will **not** unblock it — the skipped
+check simply doesn't meet a "required: success" rule. The approaches above are
+the only reliable solutions.
+
+## Commit message convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+Every commit title must match:
+
+```
+<type>(<scope>): <subject>
+```
+
+Common types: `feat`, `fix`, `chore`, `docs`, `ci`, `test`, `refactor`.
+
+The `commitlint.yml` workflow enforces this on every PR.
+
+## Translation completeness
+
+The Android string-resource translation-validation job (`android-ci.yml`,
+`translation-validation` step) requires every key in
+`android/app/src/main/res/values/strings.xml` (default English) to also exist
+in every locale file under `values-{locale}/strings.xml`.
+
+When you add a new string key to the default file, add a matching key to
+**all** locale files in the same PR. The CI job will fail and list every
+missing key if you forget.
+
+Supported locales: `ar`, `de`, `es`, `fr`, `hi`, `it`, `ko`, `pt`, `ru`, `zh`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,13 +4,13 @@
 
 Most workflows are path-filtered so they only run when relevant files change:
 
-| Workflow | Runs when these paths change |
-|---|---|
-| `android-ci.yml` | `android/**`, the workflow file itself |
-| `azure-deploy.yml` | `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, the workflow file |
-| `test_update.yml` | `api/**`, `frontend/**`, `docker-compose*.yml`, `scripts/**`, the workflow file |
-| `pre-commit.yml` | every PR (lints docs, configs, and code) |
-| `commitlint.yml` | every PR (lints commit messages) |
+| Workflow           | Runs when these paths change                                                    |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `android-ci.yml`   | `android/**`, the workflow file itself                                          |
+| `azure-deploy.yml` | `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, the workflow file       |
+| `test_update.yml`  | `api/**`, `frontend/**`, `docker-compose*.yml`, `scripts/**`, the workflow file |
+| `pre-commit.yml`   | every PR (lints docs, configs, and code)                                        |
+| `commitlint.yml`   | every PR (lints commit messages)                                                |
 
 A PR that changes **only** files under `docs/` (e.g. a backlog story) will skip
 `android-ci.yml`, `azure-deploy.yml`, and `test_update.yml`. Only


### PR DESCRIPTION
## Summary

`test_update.yml` ran on every `pull_request` and `push`, so a PR whose only change was a markdown file under `docs/` (e.g. a backlog story) currently spins up:

- a Postgres service container + backend pytest run,
- a Node 20 *and* Node 22 frontend test matrix (two parallel jobs),
- a full docker-compose integration test that pulls Ollama, builds the API + frontend images, and runs end-to-end checks.

That's roughly **10–15 wasted runner-minutes per doc-only PR**, plus a wall of unrelated check noise.

This PR adds `paths:` filters to both the `pull_request` and `push` triggers so the workflow only runs when files relevant to it change.

## What changed

- **`.github/workflows/test_update.yml`**: paths filter on both triggers — `api/**`, `frontend/**`, `docker-compose*.yml`, `scripts/**`, and the workflow file itself.
- **`docs/CONTRIBUTING.md`** (new): documents which paths trigger which workflow and explains the branch-protection "skipped ≠ success" problem with two concrete fix options.
- **`docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md`** (new): backlog story with rationale, scope, and acceptance criteria.

## Audit of other workflows

| Workflow | Path filters? | OK? |
|---|---|---|
| `android-ci.yml` | ✅ `android/**` + own file | ✅ |
| `azure-deploy.yml` | ✅ `api/**`, `frontend/**`, `scripts/**`, `deployment/**`, own file | ✅ |
| `test_update.yml` | ❌ → ✅ this PR | now fixed |
| `pre-commit.yml` | ❌ | intentional — lints docs too |
| `commitlint.yml` | ❌ | intentional — every PR |
| `release-please.yml`, `prod-monitor.yml`, `android-publish.yml`, `android-debug.yml` | n/a (push-to-main / schedule / workflow_dispatch) | ✅ |

## ⚠️ Branch protection follow-up

When a workflow is skipped because no path matched, GitHub records its status as **skipped**, not **success**. If branch protection requires e.g. `Backend API Tests` to pass, doc-only PRs will be blocked forever after this change merges.

`docs/CONTRIBUTING.md` (in this PR) lists two solutions:

1. **Recommended**: change the required check to `Pre-Commit Hooks` (always runs).
2. Add a tiny `ci-gate` aggregator job that converts skipped → success.

## Test plan

- [ ] Open a draft PR that touches only `docs/foo.md` after this merges and confirm `Tests` does NOT run, while `Pre-commit` and `Commitlint` do.
- [ ] Open a PR that touches `api/main.py` and confirm `Tests` runs (backend, frontend matrix, integration).
- [ ] Open a PR that touches `frontend/src/foo.tsx` and confirm `Tests` runs.
- [ ] Verify branch protection is updated according to one of the options in `docs/CONTRIBUTING.md` before relying on a doc-only PR being mergeable.

## Related

This PR is one of three filed in this work cycle. Companion PRs:

- **#531** — bug-report email flow for "Send Diagnostic Report" in Android.
- **#532** — translate Privacy Policy and Terms of Service into all 10 non-English locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015gj3KDKPrCbyWjdXwzdEqB)_