### PR TITLE
docs(backlog): add BITB-031/032/033 for Android settings, support inbox, and post-send button

### DIFF
--- a/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
+++ b/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
@@ -59,9 +59,10 @@ emit **all** entries. Recommended split of work:
 
 - **Generalize the existing script** (or add a sibling
   `scripts/extract-all-changelog.mjs` at the repo root) that reuses the
-  same `parseLatestEntry` regex in a loop, walking every `^## ` heading
-  in `CHANGELOG.md` and emitting an array. Keep the parser logic shared
-  so it stays in sync with release-please's heading format.
+  same `parseLatestEntry` regex in a loop, walking every line that
+  starts with `##` in `CHANGELOG.md` and emitting an array. Keep the
+  parser logic shared so it stays in sync with release-please's heading
+  format.
 - **Add a Gradle task** to the Android module's build script that:
   - Runs the Node script (or, simpler, parses the markdown directly in
     Gradle/Kotlin if you want to avoid a Node dependency in the Android
@@ -82,7 +83,7 @@ emit **all** entries. Recommended split of work:
 > **Alternative path**: shell out to `node frontend/scripts/extract-all-changelog.mjs`
 > from a Gradle `Exec` task. Reuses the parser; adds a Node toolchain
 > requirement to Android builds.
-
+>
 > Implementer note: verify the actual module build script path. Likely
 > `android/app/build.gradle.kts`; could be `build.gradle` if the module
 > hasn't been migrated to KTS.

--- a/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
+++ b/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
@@ -17,8 +17,30 @@ without that visibility.
 
 The repo-root `CHANGELOG.md` is the canonical source — it's
 release-please-managed, updated on every release, and already structured by
-version. Bundling it into the APK keeps the Android changelog automatically
-in sync with releases (no separate hand-maintained list) and works offline.
+version. Bundling a **pre-parsed JSON** derivation of it into the APK keeps
+the Android changelog automatically in sync with releases (no separate
+hand-maintained list), works offline, and avoids shipping a Markdown
+renderer on Android just to display release notes.
+
+## Approach: pre-bundled JSON asset
+
+Generate a `changelog.json` file at build time that contains **all**
+release entries (not just the latest, which is what
+`frontend/public/changelog.json` already holds — that single-entry artifact
+is intentional for the frontend's "What's New" modal). The Android module
+will read this JSON from `assets/` and render it as native Compose UI.
+
+Shape:
+
+```json
+[
+  { "version": "0.8.0", "date": "2026-05-08", "body": "### Features\n- …\n" },
+  { "version": "0.7.0", "date": "2026-04-22", "body": "…" }
+]
+```
+
+The `body` stays as Markdown text — the v1 Android screen renders it as
+plain text. No new Markdown dependency required.
 
 ## Proposed Changes
 
@@ -30,19 +52,36 @@ Privacy Policy, and Terms of Service (lines 190–241). Add a third
 `ChangelogScreen`. Keep it grouped with About — it's reference info, not a
 preference.
 
-### 2. Bundle the repo-root `CHANGELOG.md` into the APK at build time
+### 2. Generate the pre-bundled `changelog.json` asset at build time
 
-Mirror the prior-art pattern in
-`frontend/scripts/extract-latest-changelog.mjs`. Add a Gradle task to the
-Android module's build script that:
+Mirror the pattern in `frontend/scripts/extract-latest-changelog.mjs`, but
+emit **all** entries. Recommended split of work:
 
-- Copies `CHANGELOG.md` from the repo root to
-  `android/app/src/main/assets/CHANGELOG.md` before the Android `preBuild`
-  task runs.
-- Makes `preBuild` depend on the new task so the asset is always fresh.
-- **Fails soft**: if the source file is missing (e.g. someone checking out
-  only the `android/` subtree), log a warning and let the build continue —
-  the screen will show its empty-state fallback.
+- **Generalize the existing script** (or add a sibling
+  `scripts/extract-all-changelog.mjs` at the repo root) that reuses the
+  same `parseLatestEntry` regex in a loop, walking every `^## ` heading
+  in `CHANGELOG.md` and emitting an array. Keep the parser logic shared
+  so it stays in sync with release-please's heading format.
+- **Add a Gradle task** to the Android module's build script that:
+  - Runs the Node script (or, simpler, parses the markdown directly in
+    Gradle/Kotlin if you want to avoid a Node dependency in the Android
+    build — see "Alternative" below).
+  - Writes the JSON to `android/app/src/main/assets/changelog.json`
+    before the Android `preBuild` task runs.
+  - Makes `preBuild` depend on the new task so the asset is always
+    fresh.
+  - **Fails soft**: if the source `CHANGELOG.md` is missing (e.g. someone
+    checking out only the `android/` subtree), write
+    `{ "entries": [] }` and continue — the screen shows its empty-state
+    fallback.
+
+> **Recommended path**: do the parse in pure Gradle/Kotlin so the Android
+> build doesn't require Node. The grammar is simple enough (single regex)
+> that this is a few dozen lines.
+>
+> **Alternative path**: shell out to `node frontend/scripts/extract-all-changelog.mjs`
+> from a Gradle `Exec` task. Reuses the parser; adds a Node toolchain
+> requirement to Android builds.
 
 > Implementer note: verify the actual module build script path. Likely
 > `android/app/build.gradle.kts`; could be `build.gradle` if the module
@@ -52,23 +91,22 @@ Android module's build script that:
 
 - Location:
   `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChangelogScreen.kt`.
-- Reads the asset via `context.assets.open("CHANGELOG.md")`. Wrap the read
-  in a try/catch — return an empty list if the asset is missing.
-- Parses the Markdown into a list of release entries by splitting on the
-  `^## ` heading pattern (matches `## [0.8.0]` and `## 0.8.0` — same regex
-  that `frontend/scripts/extract-latest-changelog.mjs` already uses; consider
-  porting that logic).
-- Renders the entries in a `LazyColumn`. Each entry shows the version + date
-  as a header and the body below.
+- Reads the asset via `context.assets.open("changelog.json")`. Wrap the
+  read in a try/catch — return an empty list if the asset is missing or
+  unparseable.
+- Deserialize with `kotlinx.serialization` into a
+  `List<ChangelogEntry>` where
+  `data class ChangelogEntry(val version: String, val date: String?, val body: String)`.
+- Renders the entries in a `LazyColumn`. Each card shows version + date as
+  a header and the body below.
 
-**v1 rendering — recommended:** render the body as plain text inside a
-`Text(style = MaterialTheme.typography.bodyMedium)` (or in a monospaced
-block) without a Markdown library. Trade-off: bullets and links won't be
-clickable, but it avoids adding a new dependency and the content is short.
+**v1 rendering — recommended:** render `body` as plain text in
+`Text(style = MaterialTheme.typography.bodyMedium)`. The body is short
+Markdown (mostly bullet lists) — readable as plain text. No new dependency.
 
 Alternative: pull in a lightweight Compose Markdown renderer
-(e.g. `compose-markdown` or `markdown-compose`) for richer formatting.
-Defer this unless v1 reads poorly in QA.
+(e.g. `compose-markdown`) for richer formatting. Defer unless v1 reads
+poorly in QA.
 
 ### 4. Navigation wiring
 
@@ -96,13 +134,13 @@ auto-generated), matching the frontend's behaviour.
 
 - [ ] Settings shows a "What's New" entry in the About section that opens a
       new screen.
-- [ ] The Changelog screen renders the contents of repo-root `CHANGELOG.md`
-      that was bundled at build time.
-- [ ] When `CHANGELOG.md` is missing from the assets, the screen shows the
+- [ ] The Changelog screen lists every release present in the repo-root
+      `CHANGELOG.md`, rendered from the bundled `changelog.json` asset.
+- [ ] When `changelog.json` is missing or empty, the screen shows the
       `changelog_empty` fallback instead of crashing.
 - [ ] The Gradle task runs automatically before `preBuild` — running
-      `./gradlew clean assembleDebug` produces an APK that contains
-      `assets/CHANGELOG.md` matching the repo-root file.
+      `./gradlew clean assembleDebug` produces an APK that contains a
+      non-empty `assets/changelog.json` matching the repo-root markdown.
 - [ ] All 11 locales (English + 10 variants) have translated values for the
       new strings.
 - [ ] `./gradlew assembleDebug` succeeds.
@@ -113,7 +151,8 @@ auto-generated), matching the frontend's behaviour.
 
 | File | Change |
 |---|---|
