### PR TITLE
fix(ci): filter Android CI runs by .path, not .name

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -111,12 +111,16 @@ jobs:
           POLL_INTERVAL=30
           echo "Waiting for Android CI to complete on commit ${SHA}"
           while :; do
-            # Most recent "Android CI" workflow run for this SHA (re-runs win).
+            # Most recent android-ci.yml workflow run for this SHA (re-runs win).
+            # Filter by .path, not .name: the workflow_runs API returns the
+            # *run* name (which uses our dynamic run-name template, e.g.
+            # "Android CI (main)"), not the workflow's static name. .path is
+            # the workflow file path and is invariant.
             # Emit "status|conclusion" so we can branch on both fields. The
             # "missing" sentinel covers the case where no run exists yet.
             LINE=$(gh api \
               "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
-              --jq '[.workflow_runs[] | select(.name=="Android CI")]
+              --jq '[.workflow_runs[] | select(.path==".github/workflows/android-ci.yml")]
                     | sort_by(.run_started_at) | last
                     | if . == null then "missing|" else "\(.status)|\(.conclusion // "")" end')
             STATUS="${LINE%|*}"


### PR DESCRIPTION
## Summary

The real root cause behind every release publish failure since #558. `verify-release-gate`'s jq filter has never matched any workflow run.

## Why

`.github/workflows/android-publish.yml:119` filters by `select(.name == "Android CI")`. But `.github/workflows/android-ci.yml:17-19` defines a dynamic `run-name`:

```yaml
run-name: >-
  ${{ github.event_name == 'pull_request'
      && format('Android CI PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
      || format('Android CI ({0})', github.ref_name) }}
```

GitHub's REST API returns the **run name** in `workflow_runs[].name` (not the workflow's static `name:` field). For push events on `main` that resolves to `"Android CI (main)"`, never `"Android CI"`. The filter always returned an empty array → `last` was `null` → the script reported `"missing"`.

The `run-name` was already in the file before the gate code was added in #558. So PR #558's one-shot check, PR #560's poll loop, and PR #562's parent-SHA detection all sat downstream of a broken filter and didn't actually do anything useful. The v1.6.0, v1.6.1, and v1.6.2 publishes all failed at this same line.

## Fix

Change the filter to use `.path == ".github/workflows/android-ci.yml"`. `.path` is the workflow file path on workflow_runs entries and is invariant under `run-name` / workflow `name:` changes or renames.

```diff
- --jq '[.workflow_runs[] | select(.name=="Android CI")]
+ --jq '[.workflow_runs[] | select(.path==".github/workflows/android-ci.yml")]
```

Confirmed on `d046365` (v1.6.2's parent commit): Android CI #534 ran for 11m 28s with `conclusion: success` — the run is right there, the old filter just doesn't find it.

## Test plan

- [ ] Local API sanity check: `gh api "repos/zioalex/getinspiredbythebible/actions/runs?head_sha=d046365&per_page=100" --jq '[.workflow_runs[] | select(.path==".github/workflows/android-ci.yml")] | sort_by(.run_started_at) | last | .conclusion'` returns `"success"`.
- [ ] After merge: cancel the stuck `Android Publish v1.6.2` run, then `workflow_dispatch` Android Publish with `track: production` and `version_name: 1.6.2` to retry the upload (dispatch skips `verify-release-gate`, so this isn't blocked on the fix anyway, but the next *automatic* release will use the new filter).
- [ ] Next release-please flow lands a normal tag → `verify-release-gate` resolves the parent's Android CI in a single iteration → publish proceeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPCa9vvGcmDZsBsWm3L5Ty)_