### PR TITLE
fix(android): re-throw CancellationException in all coroutine catch blocks

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/repositories/ChatRepositoryImpl.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/repositories/ChatRepositoryImpl.kt
@@ -15,6 +15,7 @@ import org.voxquieta.app.domain.models.FeedbackRating
 import org.voxquieta.app.domain.models.Message
 import org.voxquieta.app.domain.models.StreamChunk
 import org.voxquieta.app.domain.repositories.ChatRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -107,6 +108,7 @@ class ChatRepositoryImpl @Inject constructor(
             )
             api.submitFeedback(dto)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             // Best-effort: silently swallow all errors so feedback never
             // disrupts the user's experience.
             Timber.w(e, "submitFeedback failed (non-fatal)")

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
@@ -2,6 +2,7 @@ package org.voxquieta.app.data.streaming
 
 import org.voxquieta.app.data.remote.models.StreamChunkDto
 import org.voxquieta.app.data.remote.models.VerseDto
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
@@ -107,6 +108,7 @@ fun ResponseBody.toChunkFlow(): Flow<StreamChunkDto> = flow {
                     }
                 }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.w(e, "SSE: failed to parse chunk: %s", data)
             }
         }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -31,6 +31,7 @@ import org.voxquieta.app.utils.LogCollector
 import org.voxquieta.app.utils.NetworkMonitor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -284,6 +285,7 @@ class ChatViewModel @Inject constructor(
                 _availableTranslations.value = response.translations
                 return
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 val isLastAttempt = attempt == maxAttempts - 1
                 if (isLastAttempt) {
                     Timber.w(e, "Failed to fetch translations after $maxAttempts attempts; defaulting to empty list")
@@ -318,6 +320,7 @@ class ChatViewModel @Inject constructor(
                 _bookNames.value = response
                 return
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 val isLastAttempt = attempt == maxAttempts - 1
                 if (isLastAttempt) {
                     Timber.w(e, "Failed to fetch book names after $maxAttempts attempts; falling back to default regex")
@@ -715,6 +718,7 @@ class ChatViewModel @Inject constructor(
                 }
                 Timber.i("Feedback submitted: messageId=%s rating=%s", assistantMsg.messageId, rating)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to submit feedback")
                 _uiState.update { it.copy(isFeedbackSubmitting = false) }
             }
@@ -757,6 +761,7 @@ class ChatViewModel @Inject constructor(
                 val response = bibleApiService.getChapter(book, chapter, translation)
                 _chapterSheetState.value = ChapterSheetState.Success(response)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "loadChapter error: $book $chapter")
                 _chapterSheetState.value = ChapterSheetState.Error(mapExceptionToMessage(e))
             }
@@ -818,6 +823,7 @@ class ChatViewModel @Inject constructor(
                     location = location.trim(),
                 )
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "searchChurches error for location=$location")
                 _churchFinderSheetState.value = ChurchFinderSheetState.Error(
                     mapExceptionToMessage(e),
@@ -855,6 +861,7 @@ class ChatViewModel @Inject constructor(
                 _contactFormState.value = ContactFormState.Success
                 Timber.i("Contact submitted: subject=%s", subject)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to submit contact form")
                 _contactFormState.value = ContactFormState.Error(
                     mapExceptionToMessage(e),
@@ -898,6 +905,7 @@ class ChatViewModel @Inject constructor(
                 _diagnosticReportState.value = ContactFormState.Success
                 Timber.i("Diagnostic bug report submitted")
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to send diagnostic email")
                 _diagnosticReportState.value = ContactFormState.Error(
                     mapExceptionToMessage(e),
@@ -933,6 +941,7 @@ class ChatViewModel @Inject constructor(
                     },
                 )
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to share debug logs")
             }
         }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -36,6 +36,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -578,6 +579,56 @@ class ChatViewModelTest {
 
         assertEquals(1, vm.availableTranslations.value.size)
         assertEquals("ESV", vm.availableTranslations.value[0].id)
+    }
+
+    @Test
+    fun `fetchTranslationsWithRetry propagates CancellationException without retrying`() = runTest {
+        coEvery { bibleApiService.getTranslations() } throws CancellationException("scope cancelled")
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // CancellationException must be re-thrown, not caught as a transient error:
+        // if it were swallowed, all 3 retry attempts would execute.
+        coVerify(exactly = 1) { bibleApiService.getTranslations() }
+    }
+
+    @Test
+    fun `fetchBookNamesWithRetry propagates CancellationException without retrying`() = runTest {
+        coEvery { bibleApiService.getBookNames() } throws CancellationException("scope cancelled")
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { bibleApiService.getBookNames() }
     }
 
     @Test

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -583,9 +583,12 @@ class ChatViewModelTest {
 
     @Test
     fun `fetchTranslationsWithRetry propagates CancellationException without retrying`() = runTest {
-        coEvery { bibleApiService.getTranslations() } throws CancellationException("scope cancelled")
+        // Use a local mock so the setUp viewModel's pending coroutines (which share the
+        // class-level bibleApiService mock) don't contribute extra invocations to the count.
+        val localApiService = mockk<BibleApiService>(relaxed = true)
+        coEvery { localApiService.getTranslations() } throws CancellationException("scope cancelled")
 
-        val vm = ChatViewModel(
+        ChatViewModel(
             repository,
             churchRepository,
             contactRepository,
@@ -596,7 +599,7 @@ class ChatViewModelTest {
             translationPreferences,
             sessionPreferences,
             lastConversationPreferences,
-            bibleApiService,
+            localApiService,
             networkMonitor,
             localeApplier,
         )
@@ -604,14 +607,15 @@ class ChatViewModelTest {
 
         // CancellationException must be re-thrown, not caught as a transient error:
         // if it were swallowed, all 3 retry attempts would execute.
-        coVerify(exactly = 1) { bibleApiService.getTranslations() }
+        coVerify(exactly = 1) { localApiService.getTranslations() }
     }
 
     @Test
     fun `fetchBookNamesWithRetry propagates CancellationException without retrying`() = runTest {
-        coEvery { bibleApiService.getBookNames() } throws CancellationException("scope cancelled")
+        val localApiService = mockk<BibleApiService>(relaxed = true)
+        coEvery { localApiService.getBookNames() } throws CancellationException("scope cancelled")
 
-        val vm = ChatViewModel(
+        ChatViewModel(
             repository,
             churchRepository,
             contactRepository,
@@ -622,13 +626,13 @@ class ChatViewModelTest {
             translationPreferences,
             sessionPreferences,
             lastConversationPreferences,
-            bibleApiService,
+            localApiService,
             networkMonitor,
             localeApplier,
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify(exactly = 1) { bibleApiService.getBookNames() }
+        coVerify(exactly = 1) { localApiService.getBookNames() }
     }
 
     @Test


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `catch (e: Exception)` silently swallowed `CancellationException` (which extends `Exception` in Kotlin), breaking structured concurrency across the app
- The reported bug — spurious "Failed to fetch translations/book names (attempt 1/3); retrying" log lines on every app open — was caused by the `resume` navigation route creating a `ChatViewModel` whose `viewModelScope` was immediately cancelled when the route popped, with `JobCancellationException` being caught and misreported as a transient network error
- Fix: add `if (e is CancellationException) throw e` as the first statement in every affected `catch` block (10 sites across 3 files)

## Files changed

| File | Sites |
|------|-------|
| `ChatViewModel.kt` | 8: `fetchTranslationsWithRetry`, `fetchBookNamesWithRetry`, `submitFeedback`, `loadChapter`, `searchChurches`, `submitContact`, `sendDiagnosticEmail`, `saveDiagnosticLogLocally` |
| `EventSourceParser.kt` | 1: outer catch wrapping `emit()` in the SSE `flow {}` builder |
| `ChatRepositoryImpl.kt` | 1: best-effort `submitFeedback` |

Two unit tests added to `ChatViewModelTest` verify that `CancellationException` propagates immediately from the retry functions rather than triggering retry attempts (call count must be 1, not 3).

## Test plan

- [ ] `./gradlew :app:testDebugUnitTest` passes, including the two new cancellation-propagation tests
- [ ] Manual: open app, background, reopen — no "Failed to fetch … retrying" warnings in logcat under normal conditions

https://claude.ai/code/session_01Bs5Uz1WGMv123Bab3EazaJ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bs5Uz1WGMv123Bab3EazaJ)_