-| `android/app/build.gradle.kts` (verify path) | Add Gradle task to copy `CHANGELOG.md` into `src/main/assets/`; wire it as a `preBuild` dependency |
+| `android/app/build.gradle.kts` (verify path) | Add Gradle task to parse repo-root `CHANGELOG.md` into `src/main/assets/changelog.json`; wire it as a `preBuild` dependency |
+| `frontend/scripts/extract-latest-changelog.mjs` *(optional)* | If reusing the Node parser: extract `parseAllEntries` so it can be shared between frontend single-entry output and Android all-entries output |
 | `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt` | Add `onNavigateToChangelog` parameter; add "What's New" `TextButton` in the About section |
 | `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChangelogScreen.kt` | New file — load asset, parse, render |
 | Navigation graph (e.g. `MainActivity.kt` or `presentation/navigation/*.kt`) | Register the new route and wire `onNavigateToChangelog` |

--- a/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
+++ b/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
@@ -1,0 +1,152 @@
+# BITB-031: Android Settings — "What's New" / Changelog Screen
+
+## User Story
+
+As an Android user, I want to see a "What's New" / Changelog section in the
+Settings screen, so I can discover what changed in each release without
+leaving the app and without having to visit the website.
+
+## Problem
+
+The Android app has no in-app surface for release notes. The web frontend
+already exposes a changelog page at `/[locale]/changelog`, backed by
+`frontend/public/changelog.json` and `frontend/public/CHANGELOG.md` (both
+generated at build time from the repo-root `CHANGELOG.md` by
+`frontend/scripts/extract-latest-changelog.mjs`). Mobile users are left
+without that visibility.
+
+The repo-root `CHANGELOG.md` is the canonical source — it's
+release-please-managed, updated on every release, and already structured by
+version. Bundling it into the APK keeps the Android changelog automatically
+in sync with releases (no separate hand-maintained list) and works offline.
+
+## Proposed Changes
+
+### 1. Add a "What's New" entry to the About section in Settings
+
+Inside `SettingsScreen.kt` the About section currently lists Version,
+Privacy Policy, and Terms of Service (lines 190–241). Add a third
+`TextButton` after Terms of Service that navigates to a new
+`ChangelogScreen`. Keep it grouped with About — it's reference info, not a
+preference.
+
+### 2. Bundle the repo-root `CHANGELOG.md` into the APK at build time
+
+Mirror the prior-art pattern in
+`frontend/scripts/extract-latest-changelog.mjs`. Add a Gradle task to the
+Android module's build script that:
+
+- Copies `CHANGELOG.md` from the repo root to
+  `android/app/src/main/assets/CHANGELOG.md` before the Android `preBuild`
+  task runs.
+- Makes `preBuild` depend on the new task so the asset is always fresh.
+- **Fails soft**: if the source file is missing (e.g. someone checking out
+  only the `android/` subtree), log a warning and let the build continue —
+  the screen will show its empty-state fallback.
+
+> Implementer note: verify the actual module build script path. Likely
+> `android/app/build.gradle.kts`; could be `build.gradle` if the module
+> hasn't been migrated to KTS.
+
+### 3. New `ChangelogScreen.kt`
+
+- Location:
+  `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChangelogScreen.kt`.
+- Reads the asset via `context.assets.open("CHANGELOG.md")`. Wrap the read
+  in a try/catch — return an empty list if the asset is missing.
+- Parses the Markdown into a list of release entries by splitting on the
+  `^## ` heading pattern (matches `## [0.8.0]` and `## 0.8.0` — same regex
+  that `frontend/scripts/extract-latest-changelog.mjs` already uses; consider
+  porting that logic).
+- Renders the entries in a `LazyColumn`. Each entry shows the version + date
+  as a header and the body below.
+
+**v1 rendering — recommended:** render the body as plain text inside a
+`Text(style = MaterialTheme.typography.bodyMedium)` (or in a monospaced
+block) without a Markdown library. Trade-off: bullets and links won't be
+clickable, but it avoids adding a new dependency and the content is short.
+
+Alternative: pull in a lightweight Compose Markdown renderer
+(e.g. `compose-markdown` or `markdown-compose`) for richer formatting.
+Defer this unless v1 reads poorly in QA.
+
+### 4. Navigation wiring
+
+`SettingsScreen` already accepts `onNavigateBack: () -> Unit`. Add a sibling
+parameter `onNavigateToChangelog: () -> Unit`, pass it down from wherever
+`SettingsScreen` is composed, and register the new route in the navigation
+graph. Implementer should locate the nav graph — likely in
+`MainActivity.kt` or `android/app/src/main/kotlin/org/voxquieta/app/presentation/navigation/` (verify path).
+
+### 5. String resources
+
+Add to `android/app/src/main/res/values/strings.xml` and to all 10 locale
+variants (`values-de`, `values-ru`, `values-zh`, `values-hi`, `values-ar`,
+`values-pt`, `values-ko`, `values-fr`, `values-it`, `values-es`):
+
+- `settings_changelog_title` — title of the screen (e.g. "What's New")
+- `settings_changelog_link` — label of the Settings entry (e.g. "What's New")
+- `changelog_empty` — fallback shown when the asset is missing/empty
+  (e.g. "Release notes are not available right now.")
+
+The changelog body itself stays in English (it's release-managed and
+auto-generated), matching the frontend's behaviour.
+
+## Acceptance Criteria
+
+- [ ] Settings shows a "What's New" entry in the About section that opens a
+      new screen.
+- [ ] The Changelog screen renders the contents of repo-root `CHANGELOG.md`
+      that was bundled at build time.
+- [ ] When `CHANGELOG.md` is missing from the assets, the screen shows the
+      `changelog_empty` fallback instead of crashing.
+- [ ] The Gradle task runs automatically before `preBuild` — running
+      `./gradlew clean assembleDebug` produces an APK that contains
+      `assets/CHANGELOG.md` matching the repo-root file.
+- [ ] All 11 locales (English + 10 variants) have translated values for the
+      new strings.
+- [ ] `./gradlew assembleDebug` succeeds.
+- [ ] Manual QA: open Settings → tap "What's New" → verify recent releases
+      (0.8.0, 0.7.0, …) are visible and readable.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `android/app/build.gradle.kts` (verify path) | Add Gradle task to copy `CHANGELOG.md` into `src/main/assets/`; wire it as a `preBuild` dependency |
+| `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/SettingsScreen.kt` | Add `onNavigateToChangelog` parameter; add "What's New" `TextButton` in the About section |
+| `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChangelogScreen.kt` | New file — load asset, parse, render |
+| Navigation graph (e.g. `MainActivity.kt` or `presentation/navigation/*.kt`) | Register the new route and wire `onNavigateToChangelog` |
+| `android/app/src/main/res/values/strings.xml` + 10 locale variants | Add `settings_changelog_title`, `settings_changelog_link`, `changelog_empty` |
+| `.gitignore` (verify) | If `assets/CHANGELOG.md` is generated, optionally ignore it so the bundled copy isn't checked in |
+
+## Out of Scope
+
+- Markdown fidelity beyond headings + paragraphs (no syntax highlighting,
+  no clickable PR links).
+- Translation of the changelog body — body stays in English, mirroring the
+  frontend.
+- Fetching the changelog from GitHub at runtime.
+- A "What's New" modal on app start after an upgrade (separate story).
+- iOS app.
+
+## Priority
+
+P2 — Medium. Improves discoverability of new features; no broken
+functionality today.
+
+## Size
+
+M (4–8 hours) — build-script glue + a new screen + nav wiring + 11 string
+resource files.
+
+## Dependencies / Related Work
+
+- Frontend equivalent: PR #474 (`feat(frontend): add changelog page and
+  what's-new modal`).
+- Prior-art script: `frontend/scripts/extract-latest-changelog.mjs`.
+- Builds on: BITB-026 (settings UX improvements).
+
+## Assignee
+
+android-expert

