### PR TITLE
fix(android): show submitting/success/error feedback in diagnostic report sheet

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -40,13 +41,17 @@ import org.voxquieta.app.R
  * Bottom sheet that lets the user file a bug report. Collects two short answers
  * (what they were doing / what they expected) and offers two actions:
  *
- *  1. Primary — open an email composer with the answers prefilled and the
- *     diagnostic log attached.
- *  2. Secondary — save the log to local storage via the system share sheet.
+ *  1. Primary — submit the report through the built-in contact pipeline
+ *     (same backend path the contact form uses). The sheet stays open and
+ *     reflects [formState] so the user sees a spinner, a success screen, or
+ *     an inline error message rather than the sheet silently closing.
+ *  2. Secondary — save the full diagnostic log locally via the system share
+ *     sheet.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiagnosticReportBottomSheet(
+    formState: ContactFormState,
     onSendEmail: (whatWereYouDoing: String, whatDidYouExpect: String) -> Unit,
     onSaveLocally: () -> Unit,
     onDismiss: () -> Unit,
@@ -91,6 +96,35 @@ fun DiagnosticReportBottomSheet(
                 }
             }
 
+            // ── Success state ─────────────────────────────────────────────────
+            if (formState is ContactFormState.Success) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.diagnostic_success_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = stringResource(R.string.diagnostic_success_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+                        Text(stringResource(R.string.action_cancel))
+                    }
+                }
+                return@Column
+            }
+
+            val isSubmitting = formState is ContactFormState.Submitting
+
             OutlinedTextField(
                 value = doingInput,
                 onValueChange = { doingInput = it },
@@ -100,6 +134,7 @@ fun DiagnosticReportBottomSheet(
                 maxLines = 6,
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                enabled = !isSubmitting,
             )
 
             OutlinedTextField(
@@ -111,6 +146,7 @@ fun DiagnosticReportBottomSheet(
                 maxLines = 6,
                 modifier = Modifier.fillMaxWidth(),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Default),
+                enabled = !isSubmitting,
             )
 
             Text(
@@ -119,17 +155,36 @@ fun DiagnosticReportBottomSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
+            // ── Error ─────────────────────────────────────────────────────────
+            if (formState is ContactFormState.Error) {
+                Text(
+                    text = formState.message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+
             Button(
                 onClick = { onSendEmail(doingInput, expectedInput) },
                 modifier = Modifier.fillMaxWidth(),
+                enabled = !isSubmitting,
             ) {
-                Text(stringResource(R.string.diagnostic_send_email_button))
+                if (isSubmitting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Text(stringResource(R.string.diagnostic_send_email_button))
+                }
             }
 
             // Secondary, less prominent option to save the raw log without sending.
             TextButton(
                 onClick = onSaveLocally,
                 modifier = Modifier.fillMaxWidth(),
+                enabled = !isSubmitting,
             ) {
                 Text(
                     text = stringResource(R.string.diagnostic_save_locally_link),

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt
@@ -70,6 +70,7 @@ fun SettingsScreen(
     val availableTranslations by viewModel.availableTranslations.collectAsState()
     val preferredTranslation by viewModel.preferredTranslation.collectAsState()
     val contactFormState by viewModel.contactFormState.collectAsState()
+    val diagnosticReportState by viewModel.diagnosticReportState.collectAsState()
     val context = LocalContext.current
     val currentLanguage = LocalConfiguration.current.locales[0].language
     var showContactSheet by rememberSaveable { mutableStateOf(false) }
@@ -261,15 +262,19 @@ fun SettingsScreen(
         // ── Diagnostic report bottom sheet ─────────────────────────────────────
         if (showDiagnosticSheet) {
             DiagnosticReportBottomSheet(
+                formState = diagnosticReportState,
                 onSendEmail = { doing, expected ->
                     viewModel.sendDiagnosticEmail(doing, expected)
-                    showDiagnosticSheet = false
                 },
                 onSaveLocally = {
                     viewModel.saveDiagnosticLogLocally(context)
                     showDiagnosticSheet = false
+                    viewModel.resetDiagnosticReport()
                 },
-                onDismiss = { showDiagnosticSheet = false },
+                onDismiss = {
+                    showDiagnosticSheet = false
+                    viewModel.resetDiagnosticReport()
+                },
             )
         }
     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -223,6 +223,13 @@ class ChatViewModel @Inject constructor(
     private val _contactFormState = MutableStateFlow<ContactFormState>(ContactFormState.Idle)
     val contactFormState: StateFlow<ContactFormState> = _contactFormState.asStateFlow()
 
+    // Diagnostic-report submission reuses the generic submit-lifecycle states
+    // from [ContactFormState] because the flow is the same: Idle → Submitting →
+    // Success / Error. The bottom sheet renders a spinner, success screen or
+    // inline error message based on this state.
+    private val _diagnosticReportState = MutableStateFlow<ContactFormState>(ContactFormState.Idle)
+    val diagnosticReportState: StateFlow<ContactFormState> = _diagnosticReportState.asStateFlow()
+
     init {
         // isTurnstileReady is true when a valid token is held OR when Turnstile has
         // errored (fail-open): the interceptor already forwards requests without a
@@ -857,11 +864,16 @@ class ChatViewModel @Inject constructor(
     // ---------------------------------------------------------------------------
 
     /**
-     * Sends a bug report through the app's built-in contact/email pipeline
-     * (same backend path used by the contact form) with the user's answers,
-     * device metadata, and current diagnostic log in the message body.
+     * Sends a bug report through the app's built-in contact pipeline (same
+     * backend path used by the contact form) with the user's answers, device
+     * metadata, and current diagnostic log in the message body.
+     *
+     * Transitions [diagnosticReportState] through Submitting → Success or
+     * Error so the bottom sheet can show a spinner, a success screen, or an
+     * inline error message.
      */
     fun sendDiagnosticEmail(whatWereYouDoing: String, whatDidYouExpect: String) {
+        _diagnosticReportState.value = ContactFormState.Submitting
         viewModelScope.launch {
             try {
                 val log = LogCollector.getLog()
@@ -874,11 +886,20 @@ class ChatViewModel @Inject constructor(
                         "(SDK ${android.os.Build.VERSION.SDK_INT}; " +
                         "${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL})",
                 )
+                _diagnosticReportState.value = ContactFormState.Success
                 Timber.i("Diagnostic bug report submitted")
             } catch (e: Exception) {
                 Timber.e(e, "Failed to send diagnostic email")
+                _diagnosticReportState.value = ContactFormState.Error(
+                    mapExceptionToMessage(e),
+                )
             }
         }
+    }
+
+    /** Resets the diagnostic-report state to [ContactFormState.Idle]. */
+    fun resetDiagnosticReport() {
+        _diagnosticReportState.value = ContactFormState.Idle
     }
 
     /**

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">تقرير خطأ Vox Quieta</string>
     <string name="diagnostic_no_email_app">لا يوجد تطبيق بريد إلكتروني مهيأ على هذا الجهاز. تم حفظ السجل بدلاً من ذلك.</string>
     <string name="diagnostic_save_failed">تعذّر حفظ سجل التشخيص.</string>
+    <string name="diagnostic_success_title">تم إرسال تقرير الخطأ</string>
+    <string name="diagnostic_success_description">شكرًا — تلقّينا تقريرك وسنراجعه قريبًا.</string>
 
     <string name="settings_about_title">حول</string>
     <string name="settings_version">الإصدار</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Vox Quieta Fehlerbericht</string>
     <string name="diagnostic_no_email_app">Auf diesem Gerät ist keine E-Mail-App eingerichtet. Das Protokoll wurde stattdessen gespeichert.</string>
     <string name="diagnostic_save_failed">Das Diagnoseprotokoll konnte nicht gespeichert werden.</string>
+    <string name="diagnostic_success_title">Fehlerbericht gesendet</string>
+    <string name="diagnostic_success_description">Danke — wir haben deinen Bericht erhalten und werden ihn bald prüfen.</string>
 
     <string name="settings_about_title">Über</string>
     <string name="settings_version">Version</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Informe de error de Vox Quieta</string>
     <string name="diagnostic_no_email_app">No hay ninguna app de correo configurada. El registro se guardó.</string>
     <string name="diagnostic_save_failed">No se pudo guardar el registro de diagnóstico.</string>
+    <string name="diagnostic_success_title">Informe enviado</string>
+    <string name="diagnostic_success_description">Gracias — hemos recibido tu informe y lo revisaremos pronto.</string>
 
     <string name="settings_about_title">Acerca de</string>
     <string name="settings_version">Versión</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Rapport de bug Vox Quieta</string>
     <string name="diagnostic_no_email_app">Aucune application e-mail n\'est configurée. Le journal a été enregistré.</string>
     <string name="diagnostic_save_failed">Impossible d\'enregistrer le journal de diagnostic.</string>
+    <string name="diagnostic_success_title">Rapport envoyé</string>
+    <string name="diagnostic_success_description">Merci — nous avons reçu votre rapport et nous l\'examinerons sous peu.</string>
 
     <string name="settings_about_title">À propos</string>
     <string name="settings_version">Version</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Vox Quieta बग रिपोर्ट</string>
     <string name="diagnostic_no_email_app">इस डिवाइस पर कोई ईमेल ऐप सेट नहीं है। लॉग सहेज लिया गया है।</string>
     <string name="diagnostic_save_failed">डायग्नोस्टिक लॉग सहेजा नहीं जा सका।</string>
+    <string name="diagnostic_success_title">बग रिपोर्ट भेज दी गई</string>
+    <string name="diagnostic_success_description">धन्यवाद — हमें आपकी रिपोर्ट मिल गई है और हम जल्द ही इसकी समीक्षा करेंगे।</string>
 
     <string name="settings_about_title">के बारे में</string>
     <string name="settings_version">संस्करण</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Segnalazione bug Vox Quieta</string>
     <string name="diagnostic_no_email_app">Nessuna app email configurata. Il log è stato salvato.</string>
     <string name="diagnostic_save_failed">Impossibile salvare il log diagnostico.</string>
+    <string name="diagnostic_success_title">Segnalazione inviata</string>
+    <string name="diagnostic_success_description">Grazie — abbiamo ricevuto la tua segnalazione e la esamineremo a breve.</string>
 
     <string name="settings_about_title">Informazioni</string>
     <string name="settings_version">Versione</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Vox Quieta 버그 보고</string>
     <string name="diagnostic_no_email_app">이 기기에 설정된 이메일 앱이 없습니다. 로그가 대신 저장되었습니다.</string>
     <string name="diagnostic_save_failed">진단 로그를 저장할 수 없습니다.</string>
+    <string name="diagnostic_success_title">버그 보고서를 보냈습니다</string>
+    <string name="diagnostic_success_description">감사합니다 — 보고서를 받았으며 곧 검토하겠습니다.</string>
 
     <string name="settings_about_title">정보</string>
     <string name="settings_version">버전</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Relatório de erro Vox Quieta</string>
     <string name="diagnostic_no_email_app">Nenhum app de e-mail configurado. O log foi salvo.</string>
     <string name="diagnostic_save_failed">Não foi possível salvar o log de diagnóstico.</string>
+    <string name="diagnostic_success_title">Relatório enviado</string>
+    <string name="diagnostic_success_description">Obrigado — recebemos seu relatório e o analisaremos em breve.</string>
 
     <string name="settings_about_title">Sobre</string>
     <string name="settings_version">Versão</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Отчёт об ошибке Vox Quieta</string>
     <string name="diagnostic_no_email_app">На устройстве не настроено почтовое приложение. Журнал сохранён локально.</string>
     <string name="diagnostic_save_failed">Не удалось сохранить журнал диагностики.</string>
+    <string name="diagnostic_success_title">Отчёт отправлен</string>
+    <string name="diagnostic_success_description">Спасибо — мы получили ваш отчёт и скоро его рассмотрим.</string>
 
     <string name="settings_about_title">О приложении</string>
     <string name="settings_version">Версия</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -162,6 +162,8 @@
     <string name="diagnostic_email_subject">Vox Quieta 错误报告</string>
     <string name="diagnostic_no_email_app">此设备上未设置邮件应用。日志已改为保存。</string>
     <string name="diagnostic_save_failed">无法保存诊断日志。</string>
+    <string name="diagnostic_success_title">错误报告已发送</string>
+    <string name="diagnostic_success_description">感谢您 — 我们已收到您的报告，将尽快审阅。</string>
 
     <string name="settings_about_title">关于</string>
     <string name="settings_version">版本</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -157,6 +157,8 @@
     <string name="diagnostic_email_subject">Vox Quieta bug report</string>
     <string name="diagnostic_no_email_app">No email app is set up on this device. The log was saved instead.</string>
     <string name="diagnostic_save_failed">Could not save the diagnostic log.</string>
+    <string name="diagnostic_success_title">Bug report sent</string>
+    <string name="diagnostic_success_description">Thanks — we received your report and will review it soon.</string>
 
     <!-- Settings: About section -->
     <string name="settings_about_title">About</string>

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -1353,6 +1353,40 @@ class ChatViewModelTest {
         assertTrue(messageSlot.captured.contains("Diagnostic log:\nI/Test: Diagnostic line"))
     }
 
+    @Test
+    fun `sendDiagnosticEmail transitions state to Success on success`() = runTest {
+        coEvery { contactRepository.submitContact(any(), any(), any(), any()) } returns 42
+
+        viewModel.sendDiagnosticEmail("Doing something", "Expected something else")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.diagnosticReportState.value is ContactFormState.Success)
+    }
+
+    @Test
+    fun `sendDiagnosticEmail transitions state to Error on failure`() = runTest {
+        coEvery {
+            contactRepository.submitContact(any(), any(), any(), any())
+        } throws IOException("no network")
+
+        viewModel.sendDiagnosticEmail("Doing something", "Expected something else")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.diagnosticReportState.value is ContactFormState.Error)
+    }
+
+    @Test
+    fun `resetDiagnosticReport returns state to Idle`() = runTest {
+        coEvery { contactRepository.submitContact(any(), any(), any(), any()) } returns 1
+        viewModel.sendDiagnosticEmail("Doing", "Expected")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(viewModel.diagnosticReportState.value is ContactFormState.Success)
+
+        viewModel.resetDiagnosticReport()
+
+        assertTrue(viewModel.diagnosticReportState.value is ContactFormState.Idle)
+    }
+
     // ── allVerses (GAP-011) ───────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #531. After the bug-report sheet was wired to the built-in contact pipeline, tapping **"Send report with log"** closed the sheet immediately with no visible feedback — the user couldn't tell whether the report was sent, failed, or still in flight.

This PR adds the same submit-lifecycle feedback the contact form already uses:

- **Submitting** → spinner inside the primary button; text fields and both action buttons disabled.
- **Success** → the form is replaced by a centred *"Bug report sent — we'll review it soon"* screen with a single Dismiss button.
- **Error** → inline error text appears under the attachment note (using `mapExceptionToMessage`, so the user sees `error_network`, `error_timeout`, `error_server`, etc. as appropriate). The form stays editable so the user can fix and retry without re-opening the sheet.

## What changed

- **`ChatViewModel.kt`** — new `diagnosticReportState: StateFlow<ContactFormState>` next to `contactFormState`. `sendDiagnosticEmail` now transitions through Submitting → Success / Error. New `resetDiagnosticReport()` matches the existing `resetContactForm()`. Both functions reuse the existing `mapExceptionToMessage` helper for error strings.
- **`DiagnosticReportBottomSheet.kt`** — accepts `formState: ContactFormState`. Renders Success / Submitting / Error branches identical in style to `ContactFormBottomSheet`.
- **`SettingsScreen.kt`** — collects the new state, passes it to the sheet, no longer hides the sheet on send. `onDismiss` and `onSaveLocally` now call `viewModel.resetDiagnosticReport()` so re-opening starts fresh.
- **`values/strings.xml` + all 10 locale variants** — adds `diagnostic_success_title` and `diagnostic_success_description`. Translation-validation CI stays green.
- **`ChatViewModelTest.kt`** — three new tests mirroring the contact-form pattern: state → `Success`, state → `Error` on `IOException`, `resetDiagnosticReport` → `Idle`. The existing message-body assertion test still passes (unchanged).

## Notes / decisions

- **Reused `ContactFormState`** rather than introducing a parallel `DiagnosticReportState`. The sealed class is already a generic submit lifecycle (Idle / Submitting / Success / Error). Adding a duplicate would be churn.
- The secondary **"Save log to this device"** action still closes the sheet immediately — that path doesn't go through the contact endpoint, so there's no async state to surface. It also resets the diagnostic state on close.

## Test plan

- [ ] CI: Android Unit Tests + Translation Validation + Kotlin Compile Check pass.
- [ ] Manual: Settings → Send Diagnostic Report → fill in both fields → tap Send report. Verify spinner appears, inputs disabled.
- [ ] Manual (success): on a healthy network, verify the success screen appears with title + description + Dismiss button. Dismiss → re-open → form is empty.
- [ ] Manual (error): enable airplane mode → tap Send report. Verify the inline error message appears (e.g. *"Network error. Please check your connection."*), the form stays editable, and tapping Send again retries.
- [ ] Manual: while a request is in flight, the "Or save the log to this device" link is also disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015gj3KDKPrCbyWjdXwzdEqB)_