### PR TITLE
Wrap message persistence in NonCancellable context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,17 @@ Critical variables:
 
 ## Testing
 
+> **Rule: every code change must ship with tests. No exceptions.**
+>
+> - Bug fix → add a regression test that would have caught the bug
+> - New feature → add tests covering the happy path and key edge cases
+> - Refactor → ensure existing tests still pass; add tests for any newly
+>   reachable behaviour
+>
+> Do not open or update a PR without tests. CI running green is necessary
+> but not sufficient — reviewers will reject PRs that lack coverage for
+> the changed code.
+
 ### Backend Tests
 
 ```bash

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -34,6 +34,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -457,52 +459,58 @@ class ChatViewModel @Inject constructor(
                             messageId = metadataMessageId,
                             versesCited = finalVersesCited,
                         )
-                        // Persist finished assistant message and bump conversation timestamp.
-                        repository.saveMessage(conversationId, finalAssistant)
-                        repository.touchConversation(conversationId)
+                        // Use NonCancellable so that DB writes and the isLoading reset always
+                        // complete even when the coroutine was cancelled by the Stop button.
+                        // Without this, the first suspending call (saveMessage) throws
+                        // CancellationException and isLoading stays true permanently.
+                        withContext(NonCancellable) {
+                            // Persist finished assistant message and bump conversation timestamp.
+                            repository.saveMessage(conversationId, finalAssistant)
+                            repository.touchConversation(conversationId)
 
-                        _uiState.update { state ->
-                            val newCount = state.interactionCount + 1
-                            // Detect the exact moment the session limit is reached so we can
-                            // proactively block the input and show the invitation message —
-                            // no need for the user to attempt a failing 11th request.
-                            val sessionLimitJustReached =
-                                !state.isSessionLimitReached && newCount >= MAX_INTERACTIONS
-                            // Append new verses, deduplicating by reference only (not translation)
-                            // so each verse appears once regardless of which translation it came from.
-                            val existingRefs = state.allVerses.map { "${it.book}${it.chapter}:${it.verse}" }.toHashSet()
-                            val dedupedNew = finalVerses.filterNot { v ->
-                                "${v.book}${v.chapter}:${v.verse}" in existingRefs
-                            }
-                            // When the limit is just reached, append a synthetic assistant
-                            // message so the user sees the invitation in the conversation.
-                            val limitMessage = if (sessionLimitJustReached) {
-                                Message(
-                                    id = UUID.randomUUID().toString(),
-                                    role = Message.Role.ASSISTANT,
-                                    content = context.getString(R.string.error_session_limit),
+                            _uiState.update { state ->
+                                val newCount = state.interactionCount + 1
+                                // Detect the exact moment the session limit is reached so we can
+                                // proactively block the input and show the invitation message —
+                                // no need for the user to attempt a failing 11th request.
+                                val sessionLimitJustReached =
+                                    !state.isSessionLimitReached && newCount >= MAX_INTERACTIONS
+                                // Append new verses, deduplicating by reference only (not translation)
+                                // so each verse appears once regardless of which translation it came from.
+                                val existingRefs = state.allVerses.map { "${it.book}${it.chapter}:${it.verse}" }.toHashSet()
+                                val dedupedNew = finalVerses.filterNot { v ->
+                                    "${v.book}${v.chapter}:${v.verse}" in existingRefs
+                                }
+                                // When the limit is just reached, append a synthetic assistant
+                                // message so the user sees the invitation in the conversation.
+                                val limitMessage = if (sessionLimitJustReached) {
+                                    Message(
+                                        id = UUID.randomUUID().toString(),
+                                        role = Message.Role.ASSISTANT,
+                                        content = context.getString(R.string.error_session_limit),
+                                    )
+                                } else null
+                                state.copy(
+                                    messages = state.messages.map { msg ->
+                                        if (msg.id == assistantId) finalAssistant else msg
+                                    } + listOfNotNull(limitMessage),
+                                    isLoading = false,
+                                    isBackendWarming = false,
+                                    interactionCount = newCount,
+                                    isSessionLimitReached = state.isSessionLimitReached || sessionLimitJustReached,
+                                    // Show the banner exactly once, at interaction 3.
+                                    // Using == rather than >= prevents re-showing the banner
+                                    // after it has been dismissed (banner=false, inline=false).
+                                    showChurchFinderBanner = !state.showChurchFinderBanner &&
+                                        !state.showChurchFinderInlineCard &&
+                                        newCount == 3,
+                                    // Show the inline card after 5 interactions if the banner
+                                    // was already dismissed without opening the sheet.
+                                    showChurchFinderInlineCard = state.showChurchFinderInlineCard ||
+                                        (newCount >= 5 && !state.showChurchFinderBanner),
+                                    allVerses = state.allVerses + dedupedNew,
                                 )
-                            } else null
-                            state.copy(
-                                messages = state.messages.map { msg ->
-                                    if (msg.id == assistantId) finalAssistant else msg
-                                } + listOfNotNull(limitMessage),
-                                isLoading = false,
-                                isBackendWarming = false,
-                                interactionCount = newCount,
-                                isSessionLimitReached = state.isSessionLimitReached || sessionLimitJustReached,
-                                // Show the banner exactly once, at interaction 3.
-                                // Using == rather than >= prevents re-showing the banner
-                                // after it has been dismissed (banner=false, inline=false).
-                                showChurchFinderBanner = !state.showChurchFinderBanner &&
-                                    !state.showChurchFinderInlineCard &&
-                                    newCount == 3,
-                                // Show the inline card after 5 interactions if the banner
-                                // was already dismissed without opening the sheet.
-                                showChurchFinderInlineCard = state.showChurchFinderInlineCard ||
-                                    (newCount >= 5 && !state.showChurchFinderBanner),
-                                allVerses = state.allVerses + dedupedNew,
-                            )
+                            }
                         }
                     }
                 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -39,6 +39,7 @@ import io.mockk.slot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -1537,6 +1538,84 @@ class ChatViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.allVerses.isEmpty())
+    }
+
+    // ── cancelStream / Stop button ────────────────────────────────────────────
+
+    @Test
+    fun `cancelStream resets isLoading so the user can send further messages`() = runTest {
+        // A flow that emits one partial chunk then suspends — simulates a long SSE
+        // stream interrupted by the Stop button.
+        every { repository.chatStream(any()) } returns flow {
+            emit(StreamChunk(content = "Partial answer…", done = false))
+            awaitCancellation()
+        }
+
+        viewModel.sendMessage("Hello")
+        // Run until the coroutine blocks on awaitCancellation().
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.isLoading)
+
+        // Simulate the user tapping Stop.
+        viewModel.cancelStream()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // isLoading must be false so the Send button reappears and new messages can be sent.
+        assertFalse(viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `cancelStream preserves the partial assistant message content`() = runTest {
+        every { repository.chatStream(any()) } returns flow {
+            emit(StreamChunk(content = "Only the beginning", done = false))
+            awaitCancellation()
+        }
+
+        viewModel.sendMessage("Tell me something")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.cancelStream()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val assistantMsg = viewModel.uiState.value.messages
+            .last { it.role == Message.Role.ASSISTANT }
+        assertEquals("Only the beginning", assistantMsg.content)
+        assertFalse(assistantMsg.isStreaming)
+    }
+
+    @Test
+    fun `cancelStream is a no-op when no stream is active`() = runTest {
+        // streamJob is null at this point — must not throw.
+        viewModel.cancelStream()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertTrue(viewModel.uiState.value.messages.isEmpty())
+    }
+
+    @Test
+    fun `sendMessage succeeds after a previous stream was cancelled`() = runTest {
+        every { repository.chatStream(any()) } returnsMany listOf(
+            flow {
+                emit(StreamChunk(content = "First partial", done = false))
+                awaitCancellation()
+            },
+            flowOf(StreamChunk(content = "Second complete", done = true)),
+        )
+
+        viewModel.sendMessage("First question")
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.cancelStream()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isLoading)
+
+        viewModel.sendMessage("Second question")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isLoading)
+        val lastAssistant = viewModel.uiState.value.messages
+            .last { it.role == Message.Role.ASSISTANT }
+        assertEquals("Second complete", lastAssistant.content)
     }
 
     // ── Language seeding (new) ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes a bug where cancelling a chat message (via the Stop button) would leave the UI in a broken state with `isLoading` permanently set to `true`. The issue occurred because database write operations were being cancelled before completion.

## Changes
- Wrapped message persistence and UI state updates in `withContext(NonCancellable)` to ensure database writes and loading state resets complete even when the coroutine is cancelled
- Added imports for `NonCancellable` and `withContext` from `kotlinx.coroutines`

## Implementation Details
When a user clicks the Stop button to cancel an in-flight message, the coroutine is cancelled. Previously, this would throw a `CancellationException` at the first suspending call (`repository.saveMessage()`), preventing the `isLoading` flag from being reset to `false`. 

By wrapping the critical section in `NonCancellable`, we ensure that:
1. The assistant message is persisted to the database
2. The conversation timestamp is updated
3. The UI state is properly updated with `isLoading = false`

This guarantees a consistent UI state regardless of whether the operation completes normally or is cancelled.

https://claude.ai/code/session_01KXwdbGWFVB3r8MSRxRDWWN