### PR TITLE
fix(android): allow partial text selection in assistant messages

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Refresh
@@ -411,11 +412,13 @@ fun ChatMessageItem(
                         // (b) Streaming with partial content — show text + blinking cursor
                         !isUser && message.isStreaming && message.content.isNotEmpty() -> {
                             Row(verticalAlignment = Alignment.Bottom) {
-                                Text(
-                                    text = message.content,
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = textColor,
-                                )
+                                SelectionContainer {
+                                    Text(
+                                        text = message.content,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = textColor,
+                                    )
+                                }
                                 Text(
                                     text = "▌",
                                     style = MaterialTheme.typography.bodyLarge,
@@ -434,6 +437,7 @@ fun ChatMessageItem(
                                 markdown = injectVerseLinks(message.content, verseRefRegex),
                                 style = bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
                                 linkColor = amberColor,
+                                isTextSelectable = true,
                                 onLinkClicked = { url ->
                                     val parsed = parseVerseLink(url, preferredTranslation)
                                     if (parsed != null) {


### PR DESCRIPTION
## Summary

On the web, users can highlight any portion of an assistant answer and copy it with the browser's native text selection. On the Android app the only way to copy content was the "Copy" icon button next to "Share", which copies the **entire** message. Users asked to be able to copy just part of a verse or answer.

Root cause: Compose `Text` is not selectable by default, and the markdown body is rendered through `MarkdownText` (compose-markdown 0.5.0) which is backed by a Markwon `TextView` inside an `AndroidView` — `SelectionContainer` does not affect it. The library exposes an `isTextSelectable` parameter that forwards to `TextView.setTextIsSelectable(true)`.

## Changes

`android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt`:

- Import `androidx.compose.foundation.text.selection.SelectionContainer`.
- Wrap the streaming assistant `Text` in `SelectionContainer` (cursor `▌` stays outside so it isn't selectable).
- Pass `isTextSelectable = true` to the finished-message `MarkdownText`.
- User messages, typing indicator, and the existing whole-message Copy button are unchanged.

## Test plan

- [ ] `./gradlew :app:assembleDebug` succeeds (could not run in sandboxed env — needs verification in CI).
- [ ] `./gradlew :app:testDebugUnitTest` passes.
- [ ] On device/emulator: long-press an assistant bubble → selection handles appear → drag → system Copy/Share bar shows.
- [ ] Tapping a verse link inside the same message still opens the verse detail sheet.
- [ ] User message bubbles are not selectable.
- [ ] During streaming, the partial content is selectable and the `▌` cursor still blinks.
- [ ] The existing one-tap Copy IconButton still copies the full message with the "Copied" toast.

https://claude.ai/code/session_01P7rwWfmPKpNd1tiDsFW2VB

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7rwWfmPKpNd1tiDsFW2VB)_