### PR TITLE
fix(android-publish): default tag publishes to internal + validate_only pre-flight

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -265,9 +265,14 @@ jobs:
         id: lane
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            # Tag pushes always go to production. The :production lane defaults
-            # release_status=draft, so a human still clicks "Start rollout".
-            echo "lane=production" >> "$GITHUB_OUTPUT"
+            # Tag pushes (release-please tags) go to the **internal** track
+            # until the app has an established production presence. Promoting
+            # straight to production for the first time triggers Play Console
+            # precondition errors (no prior production release to compare
+            # against) and is operationally risky — we want internal testers
+            # to validate each tag before any production rollout. Promote to
+            # beta/production manually via workflow_dispatch when ready.
+            echo "lane=internal" >> "$GITHUB_OUTPUT"
           else
             echo "lane=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
           fi

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -58,6 +58,19 @@ platform :android do
     # Play Store rejects rollout + draft together. Only attach a rollout
     # percentage when the release is actually going live.
     params[:rollout] = ENV.fetch("ROLLOUT", "1.0") unless status == "draft"
+
+    # Pre-flight: dry-run the upload first so a Play Console precondition
+    # failure (stuck draft / unsubmitted edit / half-open `inProgress` edit)
+    # surfaces with the actual FAILED_PRECONDITION reason *before* we
+    # commit a real edit. Avoids burning a versionCode every time we hit a
+    # stuck Play Console state. The :validate lane below is functionally
+    # equivalent but anchored to internal — keep both: this guards every
+    # production publish automatically; :validate stays available for
+    # operator-initiated dry-runs after a manual cleanup.
+    upload_to_play_store(
+      **params.merge(validate_only: true, rollout: nil),
+    )
+
     upload_to_play_store(**params)
   end
 


### PR DESCRIPTION
## Summary

Two fixes to the publish pipeline that together address the v1.6.x publish failures.

### 1. Default tag publishes go to `internal`, not `production`

`.github/workflows/android-publish.yml` was sending every release-please tag straight to the `production` lane. The docs (`docs/RELEASE_PROCESS.md:32` and `:168`) have always said tag pushes land on the **internal** track — the workflow was the inconsistent piece.

Promoting straight to production for an app with no established production presence is exactly what triggers the "Precondition check failed" error mode we've been chasing: there's no prior production release to anchor the new draft against, and production drafts have stricter validation than internal/beta drafts. The recent v1.6.0 / v1.6.1 / v1.6.2 publish failures all match this signature.

Change: tag pushes now use `lane=internal`. Beta/production promotion is an explicit `workflow_dispatch` with `track: beta` or `track: production`, as the docs already describe.

### 2. `validate_only` pre-flight inside the `:production` lane

Defensive: when someone *does* later run `workflow_dispatch` with `track: production`, run a `validate_only: true` `upload_to_play_store` first. If Play Console is stuck (pending draft / unsubmitted edit / half-open `inProgress` edit) the pre-flight surfaces the actual `FAILED_PRECONDITION` reason in the same fastlane log the operator was going to read, and the real upload is skipped — so no versionCode is burned.

The standalone `:validate` lane (anchored to internal) stays — still useful for operator-initiated dry-runs after a manual Play Console cleanup.

## Important: still does not unstick v1.6.2 retroactively

v1.6.2's stuck state requires manual Play Console cleanup. Runbook:

1. Download `fastlane-log-25961476124` artifact from the failing run → search for `FAILED_PRECONDITION` to see the exact reason.
2. Play Console → Releases overview → discard any draft release on production. Dashboard → "Unsubmitted changes" banner → Send for review **or** Discard.
3. Run workflow with `track: validate` to confirm clean state.
4. Run workflow with `track: internal`, `version_name: 1.6.2` — now safe by default.

After this PR merges, *future* tag publishes go to internal automatically, so the precondition-stall failure mode shouldn't recur unless production is explicitly chosen.

## Test plan

- [ ] All standard PR checks (Android CI on PR paths fires because `android/**` is touched).
- [ ] After merge, next release-please tag → confirm publish lane is `internal`, AAB lands as a draft in Play Console internal testing track.
- [ ] Optional later: `workflow_dispatch` `track: production` while a draft is pending in Play Console — confirm pre-flight fails with the underlying precondition reason and no real upload is attempted.