### PR TITLE
fix(android): show "Bible Version" on translation chip instead of "Auto"

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -209,11 +209,8 @@ fun ChatScreen(
     }
 
     // Label shown on the translation chip: the short ID (e.g. "KJV") or "Bible Version".
-    val translationLabel = if (preferredTranslation.isBlank()) {
-        stringResource(R.string.translation_picker_title)
-    } else {
-        preferredTranslation.uppercase()
-    }
+    val translationLabel = translationChipLabel(preferredTranslation)
+        ?: stringResource(R.string.translation_picker_title)
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val conversations by conversationsViewModel.conversations.collectAsState()

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -208,9 +208,9 @@ fun ChatScreen(
         )
     }
 
-    // Label shown on the translation chip: the short ID (e.g. "KJV") or "Auto".
+    // Label shown on the translation chip: the short ID (e.g. "KJV") or "Bible Version".
     val translationLabel = if (preferredTranslation.isBlank()) {
-        stringResource(R.string.translation_auto)
+        stringResource(R.string.translation_picker_title)
     } else {
         preferredTranslation.uppercase()
     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatTopBarPolicy.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatTopBarPolicy.kt
@@ -44,3 +44,16 @@ internal fun chatTopBarPolicy(
     showVersesPanelInTopBar = versesCount > 0,
     showClearConversationInDrawer = messagesCount > 0,
 )
+
+/**
+ * Returns the display ID for the translation chip, or `null` when no translation
+ * has been selected (i.e. the backend should auto-detect from the user's locale).
+ *
+ * The composable resolves `null` to the localised `translation_picker_title` string
+ * ("Bible Version"), matching the web placeholder introduced in #551.
+ *
+ * @param preferredTranslation the raw value stored in [TranslationPreferences] —
+ *   an empty string means "no preference / auto-detect".
+ */
+internal fun translationChipLabel(preferredTranslation: String): String? =
+    if (preferredTranslation.isBlank()) null else preferredTranslation.uppercase()

--- a/android/app/src/test/kotlin/org/voxquieta/app/screens/ChatTopBarPolicyTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/screens/ChatTopBarPolicyTest.kt
@@ -2,10 +2,12 @@ package org.voxquieta.app.screens
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.voxquieta.app.presentation.screens.ChatTopBarPolicy
 import org.voxquieta.app.presentation.screens.chatTopBarPolicy
+import org.voxquieta.app.presentation.screens.translationChipLabel
 
 /**
  * Unit tests for the [chatTopBarPolicy] helper which encodes the visibility
@@ -107,5 +109,34 @@ class ChatTopBarPolicyTest {
         val policy = chatTopBarPolicy(versesCount = -1, messagesCount = -5)
         assertFalse(policy.showVersesPanelInTopBar)
         assertFalse(policy.showClearConversationInDrawer)
+    }
+
+    // ── translationChipLabel ──────────────────────────────────────────────────
+
+    @Test
+    fun `translationChipLabel returns null for empty preference (auto-detect)`() {
+        // null signals the composable to display the localised "Bible Version"
+        // placeholder, matching the web behaviour introduced in #551.
+        assertNull(translationChipLabel(""))
+    }
+
+    @Test
+    fun `translationChipLabel returns null for blank preference`() {
+        assertNull(translationChipLabel("   "))
+    }
+
+    @Test
+    fun `translationChipLabel uppercases a stored translation id`() {
+        assertEquals("KJV", translationChipLabel("kjv"))
+    }
+
+    @Test
+    fun `translationChipLabel preserves already-uppercase id`() {
+        assertEquals("NIV", translationChipLabel("NIV"))
+    }
+
+    @Test
+    fun `translationChipLabel uppercases mixed-case id`() {
+        assertEquals("ESV", translationChipLabel("Esv"))
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause:** PR #551 fixed the web header dropdown placeholder from "Auto-detect" → "Bible version", but the Android translation chip (`translationLabel` in `ChatScreen.kt`) was a separate code path that still fell back to `R.string.translation_auto` ("Auto") when no translation was selected.
- **Fix:** The chip now uses `translation_picker_title` ("Bible Version") as the placeholder when no translation is set — all 10 locale string files already had this key translated, so no string resource changes were needed.
- **Refactor:** Extracted the chip-label derivation into a pure `translationChipLabel()` function in `ChatTopBarPolicy.kt` (returns `null` for auto-detect, uppercase ID otherwise), following the project convention of keeping screen-level logic in small, JVM-testable units.
- **Tests:** Added 5 unit tests in `ChatTopBarPolicyTest` covering: empty preference (null → "Bible Version" placeholder), blank preference, lowercase ID uppercasing, already-uppercase ID, and mixed-case ID.

## Test plan

- [x] 5 new JVM unit tests in `ChatTopBarPolicyTest` — all passing locally
- [ ] Manual Android check: open the app with no translation selected, confirm the chip reads "Bible Version" (not "Auto")
- [ ] Manual Android check: select a translation (e.g. KJV), confirm the chip reads "KJV"

https://claude.ai/code/session_01Q59y2Y63jP3GRwDdjUD5od

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q59y2Y63jP3GRwDdjUD5od)_