### PR TITLE
ci: gate release-please and android-publish on green Android CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -8,9 +8,10 @@ on:
       - "android/**"
       - ".github/workflows/android-ci.yml"
   push:
+    # No paths filter on main: every commit landing on main must produce an
+    # Android-CI verdict so release-please (workflow_run-gated) and the
+    # publish-time CI-green check have a definitive status to read.
     branches: [main]
-    paths:
-      - "android/**"
   workflow_dispatch:
 
 run-name: >-

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -40,11 +40,48 @@ run-name: >-
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
+  # Defence-in-depth: even though release-please is gated on Android CI via
+  # workflow_run, a manually-pushed tag (or future trigger misconfiguration)
+  # could still fire this workflow. Re-verify that Android CI succeeded for
+  # the tagged commit before building or uploading anything to Play Store.
+  # Skipped for workflow_dispatch runs — those are operator-initiated and
+  # may legitimately want to publish off a non-main branch.
+  verify-ci-green:
+    name: Verify Android CI is green
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Check Android CI conclusion for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="${GITHUB_SHA}"
+          echo "Looking up Android CI status for commit ${SHA}"
+          # Find the most recent "Android CI" workflow run for this SHA.
+          # We sort by run_started_at and take the last entry so re-runs win.
+          CONCLUSION=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
+            --jq '[.workflow_runs[] | select(.name=="Android CI")]
+                  | sort_by(.run_started_at) | last | .conclusion // "missing"')
+          echo "Android CI conclusion: ${CONCLUSION}"
+          if [ "${CONCLUSION}" != "success" ]; then
+            echo "❌ Refusing to publish: Android CI for ${SHA} is '${CONCLUSION}'."
+            echo "   Release tags must be created from commits with a green Android CI run."
+            exit 1
+          fi
+          echo "✅ Android CI succeeded for ${SHA} — proceeding with publish."
+
   publish:
     name: Build & Publish AAB
     runs-on: ubuntu-latest
+    needs: [verify-ci-green]
+    # `needs` skips dependents when the dep itself is skipped (workflow_dispatch
+    # path). Use always() + explicit conclusion check so dispatch runs proceed
+    # while a real verify-ci-green failure still blocks publish.
+    if: always() && (needs.verify-ci-green.result == 'success' || needs.verify-ci-green.result == 'skipped')
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,9 +2,13 @@ name: Release Please
 
 # yamllint disable-line rule:truthy
 on:
-  push:
-    branches:
-      - main
+  # Gated on Android CI: release-please only runs after Android CI completes
+  # successfully on main. A red Android CI never produces a Release PR update
+  # or a tag — so a release tag is structurally proof of green CI on its SHA.
+  workflow_run:
+    workflows: ["Android CI"]
+    branches: [main]
+    types: [completed]
 
 permissions:
   contents: write
@@ -18,6 +22,7 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
 
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -12,20 +12,42 @@ The flow is:
 Conventional Commits on main
         │
         ▼
+Android CI runs on every main commit
+        │
+        ▼  (only on success)
 release-please opens/updates a "Release PR"
         │
-        ▼  (maintainer merges the Release PR)
-release-please pushes a semver tag  (e.g. v0.2.0)
+        ▼  (maintainer merges the Release PR → Android CI runs on merge commit)
+release-please pushes a semver tag  (e.g. v0.2.0) — only if that CI is green
         │
         ▼
 android-publish.yml fires on push: tags: v*.*.*
         │
-        ▼
+        ▼  (verify-ci-green job re-checks Android CI for the tagged commit)
 Internal track uploaded to Google Play
 ```
 
 No manual `git tag` is required.
-**Do NOT push `vX.Y.Z` tags by hand** — release-please manages them.
+**Do NOT push `vX.Y.Z` tags by hand** — release-please manages them, and the
+publish workflow's `verify-ci-green` job will refuse to publish any tag whose
+commit does not have a successful `Android CI` run.
+
+### CI gating (defence in depth)
+
+Three layers ensure that a red Android CI cannot produce a release:
+
+1. **Android CI runs on every push to `main`** (no `paths:` filter on the
+   `push` trigger), so every main commit has a definitive verdict.
+2. **release-please is triggered by `workflow_run`** on `Android CI`
+   completion with `conclusion == 'success'`. A red main commit never
+   refreshes the Release PR and never produces a tag.
+3. **`android-publish.yml` re-verifies** Android CI's conclusion for the
+   tagged commit via the Checks API before building or uploading the AAB.
+   This catches manually-pushed tags and any future trigger misconfiguration.
+
+> Recommended follow-up (repo settings, not in code): enable branch
+> protection on `main` requiring the `Android CI` status check before merge,
+> so a red PR cannot land in the first place.
 
 ---
 


### PR DESCRIPTION
## Summary

Make it structurally impossible for a red Android CI to produce a release. Defence in depth across three layers:

1. **`android-ci.yml`** — drop the `paths:` filter on `push: main` so every main commit gets a definitive Android-CI verdict (the PR `paths:` filter is kept to avoid running emulator jobs on backend-only PRs).
2. **`release-please.yml`** — switch trigger from `push: main` to `workflow_run` on `Android CI` with `conclusion == 'success'`. A red main commit no longer refreshes the Release PR or pushes a tag. Release tags become structural proof that Android CI was green on the SHA.
3. **`android-publish.yml`** — add a `verify-ci-green` job that re-checks the tagged commit's Android-CI conclusion via the Checks API before building or uploading. Catches manually-pushed tags and any future trigger misconfiguration. Skipped on `workflow_dispatch` so operator-initiated publishes are unaffected.

`docs/RELEASE_PROCESS.md` is updated with the new flow diagram and a "CI gating (defence in depth)" section. Recommended follow-up (not in this PR, since it's a repo-settings change): enable branch protection on `main` requiring the `Android CI` status check before merge.

## Why this matters

Today nothing causally links Android CI to releases:
- `android-ci.yml`'s `push` trigger has a `paths: android/**` filter, so many main commits get no verdict at all.
- `release-please.yml` runs on every push to main unconditionally.
- `android-publish.yml` triggers on tag push with no check that CI ever passed.

A red main commit can become a tagged release that auto-publishes. The only safety net is the `production` track landing as a manual-rollout draft; `internal` and `beta` go live automatically.

## Test plan

- [ ] Push a backend-only commit to a throwaway branch and merge to a test branch — confirm Android CI now runs (it currently wouldn't).
- [ ] Merge a commit with a deliberately broken unit test to a test branch — confirm `release-please` is *skipped* (not just fails) and no Release PR update happens.
- [ ] Push a `vX.Y.Z-test` tag on a known-red commit — confirm `verify-ci-green` fails and no AAB is built. Delete the test tag.
- [ ] Happy path: land a `feat:` commit on main → Android CI passes → release-please updates Release PR → merge Release PR → tag pushed → `verify-ci-green` passes → AAB uploads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPCa9vvGcmDZsBsWm3L5Ty)_