### PR TITLE
test(metrics): BITB-021 integration tests for LLM/DB performance metrics wiring

### DIFF
--- a/api/tests/test_providers_coverage.py
+++ b/api/tests/test_providers_coverage.py
@@ -189,16 +189,23 @@ class TestClaudeProvider:
 
         from utils.metrics import llm_total_duration_histogram, llm_ttft_histogram
 
-        with patch.object(llm_ttft_histogram, "record") as mock_ttft, patch.object(
-            llm_total_duration_histogram, "record"
-        ) as mock_total:
-            chunks = [chunk async for chunk in provider.chat_stream([ChatMessage(role="user", content="Hi")])]
+        with (
+            patch.object(llm_ttft_histogram, "record") as mock_ttft,
+            patch.object(llm_total_duration_histogram, "record") as mock_total,
+        ):
+            chunks = [
+                chunk
+                async for chunk in provider.chat_stream([ChatMessage(role="user", content="Hi")])
+            ]
 
         assert chunks == ["Hello", " world"]
         mock_ttft.assert_called_once()
         ttft_value = mock_ttft.call_args[0][0]
         assert ttft_value >= 0
-        assert mock_ttft.call_args[0][1] == {"provider": "claude", "model": "claude-sonnet-4-20250514"}
+        assert mock_ttft.call_args[0][1] == {
+            "provider": "claude",
+            "model": "claude-sonnet-4-20250514",
+        }
         mock_total.assert_called_once()
         assert mock_total.call_args[0][0] >= 0
 
@@ -215,7 +222,9 @@ class TestClaudeProvider:
             mock_anthropic.AsyncAnthropic.return_value = mock_client
             from providers.claude import ClaudeProvider
 
-            provider = ClaudeProvider(api_key="test-key", model="claude-sonnet-4-20250514")  # pragma: allowlist secret
+            provider = ClaudeProvider(
+                api_key="test-key", model="claude-sonnet-4-20250514"
+            )  # pragma: allowlist secret
 
             mock_stream = AsyncMock()
             mock_stream.__aenter__ = AsyncMock(side_effect=FakeRateLimitError("rate limited"))
@@ -362,9 +371,10 @@ class TestOllamaProvider:
 
         from utils.metrics import llm_total_duration_histogram, llm_ttft_histogram
 
-        with patch.object(llm_ttft_histogram, "record") as mock_ttft, patch.object(
-            llm_total_duration_histogram, "record"
-        ) as mock_total:
+        with (
+            patch.object(llm_ttft_histogram, "record") as mock_ttft,
+            patch.object(llm_total_duration_histogram, "record") as mock_total,
+        ):
             with patch.object(provider, "_get_client") as mock_get_client:
                 mock_client = AsyncMock()
                 mock_client.stream = MagicMock(return_value=mock_stream_response)
@@ -372,7 +382,9 @@ class TestOllamaProvider:
 
                 chunks = [
                     chunk
-                    async for chunk in provider.chat_stream([ChatMessage(role="user", content="Hi")])
+                    async for chunk in provider.chat_stream(
+                        [ChatMessage(role="user", content="Hi")]
+                    )
                 ]
 
         assert chunks == ["Hello", " world"]

--- a/api/tests/test_providers_coverage.py
+++ b/api/tests/test_providers_coverage.py
@@ -172,6 +172,66 @@ class TestClaudeProvider:
         assert chunks == ["Hello", " world"]
 
     @pytest.mark.asyncio
