### PR TITLE
feat(android): redesign Settings UX (BITB-026)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -41,7 +43,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import org.voxquieta.app.BuildConfig
 import org.voxquieta.app.R
 import org.voxquieta.app.presentation.components.ContactFormBottomSheet
-import org.voxquieta.app.presentation.components.ContactFormState
 import org.voxquieta.app.presentation.components.DiagnosticReportBottomSheet
 import org.voxquieta.app.presentation.viewmodels.ChatViewModel
 import org.voxquieta.app.utils.privacyUrl
@@ -74,6 +75,16 @@ fun SettingsScreen(
     val currentLanguage = LocalConfiguration.current.locales[0].language
     var showContactSheet by rememberSaveable { mutableStateOf(false) }
     var showDiagnosticSheet by rememberSaveable { mutableStateOf(false) }
+    var showClearHistoryDialog by rememberSaveable { mutableStateOf(false) }
+
+    // Resolve current translation display name for the read-only row.
+    val currentTranslationName = when {
+        preferredTranslation.isBlank() -> stringResource(R.string.bible_translation_default)
+        else -> availableTranslations
+            .firstOrNull { it.id == preferredTranslation }
+            ?.name
+            ?: preferredTranslation.uppercase()
+    }
 
     Scaffold(
         topBar = {
@@ -105,7 +116,7 @@ fun SettingsScreen(
                 .padding(horizontal = 16.dp)
                 .verticalScroll(rememberScrollState()),
         ) {
-            // ── Theme section ─────────────────────────────────────────────────
+            // ── Appearance section ─────────────────────────────────────────────
             Spacer(modifier = Modifier.height(16.dp))
             Text(
                 text = stringResource(R.string.settings_theme_title),
@@ -121,7 +132,7 @@ fun SettingsScreen(
                 )
             }
 
-            // ── Bible Translation section ──────────────────────────────────────
+            // ── Bible section ──────────────────────────────────────────────────
             Spacer(modifier = Modifier.height(24.dp))
             Text(
                 text = stringResource(R.string.bible_translation_section),
@@ -129,35 +140,52 @@ fun SettingsScreen(
                 color = MaterialTheme.colorScheme.primary,
             )
             Spacer(modifier = Modifier.height(8.dp))
-            if (availableTranslations.isEmpty()) {
-                // Loading or error state — show a single "Default" option selected.
-                TranslationRow(
-                    label = stringResource(R.string.bible_translation_default),
-                    sublabel = null,
-                    selected = true,
-                    onSelect = { viewModel.setPreferredTranslation("") },
-                )
-            } else {
-                // "Default" (no preference) row first.
-                TranslationRow(
-                    label = stringResource(R.string.bible_translation_default),
-                    sublabel = null,
-                    selected = preferredTranslation.isBlank(),
-                    onSelect = { viewModel.setPreferredTranslation("") },
-                )
-                availableTranslations.forEach { translation ->
-                    TranslationRow(
-                        label = translation.name,
-                        sublabel = translation.language.uppercase(),
-                        selected = translation.id == preferredTranslation,
-                        onSelect = { viewModel.setPreferredTranslation(translation.id) },
+            // Read-only row showing the active translation; the in-chat chip is
+            // the canonical place to change it.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.settings_current_translation),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(R.string.settings_bible_change_from_chat),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
+                Text(
+                    text = currentTranslationName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
+            // ── Data & Privacy section ─────────────────────────────────────────
             Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = stringResource(R.string.settings_data_privacy_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = { showClearHistoryDialog = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                Text(stringResource(R.string.action_clear_all_conversations))
+            }
 
             // ── Support section ────────────────────────────────────────────────
+            Spacer(modifier = Modifier.height(24.dp))
             Text(
                 text = stringResource(R.string.settings_support_title),
                 style = MaterialTheme.typography.titleSmall,
@@ -171,7 +199,7 @@ fun SettingsScreen(
                 Text(stringResource(R.string.action_send_diagnostic_report))
             }
 
-            // ── Contact section ────────────────────────────────────────────────
+            // ── Get in Touch section ───────────────────────────────────────────
             Spacer(modifier = Modifier.height(24.dp))
             Text(
                 text = stringResource(R.string.contact_section_title),
@@ -244,6 +272,33 @@ fun SettingsScreen(
         // Turnstile widget is mounted globally in MainActivity, so a token is
         // already cached by the time the user reaches this screen.
 
+        // ── Clear history confirmation dialog ──────────────────────────────────
+        if (showClearHistoryDialog) {
+            AlertDialog(
+                onDismissRequest = { showClearHistoryDialog = false },
+                title = { Text(stringResource(R.string.settings_clear_history_title)) },
+                text = { Text(stringResource(R.string.settings_clear_history_message)) },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            viewModel.clearAllConversations()
+                            showClearHistoryDialog = false
+                        },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) {
+                        Text(stringResource(R.string.action_clear_all_conversations))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showClearHistoryDialog = false }) {
+                        Text(stringResource(R.string.action_cancel))
+                    }
+                },
+            )
+        }
+
         // ── Contact Form bottom sheet ──────────────────────────────────────────
         if (showContactSheet) {
             ContactFormBottomSheet(
@@ -296,38 +351,5 @@ private fun ThemeRow(
             style = MaterialTheme.typography.bodyLarge,
             modifier = Modifier.padding(start = 8.dp),
         )
-    }
-}
-
-@Composable
-private fun TranslationRow(
-    label: String,
-    sublabel: String?,
-    selected: Boolean,
-    onSelect: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        RadioButton(
-            selected = selected,
-            onClick = onSelect,
-        )
-        Column(modifier = Modifier.padding(start = 8.dp)) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyLarge,
-            )
-            if (sublabel != null) {
-                Text(
-                    text = sublabel,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
     }
 }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -726,6 +726,15 @@ class ChatViewModel @Inject constructor(
         }
     }
 
+    /** Deletes ALL conversations from DB and resets in-memory state. */
+    fun clearAllConversations() {
+        _uiState.update { it.copy(messages = emptyList(), error = null, currentConversationId = null, allVerses = emptyList()) }
+        viewModelScope.launch {
+            lastConversationPreferences.setLastConversationId(null)
+            repository.clearAllConversations()
+        }
+    }
+
     // ---------------------------------------------------------------------------
     // Chapter sheet
     // ---------------------------------------------------------------------------

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">إعداد النظام</string>
     <string name="bible_translation_section">ترجمة الكتاب المقدس</string>
     <string name="bible_translation_default">افتراضية</string>
+    <string name="settings_current_translation">الترجمة الحالية</string>
+    <string name="settings_bible_change_from_chat">التغيير من شاشة الدردشة</string>
+    <string name="settings_data_privacy_title">البيانات والخصوصية</string>
+    <string name="settings_clear_history_title">مسح سجل المحادثات؟</string>
+    <string name="settings_clear_history_message">سيتم حذف جميع المحادثات نهائيًا.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">الدعم</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">Systemstandard</string>
     <string name="bible_translation_section">Bibelübersetzung</string>
     <string name="bible_translation_default">Standard</string>
+    <string name="settings_current_translation">Aktuelle Übersetzung</string>
+    <string name="settings_bible_change_from_chat">Im Chat-Bildschirm ändern</string>
+    <string name="settings_data_privacy_title">Daten &amp; Datenschutz</string>
+    <string name="settings_clear_history_title">Verlauf löschen?</string>
+    <string name="settings_clear_history_message">Alle Gespräche werden dauerhaft gelöscht.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">Support</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">Predeterminado del sistema</string>
     <string name="bible_translation_section">Traducción Bíblica</string>
     <string name="bible_translation_default">Predeterminada</string>
+    <string name="settings_current_translation">Traducción actual</string>
+    <string name="settings_bible_change_from_chat">Cambiar desde la pantalla de chat</string>
+    <string name="settings_data_privacy_title">Datos y privacidad</string>
+    <string name="settings_clear_history_title">¿Borrar el historial?</string>
+    <string name="settings_clear_history_message">Todas las conversaciones se eliminarán permanentemente.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">Soporte</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">Défaut du système</string>
     <string name="bible_translation_section">Traduction Biblique</string>
     <string name="bible_translation_default">Par défaut</string>
+    <string name="settings_current_translation">Traduction actuelle</string>
+    <string name="settings_bible_change_from_chat">Changer depuis l\'écran de chat</string>
+    <string name="settings_data_privacy_title">Données et confidentialité</string>
+    <string name="settings_clear_history_title">Effacer l\'historique ?</string>
+    <string name="settings_clear_history_message">Toutes les conversations seront supprimées définitivement.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">Support</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">सिस्टम डिफ़ॉल्ट</string>
     <string name="bible_translation_section">बाइबिल अनुवाद</string>
     <string name="bible_translation_default">डिफ़ॉल्ट</string>
+    <string name="settings_current_translation">वर्तमान अनुवाद</string>
+    <string name="settings_bible_change_from_chat">चैट स्क्रीन से बदलें</string>
+    <string name="settings_data_privacy_title">डेटा और गोपनीयता</string>
+    <string name="settings_clear_history_title">इतिहास मिटाएं?</string>
+    <string name="settings_clear_history_message">सभी बातचीत स्थायी रूप से हटा दी जाएंगी।</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">सहायता</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">Predefinito di sistema</string>
     <string name="bible_translation_section">Traduzione Biblica</string>
     <string name="bible_translation_default">Predefinita</string>
+    <string name="settings_current_translation">Traduzione attuale</string>
+    <string name="settings_bible_change_from_chat">Cambia dalla schermata di chat</string>
+    <string name="settings_data_privacy_title">Dati e privacy</string>
+    <string name="settings_clear_history_title">Cancellare la cronologia?</string>
+    <string name="settings_clear_history_message">Tutte le conversazioni verranno eliminate definitivamente.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">Supporto</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">시스템 기본값</string>
     <string name="bible_translation_section">성경 번역본</string>
     <string name="bible_translation_default">기본값</string>
+    <string name="settings_current_translation">현재 번역</string>
+    <string name="settings_bible_change_from_chat">채팅 화면에서 변경</string>
+    <string name="settings_data_privacy_title">데이터 및 개인 정보</string>
+    <string name="settings_clear_history_title">대화 기록을 삭제하시겠습니까?</string>
+    <string name="settings_clear_history_message">모든 대화가 영구적으로 삭제됩니다.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">지원</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">Padrão do sistema</string>
     <string name="bible_translation_section">Tradução Bíblica</string>
     <string name="bible_translation_default">Padrão</string>
+    <string name="settings_current_translation">Tradução atual</string>
+    <string name="settings_bible_change_from_chat">Alterar a partir do chat</string>
+    <string name="settings_data_privacy_title">Dados e privacidade</string>
+    <string name="settings_clear_history_title">Apagar o histórico?</string>
+    <string name="settings_clear_history_message">Todas as conversas serão eliminadas permanentemente.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">Suporte</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">Системная</string>
     <string name="bible_translation_section">Перевод Библии</string>
     <string name="bible_translation_default">По умолчанию</string>
+    <string name="settings_current_translation">Текущий перевод</string>
+    <string name="settings_bible_change_from_chat">Изменить в чате</string>
+    <string name="settings_data_privacy_title">Данные и конфиденциальность</string>
+    <string name="settings_clear_history_title">Очистить историю?</string>
+    <string name="settings_clear_history_message">Все беседы будут удалены навсегда.</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">Поддержка</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -144,6 +144,11 @@
     <string name="settings_theme_system">跟随系统</string>
     <string name="bible_translation_section">圣经译本</string>
     <string name="bible_translation_default">默认</string>
+    <string name="settings_current_translation">当前译本</string>
+    <string name="settings_bible_change_from_chat">从聊天界面更改</string>
+    <string name="settings_data_privacy_title">数据与隐私</string>
+    <string name="settings_clear_history_title">清除对话记录？</string>
+    <string name="settings_clear_history_message">所有对话将被永久删除。</string>
 
     <!-- Settings support/about section -->
     <string name="settings_support_title">支持</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -141,6 +141,11 @@
     <string name="settings_theme_system">System default</string>
     <string name="bible_translation_section">Bible Translation</string>
     <string name="bible_translation_default">Default</string>
+    <string name="settings_current_translation">Current translation</string>
+    <string name="settings_bible_change_from_chat">Change from the chat screen</string>
+    <string name="settings_data_privacy_title">Data &amp; Privacy</string>
+    <string name="settings_clear_history_title">Clear conversation history?</string>
+    <string name="settings_clear_history_message">This will permanently delete all your conversations.</string>
     <string name="settings_support_title">Support</string>
     <string name="action_send_diagnostic_report">Send Diagnostic Report</string>
 


### PR DESCRIPTION
## Summary

- **Remove** the Bible Translation radio-button list from Settings (it was a duplicate of the in-chat translation chip — both writing to the same DataStore key, confusing users about which is canonical)
- **Add** a read-only "Current translation" info row in the Bible section with a "Change from the chat screen" hint
- **Add** a new "Data & Privacy" section with a "Clear all conversations" button that shows a confirmation `AlertDialog` before permanently deleting all local conversation history
- **Reorder** sections to: Appearance → Bible → Data & Privacy → Support → Get in Touch → About
- **Add** `ChatViewModel.clearAllConversations()` that wipes all Room conversations + resets in-memory UI state + clears `lastConversationPreferences`
- **Add** 5 new string keys fully translated across all 11 supported locales (en, it, de, es, fr, pt, ar, hi, ko, ru, zh)

## Acceptance Criteria (from BITB-026)

- [x] Bible translation radio-button list removed from `SettingsScreen.kt`
- [x] Read-only Bible translation row shows current translation name + "Change from the chat screen" hint
- [x] In-chat translation chip still persists the selection across app restarts (no regression — no persistence code changed)
- [x] "Clear conversation history" button added with a confirmation `AlertDialog` before clearing
- [x] Settings sections reordered per story spec: Appearance → Bible → Data & Privacy → Support → Get in Touch → About
- [x] All 5 new string keys translated in all 11 locales (XML-validated, no lint errors)

## Files Changed

| File | Change |
|---|---|
| `SettingsScreen.kt` | Remove translation radio list; add read-only row; add Data & Privacy section with clear-history dialog; reorder sections |
| `ChatViewModel.kt` | Add `clearAllConversations()` delegating to `repository.clearAllConversations()` |
| `values/strings.xml` + 10 locale files | Add 5 new string keys fully translated |

## Test Plan

- [ ] Open Settings → sections appear in order: Appearance, Bible, Data & Privacy, Support, Get in Touch, About
- [ ] Bible section shows "Current translation" with current value (e.g. "KJV" or "Default") + hint text
- [ ] Tap "Clear all conversations" → confirmation dialog appears
- [ ] Cancel in dialog → data unchanged, conversations still in drawer
- [ ] Confirm in dialog → all conversations deleted, chat screen shows empty state + example prompts
- [ ] In-chat translation chip (bottom sheet) still works and persists across restarts (no regression)
- [ ] Theme switching still works
- [ ] Rotate device while dialog is open → dialog stays open (`rememberSaveable`)
- [ ] Test on dark theme

## Out of Scope (per story)

- Language selector in Settings (already in chat screen)
- Daily verse notification opt-in (deferred)

https://claude.ai/code/session_014Fb9gNHZ6V92aoiDif7Y7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_014Fb9gNHZ6V92aoiDif7Y7Z)_