--- a/docs/BACKLOG_STORIES/BITB-032-route-support-emails-to-dedicated-inbox.md
+++ b/docs/BACKLOG_STORIES/BITB-032-route-support-emails-to-dedicated-inbox.md
@@ -1,0 +1,137 @@
+# BITB-032: Route Support/Diagnostic Emails to `support@voxquieta.org`
+
+## User Story
+
+As the product team, I want contact-form submissions and diagnostic bug
+reports from the Android app (and any other client of the backend's
+feedback endpoint) to land in `support@voxquieta.org` instead of
+`contact@voxquieta.org`, so support requests are handled by the right
+inbox and not mixed with general inbound mail.
+
+## Problem
+
+Both the Android "Send Diagnostic Report" flow
+(`DiagnosticReportBottomSheet`) and the "Get in Touch" contact form
+(`ContactFormBottomSheet`) POST through the backend endpoint
+`/api/v1/feedback/contact` (`android/.../BibleApiService.kt:71`). The
+backend's email service then relays a notification to a single configured
+recipient.
+
+That recipient is `contact@voxquieta.org` today (`api/config.py:92`,
+default value of `contact_notification_email`). The product intent is to
+have a dedicated `support@voxquieta.org` inbox for actionable issues so
+they aren't lost in a general contact mailbox.
+
+## Background — How the email recipient is wired
+
+- **Setting**: `api/config.py:92`
+  ```python
+  contact_notification_email: str = "contact@voxquieta.org"
+  ```
+- **Usage**: `api/utils/email_service.py:142` and `:215` —
+  ```python
+  to_email = settings.contact_notification_email
+  ```
+  Used for both contact-form submissions and negative-feedback (thumbs
+  down) notifications.
+- **Env override**: documented in `deployment/README.md:863` —
+  `CONTACT_NOTIFICATION_EMAIL=your-email@example.com`. Production almost
+  certainly sets this via environment variable, so the deployed value
+  must be updated; flipping only the default in `config.py` is not
+  sufficient on its own.
+
+## Proposed Changes (Option 1 — recommended)
+
+Change the single setting that drives both flows.
+
+1. **Update the default** in `api/config.py`:
+   ```python
+   contact_notification_email: str = "support@voxquieta.org"
+   ```
+2. **Update the deployed environment value** of
+   `CONTACT_NOTIFICATION_EMAIL` to `support@voxquieta.org` in whichever
+   deployment system holds it (e.g. Container Apps env config / Terraform
+   under `infra/`, or a GitHub Actions secret). The implementer must
+   identify the actual source — search the repo for
+   `CONTACT_NOTIFICATION_EMAIL` and update every place it's set.
+3. **Refresh the doc examples** in `deployment/README.md` (lines 845,
+   863, 870, 871) so the example email matches the new convention.
+4. **Verify mail server**: confirm `support@voxquieta.org` exists as a
+   real mailbox or alias before flipping the default. Coordinate with
+   whoever runs the mail provider. Until that's verified, treat this
+   story as blocked.
+
+## Why not introduce a separate setting?
+
+Considered: add a new `support_notification_email` and route only
+diagnostic reports there, keeping the contact form on
+`contact@voxquieta.org`. **Not recommended** for now:
+
+- Doubles config surface and requires plumbing a second recipient
+  through `email_service`.
+- The two flows already share a single backend endpoint and template;
+  splitting them is a bigger change than the user story justifies.
+- A shared `support@` inbox can route internally with mail rules if
+  triage requires.
+
+Revisit only if support volume makes a single inbox unworkable.
+
+## Acceptance Criteria
+
+- [ ] `api/config.py` default for `contact_notification_email` is
+      `support@voxquieta.org`.
+- [ ] Production `CONTACT_NOTIFICATION_EMAIL` is set to
+      `support@voxquieta.org` in every deployment config file (list each
+      file in the PR description).
+- [ ] `deployment/README.md` examples reference the new address.
+- [ ] `pytest api/tests/test_email_service.py` passes. Existing tests
+      stub `mock_settings.contact_notification_email = "admin@example.com"`
+      (lines 264, 301, 339, 371, 399, 437) and do not assert the literal
+      `contact@voxquieta.org`, so no test should need editing — confirm
+      this by running the suite.
+- [ ] Manual QA after deploy: submit a diagnostic report from the
+      Android app on a build pointing at the updated environment; verify
+      the notification arrives at `support@voxquieta.org`.
+- [ ] Manual QA: submit a contact-form message; verify it also lands at
+      `support@voxquieta.org`.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `api/config.py` | Change default of `contact_notification_email` to `support@voxquieta.org` |
+| `deployment/README.md` | Update example values around lines 845, 863, 870, 871 |
+| `infra/**` and any GH Actions / Container Apps env config | Update `CONTACT_NOTIFICATION_EMAIL` (paths TBD by implementer) |
+
+## Out of Scope
+
+- Changing the SMTP **sender** address (`noreply@voxquieta.org`) — sender
+  identity stays the same.
+- Changing `frontend/messages/*.json:124` (`errorConnection`) — those are
+  user-facing fallback contact addresses ("if the problem persists, you
+  can reach us at contact@voxquieta.org") and a separate decision.
+  Flagged here so we don't accidentally couple them.
+- iOS app (no current iOS support email flow).
+- A separate `support_notification_email` setting (see "Why not"
+  section).
+- Mail provider provisioning of the new mailbox — that's a prerequisite
+  tracked outside this story.
+
+## Priority
+
+P1 — High once the mailbox is provisioned. Small change but directly
+affects how support requests are received in production.
+
+## Size
+
+XS — under 1 hour of code change. Most of the work is locating every
+deployment config that sets `CONTACT_NOTIFICATION_EMAIL`.
+
+## Dependencies / Prerequisites
+
+- `support@voxquieta.org` must exist (or be aliased) on the mail
+  provider before merging.
+
+## Assignee
+
+backend / devops

--- a/docs/BACKLOG_STORIES/BITB-032-route-support-emails-to-dedicated-inbox.md
+++ b/docs/BACKLOG_STORIES/BITB-032-route-support-emails-to-dedicated-inbox.md
@@ -25,13 +25,17 @@ they aren't lost in a general contact mailbox.
 ## Background — How the email recipient is wired
 
 - **Setting**: `api/config.py:92`
+
   ```python
   contact_notification_email: str = "contact@voxquieta.org"
   ```
+
 - **Usage**: `api/utils/email_service.py:142` and `:215` —
+
   ```python
   to_email = settings.contact_notification_email
   ```
+
   Used for both contact-form submissions and negative-feedback (thumbs
   down) notifications.
 - **Env override**: documented in `deployment/README.md:863` —
@@ -45,9 +49,11 @@ they aren't lost in a general contact mailbox.
 Change the single setting that drives both flows.
 
 1. **Update the default** in `api/config.py`:
+
    ```python
    contact_notification_email: str = "support@voxquieta.org"
    ```
+
 2. **Update the deployed environment value** of
    `CONTACT_NOTIFICATION_EMAIL` to `support@voxquieta.org` in whichever
    deployment system holds it (e.g. Container Apps env config / Terraform
@@ -109,7 +115,7 @@ Revisit only if support volume makes a single inbox unworkable.
   identity stays the same.
 - Changing `frontend/messages/*.json:124` (`errorConnection`) — those are
   user-facing fallback contact addresses ("if the problem persists, you
-  can reach us at contact@voxquieta.org") and a separate decision.
+  can reach us at `contact@voxquieta.org`) and a separate decision.
   Flagged here so we don't accidentally couple them.
 - iOS app (no current iOS support email flow).
 - A separate `support_notification_email` setting (see "Why not"

--- a/docs/BACKLOG_STORIES/BITB-033-android-rename-post-send-cancel-button.md
+++ b/docs/BACKLOG_STORIES/BITB-033-android-rename-post-send-cancel-button.md
@@ -1,0 +1,132 @@
+# BITB-033: Android — Rename Post-Send "Cancel" Button to "Done"
+
+## User Story
+
+As an Android user who has just sent a diagnostic report or a contact
+message, I want the dismiss button on the success screen to read "Done"
+instead of "Cancel", so it's clear my submission was accepted and that
+I'm just closing the panel — not undoing my message.
+
+## Problem
+
+Both bottom sheets show a success screen after a submission succeeds, and
+both reuse `R.string.action_cancel` ("Cancel") for the only action on
+that screen:
+
+- `android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt:119-121`
+  ```kotlin
+  Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+      Text(stringResource(R.string.action_cancel))
+  }
+  ```
+- `android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt:140-142`
+  ```kotlin
+  Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
+      Text(stringResource(R.string.action_cancel))
+  }
+  ```
+
+The success state is entered when the shared `ContactFormState.Success`
+is emitted (`ContactFormBottomSheet.kt:49-54`).
+
+The word "Cancel" implies the action can be undone. Post-send, that's
+misleading — the email has already been delivered.
+
+## Proposed Changes
+
+### 1. Add a new string resource — do **not** rename `action_cancel`
+
+`action_cancel` is used in many other places where "Cancel" is the
+correct word (e.g. back-arrow content description in
+`SettingsScreen.kt:92`, dismissive actions in conversation flows).
+Adding a new key is cheaper and safer than churning every call site.
+
+Add to `android/app/src/main/res/values/strings.xml`:
+
+```xml
+<string name="action_done">Done</string>
+```
+
+Add to all 10 locale variants (`values-de`, `values-ru`, `values-zh`,
+`values-hi`, `values-ar`, `values-pt`, `values-ko`, `values-fr`,
+`values-it`, `values-es`).
+
+**Proposed translations** (have these reviewed through the existing
+translation flow — they're reasonable starting points):
+
+| Locale | Value |
+|---|---|
+| de | Fertig |
+| ru | Готово |
+| zh | 完成 |
+| hi | हो गया |
+| ar | تم |
+| pt | Concluído |
+| ko | 완료 |
+| fr | Terminé |
+| it | Fatto |
+| es | Hecho |
+
+### 2. Update the two bottom-sheet success buttons
+
+In `DiagnosticReportBottomSheet.kt:120` and
+`ContactFormBottomSheet.kt:141`, swap:
+
+```kotlin
+Text(stringResource(R.string.action_cancel))
+```
+
+to:
+
+```kotlin
+Text(stringResource(R.string.action_done))
+```
+
+No other code changes needed — the `onClick = onDismiss` handler is
+already correct for "I'm done here, close the sheet".
+
+## Acceptance Criteria
+
+- [ ] Diagnostic report success screen button reads "Done" in English.
+- [ ] Contact form success screen button reads "Done" in English.
+- [ ] All 10 locale variants of `strings.xml` contain the translated
+      `action_done` value.
+- [ ] No other usage of `action_cancel` is affected.
+- [ ] Manual QA in English and in Arabic (RTL): submit a diagnostic
+      report, confirm the button label and that the sheet still dismisses
+      correctly.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt` | Line 120: swap `action_cancel` → `action_done` |
+| `android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt` | Line 141: swap `action_cancel` → `action_done` |
+| `android/app/src/main/res/values/strings.xml` | Add `<string name="action_done">Done</string>` |
+| `android/app/src/main/res/values-{de,ru,zh,hi,ar,pt,ko,fr,it,es}/strings.xml` | Add translated `action_done` per the table above |
+
+## Out of Scope
+
+- Renaming `action_cancel` itself anywhere else in the app.
+- Changing the success-screen copy (`diagnostic_success_title`,
+  `diagnostic_success_description`, `contact_success_title`,
+  `contact_success_description`).
+- Restyling the button (icon, colour) — copy change only.
+- iOS app.
+
+## Priority
+
+P3 — Low. Cosmetic clarity fix; the flow already works.
+
+## Size
+
+XS — under 1 hour, including running the translation flow review.
+
+## Dependencies / Related Work
+
+- Builds on BITB-026 (settings UX improvements) and the diagnostic
+  report flow introduced in PR #531 / #540.
+
+## Assignee
+
+android-expert

--- a/docs/BACKLOG_STORIES/BITB-033-android-rename-post-send-cancel-button.md
+++ b/docs/BACKLOG_STORIES/BITB-033-android-rename-post-send-cancel-button.md
@@ -14,12 +14,15 @@ both reuse `R.string.action_cancel` ("Cancel") for the only action on
 that screen:
 
 - `android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt:119-121`
+
   ```kotlin
   Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
       Text(stringResource(R.string.action_cancel))
   }
   ```
+
 - `android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt:140-142`
+
   ```kotlin
   Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
       Text(stringResource(R.string.action_cancel))


### PR DESCRIPTION
## Summary

Three new backlog stories under `docs/BACKLOG_STORIES/` capturing requested Android/Settings work. No code changes — analysis-only docs that follow the BITB-026 template.

- **BITB-031** — Android Settings "What's New" / Changelog screen. Bundles a pre-parsed `changelog.json` (all releases) into the APK as an `assets/` file via a new Gradle task that derives it from the repo-root `CHANGELOG.md`. New `ChangelogScreen.kt` reads the JSON and renders entries in a `LazyColumn`. Adds string resources across all 11 locales. P2 / M.
- **BITB-032** — Route `/api/v1/feedback/contact` notifications (Android contact form + diagnostic report) to `support@voxquieta.org` instead of `contact@voxquieta.org`. Single-setting change in `api/config.py:92` (`contact_notification_email`) plus updating the deployed `CONTACT_NOTIFICATION_EMAIL` env var. Flagged as blocked until the mailbox is provisioned. P1 / XS.
- **BITB-033** — Rename the post-send "Cancel" button to "Done" in `DiagnosticReportBottomSheet.kt:120` and `ContactFormBottomSheet.kt:141`. Adds a new `action_done` string resource (instead of renaming `action_cancel`, which is used widely elsewhere) with translations for all 10 locale variants. P3 / XS.

Each doc includes a real analysis of the current code with file paths, line numbers, acceptance criteria, files to modify, and out-of-scope notes — so the implementer can execute without re-discovering context.

## Test plan

Docs-only change — no code to test. Verification:

- [ ] All three files render cleanly as Markdown in the GitHub preview.
- [ ] Each doc matches the BITB-026 template sections (User Story, Problem, Proposed Changes, Acceptance Criteria, Files to Modify, Out of Scope, Priority, Size).
- [ ] File paths and line numbers referenced in the analysis sections still point to the right code on `main`.

https://claude.ai/code/session_01RiajxKgsMxuXV6h8mHXWu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiajxKgsMxuXV6h8mHXWu4)_