+    async def test_chat_stream_records_ttft_and_total_duration(self):
+        """Claude chat_stream should record TTFT and total duration metrics."""
+        provider, mock_client = self._make_provider()
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=False)
+
+        async def text_stream_gen():
+            yield "Hello"
+            yield " world"
+
+        mock_stream.text_stream = text_stream_gen()
+        mock_client.messages.stream = MagicMock(return_value=mock_stream)
+
+        from utils.metrics import llm_total_duration_histogram, llm_ttft_histogram
+
+        with patch.object(llm_ttft_histogram, "record") as mock_ttft, patch.object(
+            llm_total_duration_histogram, "record"
+        ) as mock_total:
+            chunks = [chunk async for chunk in provider.chat_stream([ChatMessage(role="user", content="Hi")])]
+
+        assert chunks == ["Hello", " world"]
+        mock_ttft.assert_called_once()
+        ttft_value = mock_ttft.call_args[0][0]
+        assert ttft_value >= 0
+        assert mock_ttft.call_args[0][1] == {"provider": "claude", "model": "claude-sonnet-4-20250514"}
+        mock_total.assert_called_once()
+        assert mock_total.call_args[0][0] >= 0
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_records_rate_limit_on_429(self):
+        """Claude chat_stream should record rate limit metric when RateLimitError is raised."""
+
+        class FakeRateLimitError(Exception):
+            pass
+
+        with patch("providers.claude.anthropic") as mock_anthropic:
+            mock_anthropic.RateLimitError = FakeRateLimitError
+            mock_client = AsyncMock()
+            mock_anthropic.AsyncAnthropic.return_value = mock_client
+            from providers.claude import ClaudeProvider
+
+            provider = ClaudeProvider(api_key="test-key", model="claude-sonnet-4-20250514")  # pragma: allowlist secret
+
+            mock_stream = AsyncMock()
+            mock_stream.__aenter__ = AsyncMock(side_effect=FakeRateLimitError("rate limited"))
+            mock_stream.__aexit__ = AsyncMock(return_value=False)
+            mock_client.messages.stream = MagicMock(return_value=mock_stream)
+
+            from utils.metrics import llm_rate_limit_counter
+
+            with patch.object(llm_rate_limit_counter, "add") as mock_add:
+                with pytest.raises(FakeRateLimitError):
+                    async for _ in provider.chat_stream([ChatMessage(role="user", content="Hi")]):
+                        pass
+
+            mock_add.assert_called_once_with(1, {"provider": "claude"})
+
+    @pytest.mark.asyncio
     async def test_health_check_success(self):
         """Claude health_check should return True on success."""
         provider, mock_client = self._make_provider()
@@ -283,6 +343,44 @@ class TestOllamaProvider:
                 chunks.append(chunk)
 
         assert chunks == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_records_ttft_and_total_duration(self):
+        """Ollama chat_stream should record TTFT and total duration metrics."""
+        provider = self._make_provider()
+
+        async def mock_aiter_lines():
+            yield '{"message": {"content": "Hello"}}'
+            yield '{"message": {"content": " world"}}'
+            yield '{"done": true}'
+
+        mock_stream_response = AsyncMock()
+        mock_stream_response.raise_for_status = MagicMock()
+        mock_stream_response.aiter_lines = mock_aiter_lines
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_stream_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=False)
+
+        from utils.metrics import llm_total_duration_histogram, llm_ttft_histogram
+
+        with patch.object(llm_ttft_histogram, "record") as mock_ttft, patch.object(
+            llm_total_duration_histogram, "record"
+        ) as mock_total:
+            with patch.object(provider, "_get_client") as mock_get_client:
+                mock_client = AsyncMock()
+                mock_client.stream = MagicMock(return_value=mock_stream_response)
+                mock_get_client.return_value = mock_client
+
+                chunks = [
+                    chunk
+                    async for chunk in provider.chat_stream([ChatMessage(role="user", content="Hi")])
+                ]
+
+        assert chunks == ["Hello", " world"]
+        mock_ttft.assert_called_once()
+        assert mock_ttft.call_args[0][0] >= 0
+        assert mock_ttft.call_args[0][1] == {"provider": "ollama", "model": "llama3:8b"}
+        mock_total.assert_called_once()
+        assert mock_total.call_args[0][0] >= 0
 
     @pytest.mark.asyncio
     async def test_health_check_model_available(self):

