### PR TITLE
fix(ui): compact Bible version selector and default verses to Cited

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/VersesPanel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/VersesPanel.kt
@@ -156,7 +156,7 @@ fun VersesPanel(
     localizedToEnglish: Map<String, String> = emptyMap(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-    var showReferenced by rememberSaveable { mutableStateOf(false) }
+    var showReferenced by rememberSaveable { mutableStateOf(true) }
 
     val displayedVerses = if (showReferenced) {
         referencedVerses(allVerses, messages, localizedToEnglish)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <!-- Verses sidebar panel -->
     <string name="action_open_verses_panel">Related verses</string>
     <string name="verses_panel_title">Related Verses</string>
-    <string name="verses_filter_referenced">Referenced</string>
+    <string name="verses_filter_referenced">Cited</string>
     <string name="verses_filter_all_related">All Related (%d)</string>
     <string name="verses_panel_empty">No verses found for this filter.</string>
 

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "استلهم يومياً من كلمة الله",
-    "bibleVersion": "إصدار الكتاب المقدس:",
-    "autoDetect": "اكتشاف تلقائي",
+    "bibleVersion": "إصدار الكتاب المقدس",
     "newChat": "محادثة جديدة"
   },
   "Welcome": {

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Lass dich täglich von Gottes Wort inspirieren",
-    "bibleVersion": "Bibelversion:",
-    "autoDetect": "Automatisch erkennen",
+    "bibleVersion": "Bibelversion",
     "newChat": "Neuer Chat"
   },
   "Welcome": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Get inspired daily by God's Word",
-    "bibleVersion": "Bible version:",
-    "autoDetect": "Auto-detect",
+    "bibleVersion": "Bible version",
     "newChat": "New Chat"
   },
   "Welcome": {
@@ -129,7 +128,7 @@
   "Verses": {
     "scriptureReferences": "Scripture References",
     "verseCount": "{count, plural, =1 {1 verse} other {# verses}}",
-    "referenced": "Referenced",
+    "referenced": "Cited",
     "allRelated": "All Related ({count})",
     "noVersesReferenced": "No verses referenced yet.",
     "noVersesReferencedHint": "Verses will appear here when mentioned in the chat.",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Inspírate cada día con la Palabra de Dios",
-    "bibleVersion": "Versión de la Biblia:",
-    "autoDetect": "Detectar automáticamente",
+    "bibleVersion": "Versión de la Biblia",
     "newChat": "Nueva Conversación"
   },
   "Welcome": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Laisse-toi inspirer chaque jour par la Parole de Dieu",
-    "bibleVersion": "Version de la Bible :",
-    "autoDetect": "Détection automatique",
+    "bibleVersion": "Version de la Bible",
     "newChat": "Nouvelle conversation"
   },
   "Welcome": {

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "परमेश्वर के वचन से हर दिन प्रेरित हों",
-    "bibleVersion": "बाइबिल संस्करण:",
-    "autoDetect": "स्वतः-पहचान",
+    "bibleVersion": "बाइबिल संस्करण",
     "newChat": "नई बातचीत"
   },
   "Welcome": {

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Lasciati ispirare ogni giorno dalla Parola di Dio",
-    "bibleVersion": "Versione biblica:",
-    "autoDetect": "Rileva automaticamente",
+    "bibleVersion": "Versione biblica",
     "newChat": "Nuova Chat"
   },
   "Welcome": {

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "매일 하나님의 말씀에서 영감을 받으세요",
-    "bibleVersion": "성경 버전:",
-    "autoDetect": "자동 감지",
+    "bibleVersion": "성경 버전",
     "newChat": "새 대화"
   },
   "Welcome": {

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Inspire-se diariamente pela Palavra de Deus",
-    "bibleVersion": "Versão da Bíblia:",
-    "autoDetect": "Detetar automaticamente",
+    "bibleVersion": "Versão da Bíblia",
     "newChat": "Nova Conversa"
   },
   "Welcome": {

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "Вдохновляйся каждый день Словом Божьим",
-    "bibleVersion": "Версия Библии:",
-    "autoDetect": "Авто-определение",
+    "bibleVersion": "Версия Библии",
     "newChat": "Новый чат"
   },
   "Welcome": {

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -6,8 +6,7 @@
   "Header": {
     "title": "Vox Quieta",
     "subtitle": "每天从上帝的话语中获得灵感",
-    "bibleVersion": "圣经版本：",
-    "autoDetect": "自动检测",
+    "bibleVersion": "圣经版本",
     "newChat": "新对话"
   },
   "Welcome": {

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -370,7 +370,7 @@ describe("Home page responsive layout", () => {
       });
 
       // Panel filter buttons (desktop sidebar also has them)
-      const referencedButtons = screen.getAllByText("Referenced");
+      const referencedButtons = screen.getAllByText("Cited");
       expect(referencedButtons.length).toBeGreaterThanOrEqual(2);
     });
 

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -166,6 +166,69 @@ describe("Home page responsive layout", () => {
       expect(newChatText.className).toContain("hidden");
       expect(newChatText.className).toContain("md:inline");
     });
+
+    it('translation selector defaults to the empty "Bible version" option (auto-detect)', async () => {
+      vi.mocked(api.getTranslations).mockResolvedValue([
+        {
+          code: "kjv",
+          language: "English",
+          short_name: "KJV",
+          full_name: "King James Version",
+        },
+      ]);
+
+      renderWithIntl(<Home />);
+
+      const select = await screen.findByLabelText<HTMLSelectElement>(
+        "Bible version",
+      );
+      expect(select.value).toBe("");
+      const placeholder = Array.from(select.options).find(
+        (o) => o.value === "",
+      );
+      expect(placeholder?.textContent).toBe("Bible version");
+    });
+
+    it("sends translation=undefined to streamMessage when placeholder is selected", async () => {
+      vi.mocked(api.getTranslations).mockResolvedValue([
+        {
+          code: "kjv",
+          language: "English",
+          short_name: "KJV",
+          full_name: "King James Version",
+        },
+      ]);
+      vi.mocked(api.streamMessage).mockImplementation(async function* () {
+        yield {
+          type: "metadata" as const,
+          message_id: "msg-auto",
+          scripture_context: { query: "", verses: [], passages: [] },
+          provider: "test",
+          model: "test-model",
+        };
+        yield { type: "content" as const, content: "ok" };
+      });
+
+      const { container } = renderWithIntl(<Home />);
+      // Wait for translations to load so the select is enabled.
+      await screen.findByLabelText("Bible version");
+
+      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      await act(async () => {
+        fireEvent.change(input, { target: { value: "hello" } });
+      });
+      const submitButton = container.querySelector('button[type="submit"]');
+      await act(async () => {
+        fireEvent.click(submitButton!);
+      });
+
+      await waitFor(() => {
+        expect(api.streamMessage).toHaveBeenCalled();
+      });
+      const call = vi.mocked(api.streamMessage).mock.calls[0];
+      // streamMessage(userMessageContent, apiMessages, translation, sessionId)
+      expect(call[2]).toBeUndefined();
+    });
   });
 
   describe("responsive main container", () => {
@@ -372,6 +435,29 @@ describe("Home page responsive layout", () => {
       // Panel filter buttons (desktop sidebar also has them)
       const referencedButtons = screen.getAllByText("Cited");
       expect(referencedButtons.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("defaults the verse filter to Cited (not All Related)", async () => {
+      await renderHomeWithVerses();
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Show scripture references"));
+      });
+
+      const citedButtons = screen.getAllByText("Cited");
+      const allButtons = screen
+        .getAllByRole("button")
+        .filter((b) => /^All Related \(/.test(b.textContent ?? ""));
+
+      // Active button uses primary background; inactive uses white.
+      expect(citedButtons.length).toBeGreaterThanOrEqual(1);
+      expect(allButtons.length).toBeGreaterThanOrEqual(1);
+      for (const btn of citedButtons) {
+        expect(btn.className).toContain("bg-primary-100");
+      }
+      for (const btn of allButtons) {
+        expect(btn.className).toContain("bg-white");
+      }
     });
 
     it("panel has lg:hidden class so it only shows on mobile", async () => {

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -179,9 +179,8 @@ describe("Home page responsive layout", () => {
 
       renderWithIntl(<Home />);
 
-      const select = await screen.findByLabelText<HTMLSelectElement>(
-        "Bible version",
-      );
+      const select =
+        await screen.findByLabelText<HTMLSelectElement>("Bible version");
       expect(select.value).toBe("");
       const placeholder = Array.from(select.options).find(
         (o) => o.value === "",
@@ -213,7 +212,9 @@ describe("Home page responsive layout", () => {
       // Wait for translations to load so the select is enabled.
       await screen.findByLabelText("Bible version");
 
-      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      const input = screen.getByPlaceholderText(
+        "Share what's on your heart...",
+      );
       await act(async () => {
         fireEvent.change(input, { target: { value: "hello" } });
       });

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -649,20 +649,18 @@ export default function Home() {
 
               {/* Translation Selector - always visible, disabled when loading */}
               <div className="flex items-center gap-2">
-                <span className="hidden md:inline text-xs text-gray-500">
-                  {tHeader("bibleVersion")}
-                </span>
                 <select
                   value={selectedTranslation}
                   onChange={(e) => handleTranslationChange(e.target.value)}
                   disabled={translations.length === 0}
+                  aria-label={tHeader("bibleVersion")}
                   className={`text-sm border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 ${
                     translations.length === 0
                       ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                       : "bg-white text-gray-600"
                   }`}
                 >
-                  <option value="">{tHeader("autoDetect")}</option>
+                  <option value="">{tHeader("bibleVersion")}</option>
                   {translations.map((t) => (
                     <option key={t.code} value={t.code}>
                       {t.language} - {t.short_name}


### PR DESCRIPTION
## Summary
- Replace the header's external "Bible version" label and "Auto-detect" placeholder with a single in-dropdown "Bible version" option — same locale-based auto-detect behavior, less bar space (especially on mobile). Translations updated across all 11 locales; unused `autoDetect` keys removed.
- Rename the English verse-panel filter "Referenced" → "Cited" to match the wording already used in other locales (Citados / Citati / Zitiert / …).
- Android: default the verse panel to the Cited tab (was "All"), mirroring the web fix from #521, and update the English string resource.
- Tests: assert the verse panel opens on the Cited tab (active styling), and that the header selector starts on the empty "Bible version" placeholder and forwards `translation=undefined` to `streamMessage` so locale-based auto-detection keeps working.

## Test plan
- [x] `npx vitest run src/app/[locale]/page.test.tsx` — 34/34 passing locally
- [ ] Manual web check: header dropdown shows "Bible version" placeholder; selecting a translation still works; verse panel opens on Cited
- [ ] Manual Android check: open a chat with cited verses, confirm the panel's segmented control starts on Cited

https://claude.ai/code/session_01EiGvq3VFY3weFqgNJHcHoi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiGvq3VFY3weFqgNJHcHoi)_