### PR TITLE
fix(android-publish): skip rollout param when release_status is draft

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -39,16 +39,20 @@ platform :android do
 
   desc "Upload AAB to Play Store production track (defaults to draft for manual rollout)"
   lane :production do
-    upload_to_play_store(
+    status = release_status_for("draft")
+    params = {
       track: "production",
       aab: "app/build/outputs/bundle/release/app-release.aab",
-      release_status: release_status_for("draft"),
-      rollout: ENV.fetch("ROLLOUT", "1.0"),
+      release_status: status,
       skip_upload_apk: true,
       skip_upload_metadata: false,
       skip_upload_changelogs: false,
       skip_upload_images: false,
       skip_upload_screenshots: false,
-    )
+    }
+    # Play Store rejects rollout + draft together. Only attach a rollout
+    # percentage when the release is actually going live.
+    params[:rollout] = ENV.fetch("ROLLOUT", "1.0") unless status == "draft"
+    upload_to_play_store(**params)
   end
 end


### PR DESCRIPTION
## Summary

The 1.5.0 production publish [failed](https://github.com/zioalex/getinspiredbythebible/actions/runs/25867597176/job/76013780370) with:

> Cannot specify rollout percentage when the release status is set to 'draft'

My prior PR (#547) made the `:production` Fastlane lane default to `release_status: "draft"` (so a human clicks "Start rollout" in Play Console) but kept the `rollout: 1.0` parameter unconditionally — Fastlane / `upload_to_play_store` rejects that combination.

## Fix

Build the `upload_to_play_store` kwargs as a hash and attach `rollout:` only when `release_status != "draft"`. For draft uploads, the Play Console surfaces the rollout slider when the user clicks "Review release" — omitting the param is the correct behaviour.

```ruby
status = release_status_for("draft")
params = { track: "production", aab: "...", release_status: status, ... }
params[:rollout] = ENV.fetch("ROLLOUT", "1.0") unless status == "draft"
upload_to_play_store(**params)
```

## Re-publishing v1.5.0

After this merges, the `v1.5.0` tag already exists but the workflow run is failed. To re-publish from the tag's commit, the simplest path is a **manual workflow_dispatch**:

1. Actions → "Android Publish" → "Run workflow"
2. Branch: `main` (uses the **fixed** Fastfile)
3. Inputs:
   - `track`: `production`
   - `version_name`: `1.5.0`  ← required, since manual dispatch isn't a tag push
   - `version_code`: (leave empty — uses fresh `date +%s`)
   - `release_status`: (leave empty — lane default `draft` applies)
4. Run

Then click "Start rollout" in Play Console on the resulting draft.

> **Alternative** (not recommended): force-move the `v1.5.0` tag to the new commit on main, but that's destructive and not necessary — the manual dispatch is cleaner.

## Test plan

- [ ] Merge → no CI breakage.
- [ ] Manual dispatch `track=production` with `version_name=1.5.0` → workflow succeeds, AAB uploaded as draft to production track.
- [ ] Play Console shows the 1.5.0 draft release awaiting "Start rollout".
- [ ] Click "Start rollout" — verifies the manual promotion path.

https://claude.ai/code/session_01RiajxKgsMxuXV6h8mHXWu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RiajxKgsMxuXV6h8mHXWu4)_