--- a/api/tests/test_providers_coverage.py
+++ b/api/tests/test_providers_coverage.py
@@ -223,8 +223,9 @@ class TestClaudeProvider:
             from providers.claude import ClaudeProvider
 
             provider = ClaudeProvider(
-                api_key="test-key", model="claude-sonnet-4-20250514"
-            )  # pragma: allowlist secret
+                api_key="test-key",  # pragma: allowlist secret
+                model="claude-sonnet-4-20250514",
+            )
 
             mock_stream = AsyncMock()
             mock_stream.__aenter__ = AsyncMock(side_effect=FakeRateLimitError("rate limited"))

--- a/api/tests/test_scripture_coverage.py
+++ b/api/tests/test_scripture_coverage.py
@@ -987,3 +987,77 @@ class TestSearchResults:
         assert sr.query == "love"
         assert sr.verses == []
         assert sr.passages == []
+
+
+# ==================== Metrics Wiring Tests ====================
+
+
+class TestRecordDurationMetrics:
+    """Verify _record_duration correctly wires duration/slow-query metrics."""
+
+    def _make_span(self):
+        return MagicMock()
+
+    def test_search_operation_records_search_histogram(self):
+        import time
+
+        from scripture.repository import _record_duration
+        from utils.metrics import db_search_duration_histogram
+
+        span = self._make_span()
+        start = time.perf_counter() - 0.005  # ~5 ms ago
+
+        with patch.object(db_search_duration_histogram, "record") as mock_record:
+            _record_duration(span, start, "semantic_search_verses", 10, "kjv")
+
+        mock_record.assert_called_once()
+        duration_ms, attrs = mock_record.call_args[0]
+        assert duration_ms > 0
+        assert attrs == {"operation": "semantic_search_verses", "translation": "kjv"}
+
+    def test_non_search_operation_records_query_histogram(self):
+        import time
+
+        from scripture.repository import _record_duration
+        from utils.metrics import db_query_duration_histogram, db_search_duration_histogram
+
+        span = self._make_span()
+        start = time.perf_counter() - 0.005
+
+        with patch.object(db_query_duration_histogram, "record") as mock_query, patch.object(
+            db_search_duration_histogram, "record"
+        ) as mock_search:
+            _record_duration(span, start, "get_verse", 1, "kjv")
+
+        mock_query.assert_called_once()
+        assert mock_query.call_args[0][0] > 0
+        assert mock_query.call_args[0][1] == {"operation": "get_verse"}
+        mock_search.assert_not_called()
+
+    def test_slow_query_increments_slow_counter(self):
+        import time
+
+        from scripture.repository import _record_duration
+        from utils.metrics import db_slow_queries_counter
+
+        span = self._make_span()
+        start = time.perf_counter() - 0.5  # 500 ms ago — well above 100 ms threshold
+
+        with patch.object(db_slow_queries_counter, "add") as mock_add:
+            _record_duration(span, start, "get_verse", 1, None)
+
+        mock_add.assert_called_once_with(1, {"operation": "get_verse"})
+
+    def test_fast_query_does_not_increment_slow_counter(self):
+        import time
+
+        from scripture.repository import _record_duration
+        from utils.metrics import db_slow_queries_counter
+
+        span = self._make_span()
+        start = time.perf_counter() - 0.001  # ~1 ms ago — below 100 ms threshold
+
+        with patch.object(db_slow_queries_counter, "add") as mock_add:
+            _record_duration(span, start, "get_verse", 1, None)
+
+        mock_add.assert_not_called()

--- a/api/tests/test_scripture_coverage.py
+++ b/api/tests/test_scripture_coverage.py
@@ -1024,9 +1024,10 @@ class TestRecordDurationMetrics:
         span = self._make_span()
         start = time.perf_counter() - 0.005
 
