### PR TITLE
fix(android): rename post-send dismiss button from "Cancel" to "Done" (BITB-033)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ContactFormBottomSheet.kt
@@ -138,7 +138,7 @@ fun ContactFormBottomSheet(
                     )
                     Spacer(Modifier.height(8.dp))
                     Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
-                        Text(stringResource(R.string.action_cancel))
+                        Text(stringResource(R.string.action_done))
                     }
                 }
                 return@Column

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/DiagnosticReportBottomSheet.kt
@@ -117,7 +117,7 @@ fun DiagnosticReportBottomSheet(
                     )
                     Spacer(Modifier.height(8.dp))
                     Button(onClick = onDismiss, modifier = Modifier.fillMaxWidth()) {
-                        Text(stringResource(R.string.action_cancel))
+                        Text(stringResource(R.string.action_done))
                     }
                 }
                 return@Column

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">سيؤدي هذا إلى حذف محفوظات المحادثة بالكامل نهائيًا.</string>
     <string name="conversations_clear_all_confirm">مسح الكل</string>
     <string name="action_cancel">إلغاء</string>
+    <string name="action_done">تم</string>
     <string name="action_new_conversation">محادثة جديدة</string>
     <string name="action_clear_all_conversations">مسح جميع المحادثات</string>
     <string name="action_delete_conversation">حذف المحادثة</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">Dadurch wird der gesamte Gesprächsverlauf dauerhaft gelöscht.</string>
     <string name="conversations_clear_all_confirm">Alle löschen</string>
     <string name="action_cancel">Abbrechen</string>
+    <string name="action_done">Fertig</string>
     <string name="action_new_conversation">Neues Gespräch</string>
     <string name="action_clear_all_conversations">Alle Gespräche löschen</string>
     <string name="action_delete_conversation">Gespräch löschen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">Se eliminará permanentemente todo el historial de conversaciones.</string>
     <string name="conversations_clear_all_confirm">Borrar todo</string>
     <string name="action_cancel">Cancelar</string>
+    <string name="action_done">Hecho</string>
     <string name="action_new_conversation">Nueva conversación</string>
     <string name="action_clear_all_conversations">Borrar todas las conversaciones</string>
     <string name="action_delete_conversation">Eliminar conversación</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">Tout l\'historique des conversations sera définitivement supprimé.</string>
     <string name="conversations_clear_all_confirm">Tout effacer</string>
     <string name="action_cancel">Annuler</string>
+    <string name="action_done">Terminé</string>
     <string name="action_new_conversation">Nouvelle conversation</string>
     <string name="action_clear_all_conversations">Effacer toutes les conversations</string>
     <string name="action_delete_conversation">Supprimer la conversation</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">यह सभी बातचीत इतिहास हमेशा के लिए हटा देगा।</string>
     <string name="conversations_clear_all_confirm">सब हटाएं</string>
     <string name="action_cancel">रद्द करें</string>
+    <string name="action_done">हो गया</string>
     <string name="action_new_conversation">नई बातचीत</string>
     <string name="action_clear_all_conversations">सभी बातचीत साफ करें</string>
     <string name="action_delete_conversation">बातचीत हटाएं</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">Questo eliminerà definitivamente tutta la cronologia delle conversazioni.</string>
     <string name="conversations_clear_all_confirm">Cancella tutto</string>
     <string name="action_cancel">Annulla</string>
+    <string name="action_done">Fatto</string>
     <string name="action_new_conversation">Nuova conversazione</string>
     <string name="action_clear_all_conversations">Cancella tutte le conversazioni</string>
     <string name="action_delete_conversation">Elimina conversazione</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">모든 대화 기록이 영구적으로 삭제됩니다.</string>
     <string name="conversations_clear_all_confirm">모두 삭제</string>
     <string name="action_cancel">취소</string>
+    <string name="action_done">완료</string>
     <string name="action_new_conversation">새 대화</string>
     <string name="action_clear_all_conversations">모든 대화 지우기</string>
     <string name="action_delete_conversation">대화 삭제</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">Isso excluirá permanentemente todo o histórico de conversas.</string>
     <string name="conversations_clear_all_confirm">Apagar tudo</string>
     <string name="action_cancel">Cancelar</string>
+    <string name="action_done">Concluído</string>
     <string name="action_new_conversation">Nova conversa</string>
     <string name="action_clear_all_conversations">Apagar todas as conversas</string>
     <string name="action_delete_conversation">Excluir conversa</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">Это навсегда удалит всю историю бесед.</string>
     <string name="conversations_clear_all_confirm">Удалить всё</string>
     <string name="action_cancel">Отмена</string>
+    <string name="action_done">Готово</string>
     <string name="action_new_conversation">Новая беседа</string>
     <string name="action_clear_all_conversations">Удалить все беседы</string>
     <string name="action_delete_conversation">Удалить беседу</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -125,6 +125,7 @@
     <string name="conversations_clear_all_message">这将永久删除所有对话记录。</string>
     <string name="conversations_clear_all_confirm">全部删除</string>
     <string name="action_cancel">取消</string>
+    <string name="action_done">完成</string>
     <string name="action_new_conversation">新对话</string>
     <string name="action_clear_all_conversations">清除所有对话</string>
     <string name="action_delete_conversation">删除对话</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="conversations_clear_all_message">This will permanently delete all conversation history.</string>
     <string name="conversations_clear_all_confirm">Clear all</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_done">Done</string>
     <string name="action_new_conversation">New conversation</string>
     <string name="action_clear_all_conversations">Clear all conversations</string>
     <string name="action_delete_conversation">Delete conversation</string>


### PR DESCRIPTION
## Summary

- After a successful contact form or diagnostic report submission, the dismiss button read **"Cancel"** — implying the action could be undone. The email was already delivered, so **"Done"** is the correct label.
- Added `action_done` string resource to all 11 locale files (EN + DE, RU, ZH, HI, AR, PT, KO, FR, IT, ES).
- Swapped `R.string.action_cancel` → `R.string.action_done` in the success-state buttons of `DiagnosticReportBottomSheet` and `ContactFormBottomSheet`. No other usages of `action_cancel` were touched.

## Files Changed

| File | Change |
|---|---|
| `android/app/src/main/res/values/strings.xml` | Add `action_done = "Done"` |
| `android/app/src/main/res/values-{de,ru,zh,hi,ar,pt,ko,fr,it,es}/strings.xml` | Add translated `action_done` per locale |
| `DiagnosticReportBottomSheet.kt:120` | `action_cancel` → `action_done` in success screen |
| `ContactFormBottomSheet.kt:141` | `action_cancel` → `action_done` in success screen |

## Test plan

- [ ] Build and install the app on a device/emulator
- [ ] Submit a diagnostic report → success screen shows **"Done"** button; tapping it dismisses the sheet
- [ ] Submit a contact form message → success screen shows **"Done"** button; tapping it dismisses the sheet
- [ ] Switch device language to Arabic (RTL) and repeat both flows — button renders correctly
- [ ] Confirm no other "Cancel" buttons in the app were affected (e.g. back-arrow, conversation dismissals)

https://claude.ai/code/session_018HB2J5QeTpJfHQsFS2KdrF

---
_Generated by [Claude Code](https://claude.ai/code/session_018HB2J5QeTpJfHQsFS2KdrF)_