### PR TITLE
ci(commitlint): lint PR titles against conventional-commits

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -27,3 +27,31 @@ jobs:
         uses: wagoid/commitlint-github-action@v6
         with:
           configFile: commitlint.config.cjs
+
+  commitlint-pr-title:
+    # PR titles become the commit subject on squash-merge — which is what
+    # release-please scans on main. If the title isn't a conventional commit
+    # the merge ends up unclassified and silently absent from the next
+    # release's changelog (cf. #565 → v1.6.2). This job lints the title with
+    # the same commitlint.config.cjs the commit job uses, so type-enum and
+    # other rules stay in one place.
+    name: Lint PR Title
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.x"
+
+      - name: Install commitlint
+        run: npm install --no-save --no-audit --no-fund @commitlint/cli @commitlint/config-conventional
+
+      - name: Lint PR title against commitlint.config.cjs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s\n' "${PR_TITLE}" | npx --no-install commitlint --config commitlint.config.cjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,14 @@ Deploys to Azure on push to `main`.
 whose commit messages do not follow the `type(scope): description` format will
 fail CI. See `commitlint.config.cjs` for the full allowed type list.
 
+**The PR title itself must also be a conventional commit.** This repo uses
+squash-merge, so the PR title becomes the commit subject on `main`.
+`release-please` scans only top-level commit subjects — a non-conventional
+PR title produces an unrecognised commit and the change is silently dropped
+from the next release's changelog (this happened on #565 → v1.6.2). The
+`Lint PR Title` job in `commitlint.yml` blocks merging until the title is a
+valid conventional commit; rename the PR if it fails.
+
 ### Automated release tagging (release-please)
 
 **Do NOT create `vX.Y.Z` git tags manually.** Semver tags are created


### PR DESCRIPTION
## Summary

PR titles become the squash-merge commit subject on `main`. `release-please` only parses top-level commit subjects, so a non-conventional PR title produces an unrecognised commit and the change is silently dropped from the next release's changelog. This just happened on #565 → v1.6.2.

## Fix

Add a parallel `Lint PR Title` job to `commitlint.yml` that runs `@commitlint/cli` against `${{ github.event.pull_request.title }}` using the existing `commitlint.config.cjs`. Single source of truth — type-enum and other rules stay defined in one place.

Fires on `pull_request: opened | edited | synchronize`, so renaming a PR title re-triggers the check.

## Test plan

- [ ] After merge, open a test PR titled `Bad title without prefix` — expect the new `Lint PR Title` check to fail.
- [ ] Rename it to `chore: bad title without prefix` — expect the check to re-run and pass.
- [ ] Existing `Lint Commit Messages` job continues to lint individual commits as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPCa9vvGcmDZsBsWm3L5Ty)_