### PR TITLE
fix(ci): poll Android CI status in verify-ci-green to handle race

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -44,35 +44,55 @@ permissions:
 
 jobs:
   # Defence-in-depth: even though release-please is gated on Android CI via
-  # workflow_run, a manually-pushed tag (or future trigger misconfiguration)
-  # could still fire this workflow. Re-verify that Android CI succeeded for
-  # the tagged commit before building or uploading anything to Play Store.
-  # Skipped for workflow_dispatch runs — those are operator-initiated and
-  # may legitimately want to publish off a non-main branch.
+  # workflow_run, that gate is not race-free — release-please tags the current
+  # HEAD of main, which may have moved past the SHA that satisfied the gate.
+  # When the Release PR merges, the merge commit pushes to main, Android CI
+  # starts on it, and release-please (fired by a *prior* Android CI success)
+  # tags the new HEAD before its CI finishes. So we poll: wait up to 45 min
+  # for the most recent Android CI run on ${GITHUB_SHA} to complete, then
+  # enforce conclusion == success. Skipped for workflow_dispatch — operator-
+  # initiated publishes may legitimately run off a non-main branch.
   verify-ci-green:
     name: Verify Android CI is green
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    timeout-minutes: 50
     steps:
-      - name: Check Android CI conclusion for this commit
+      - name: Poll Android CI status for this commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SHA="${GITHUB_SHA}"
-          echo "Looking up Android CI status for commit ${SHA}"
-          # Find the most recent "Android CI" workflow run for this SHA.
-          # We sort by run_started_at and take the last entry so re-runs win.
-          CONCLUSION=$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
-            --jq '[.workflow_runs[] | select(.name=="Android CI")]
-                  | sort_by(.run_started_at) | last | .conclusion // "missing"')
-          echo "Android CI conclusion: ${CONCLUSION}"
-          if [ "${CONCLUSION}" != "success" ]; then
-            echo "❌ Refusing to publish: Android CI for ${SHA} is '${CONCLUSION}'."
-            echo "   Release tags must be created from commits with a green Android CI run."
-            exit 1
-          fi
-          echo "✅ Android CI succeeded for ${SHA} — proceeding with publish."
+          DEADLINE=$(( $(date +%s) + 2700 )) # 45 min — Android CI itself caps at 55 min
+          POLL_INTERVAL=30
+          echo "Waiting for Android CI to complete on commit ${SHA}"
+          while :; do
+            # Most recent "Android CI" workflow run for this SHA (re-runs win).
+            # Emit "status|conclusion" so we can branch on both fields. The
+            # "missing" sentinel covers the case where no run exists yet.
+            LINE=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
+              --jq '[.workflow_runs[] | select(.name=="Android CI")]
+                    | sort_by(.run_started_at) | last
+                    | if . == null then "missing|" else "\(.status)|\(.conclusion // "")" end')
+            STATUS="${LINE%|*}"
+            CONCLUSION="${LINE#*|}"
+            echo "Android CI status=${STATUS} conclusion=${CONCLUSION}"
+            if [ "${STATUS}" = "completed" ]; then
+              if [ "${CONCLUSION}" = "success" ]; then
+                echo "✅ Android CI succeeded for ${SHA} — proceeding with publish."
+                exit 0
+              fi
+              echo "❌ Refusing to publish: Android CI for ${SHA} concluded as '${CONCLUSION}'."
+              exit 1
+            fi
+            if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+              echo "❌ Timed out waiting for Android CI on ${SHA} (last status=${STATUS})."
+              exit 1
+            fi
+            echo "Sleeping ${POLL_INTERVAL}s before re-polling..."
+            sleep "${POLL_INTERVAL}"
+          done
 
   publish:
     name: Build & Publish AAB


### PR DESCRIPTION
## Summary

Fix the race condition that caused the v1.6.0 publish to fail with `Android CI conclusion: missing`.

## Root cause

`release-please` tags the **current HEAD of main** when its action runs, not the SHA whose Android CI satisfied the `workflow_run` gate. Sequence:

1. Release PR merges → commit `43304f3` pushed to main
2. `Android CI #520` starts on `43304f3` (11 min runtime)
3. `release-please` fires via `workflow_run`, but it was triggered by an **earlier** Android CI success (on a prior commit). It looks at main's HEAD (`43304f3`) and tags `v1.6.0` there.
4. Tag push triggers `android-publish` immediately
5. `verify-ci-green` queries the Checks API while Android CI #520 is still `in_progress` (`conclusion: null`), my `// "missing"` jq default kicks in, exit 1

So Android CI *did* run on the tagged SHA — we just checked too early.

## Fix

Replace the one-shot API query in `verify-ci-green` with a 45-minute poll loop that waits for `Android CI`'s most recent run on `${GITHUB_SHA}` to reach `status=completed`, then enforces `conclusion=success`. Handles `missing`, `queued`, `in_progress`, and re-run cases cleanly. The publish-time poll becomes the authoritative gate; the `release-please` `workflow_run` trigger remains as a useful pre-filter.

Only `.github/workflows/android-publish.yml` is touched.

## Test plan

- [ ] Next Release-PR merge produces a tag whose Android CI is still in flight; verify-ci-green polls, waits, and proceeds to publish only after Android CI completes successfully.
- [ ] If Android CI on the tagged SHA fails, verify-ci-green fails fast with the actual conclusion (not "missing").
- [ ] Manually push a `vX.Y.Z-test` tag on a commit with no Android CI run — verify-ci-green times out after 45 min (sanity check; can be aborted manually).
- [ ] `workflow_dispatch` runs still skip `verify-ci-green` unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPCa9vvGcmDZsBsWm3L5Ty)_