-        with patch.object(db_query_duration_histogram, "record") as mock_query, patch.object(
-            db_search_duration_histogram, "record"
-        ) as mock_search:
+        with (
+            patch.object(db_query_duration_histogram, "record") as mock_query,
+            patch.object(db_search_duration_histogram, "record") as mock_search,
+        ):
             _record_duration(span, start, "get_verse", 1, "kjv")
 
         mock_query.assert_called_once()

--- a/docs/BACKLOG_STORIES/BITB-021-instrument-performance-metrics.md
+++ b/docs/BACKLOG_STORIES/BITB-021-instrument-performance-metrics.md
@@ -1,10 +1,10 @@
 # BITB-021: Instrument LLM and Database Performance Metrics
 
 **Priority:** P1 (High — dashboard is deployed but shows no data)
-**Status:** 🚧 In Progress (dashboard/workbook dependencies complete; backend metrics instrumentation pending)
+**Status:** ✅ Done (metrics defined, all providers instrumented, repository instrumented, integration tests added)
 **Size:** M (4-6 hours)
 **Created:** 2026-03-06
-**Updated:** 2026-04-20
+**Updated:** 2026-05-16
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds 7 integration tests that verify the OpenTelemetry metric wiring is correct — i.e., that calling production streaming and repository code paths actually invokes `.record()` / `.add()` on the right histograms/counters
- Marks **BITB-021** as ✅ Done; all instrumentation code was already merged, these tests complete the story's Definition of Done

### Tests added

**`api/tests/test_providers_coverage.py`**
- `TestClaudeProvider.test_chat_stream_records_ttft_and_total_duration` — verifies `llm_ttft_histogram.record()` and `llm_total_duration_histogram.record()` are called with non-negative values and correct provider/model labels during a Claude streaming response
- `TestClaudeProvider.test_chat_stream_records_rate_limit_on_429` — verifies `llm_rate_limit_counter.add(1, {"provider": "claude"})` is called when `anthropic.RateLimitError` is raised
- `TestOllamaProvider.test_chat_stream_records_ttft_and_total_duration` — same TTFT/duration assertions for the Ollama provider

**`api/tests/test_scripture_coverage.py`** (new class `TestRecordDurationMetrics`)
- `test_search_operation_records_search_histogram` — verifies `db_search_duration_histogram.record()` with correct `operation`/`translation` attrs
- `test_non_search_operation_records_query_histogram` — verifies `db_query_duration_histogram.record()` for non-search ops; also asserts `db_search_duration_histogram` is NOT called
- `test_slow_query_increments_slow_counter` — verifies `db_slow_queries_counter.add(1, ...)` fires when `duration_ms > threshold` (500 ms synthetic start)
- `test_fast_query_does_not_increment_slow_counter` — guards against regressions that record slow queries unconditionally

### Approach

All tests use `patch.object(<metric_object>, "record"/"add")` to spy on metric calls without a real database or LLM API. The approach is consistent with the existing `test_metrics.py` style and works because `from utils.metrics import llm_ttft_histogram` in provider modules holds a reference to the same object — patching `.record` on it intercepts all callers.

## Test plan

- [x] `pytest tests/test_providers_coverage.py::TestClaudeProvider::test_chat_stream_records_ttft_and_total_duration` ✅
- [x] `pytest tests/test_providers_coverage.py::TestClaudeProvider::test_chat_stream_records_rate_limit_on_429` ✅
- [x] `pytest tests/test_providers_coverage.py::TestOllamaProvider::test_chat_stream_records_ttft_and_total_duration` ✅
- [x] `pytest tests/test_scripture_coverage.py::TestRecordDurationMetrics` (4 tests) ✅
- [x] Full `test_providers_coverage.py` + `test_providers.py` + `test_metrics.py` suite: 109 tests pass ✅

https://claude.ai/code/session_019tj3VsdPGbn7MgcbWBrXAY

---
_Generated by [Claude Code](https://claude.ai/code/session_019tj3VsdPGbn7MgcbWBrXAY)_