### PR TITLE
docs(agents): clarify feat vs chore commit type choice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Deploys to Azure on push to `main`.
   - `docs: add BITB-025 backlog item`
 - **Branch naming:** `feature/description`, `fix/description`, or `claude/description`
 
-#### Choosing the right type: `feat` vs `chore`
+### Choosing the right type: `feat` vs `chore`
 
 > **If a user can see or feel the change → `feat:`**
 > **If only the codebase or pipeline changes → `chore:`/`ci:`/`build:`**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,25 @@ Deploys to Azure on push to `main`.
   - `docs: add BITB-025 backlog item`
 - **Branch naming:** `feature/description`, `fix/description`, or `claude/description`
 
+#### Choosing the right type: `feat` vs `chore`
+
+> **If a user can see or feel the change → `feat:`**
+> **If only the codebase or pipeline changes → `chore:`/`ci:`/`build:`**
+
+`chore:` is hidden in the changelog (`"hidden": true` in `release-please-config.json`).
+Using it for user-visible work causes those changes to be silently absent from the
+release notes. When in doubt, prefer `feat:`.
+
+| Change | Correct type |
+|--------|-------------|
+| New icon, splash screen, or graphics | `feat:` |
+| New screen or UI component | `feat:` |
+| Copy/text change visible to the user | `feat:` |
+| Bug the user could observe | `fix:` |
+| Internal refactor with no user impact | `chore:` |
+| CI workflow or tooling change | `ci:` |
+| Dependency bump | `build:` |
+
 ### Conventional Commits enforcement
 
 **Conventional Commits are enforced on every PR** via
@@ -346,3 +365,4 @@ and chapter number. Chinese also uses guillemet notation `<<BookName>>`.
    end-of-file-fixer exclude `frontend/` (handled by Prettier instead)
 8. **Android string validation** - CI checks that all strings in `values/strings.xml` exist in every locale directory
 9. **Never push to closed/merged PR branches** - Always create a fresh branch from `main` for new work
+10. **`chore:` hides from changelog** - Asset, graphic, and UI changes that users can see must use `feat:`, not `chore:`. Using `chore:` for user-visible work causes the change to be silently dropped from release notes by release-please (see Git Conventions → Choosing the right type)


### PR DESCRIPTION
## Summary

- Adds a **decision table and rule of thumb** to the Git Conventions section of `AGENTS.md` so agents always use `feat:` for user-visible changes (icons, graphics, UI) instead of `chore:`, which is hidden from the release-please changelog
- Adds this as **pitfall #10** in Common Pitfalls for quick reference

Prompted by PR #576 where all graphic/icon updates were committed as `chore:` and were silently absent from the release notes.

## Test plan

- [ ] Docs-only change — CI passes trivially

https://claude.ai/code/session_01QvPCo33wxUs64igm7fdMdz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvPCo33wxUs64igm7fdMdz)_