### PR TITLE
feat(android): add closed testing workflow for Play Store releases

### DIFF
--- a/.github/workflows/android-closed-testing.yml
+++ b/.github/workflows/android-closed-testing.yml
@@ -1,0 +1,151 @@
+name: Android Closed Testing
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      version_code:
+        description: "Override versionCode (empty = Unix epoch timestamp)."
+        required: false
+        type: string
+      version_name:
+        description: "Override versionName (empty = read from build.gradle.kts)."
+        required: false
+        type: string
+      release_status:
+        description: "Release status: 'completed' (live to testers) or 'draft'."
+        required: false
+        type: choice
+        default: "completed"
+        options:
+          - completed
+          - draft
+
+run-name: "Android Closed Testing (${{ inputs.release_status || 'completed' }})"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-upload:
+    name: Build AAB & Upload to Closed Testing
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_FILE }}" | base64 --decode > /tmp/release.keystore
+
+      - name: Write google-services.json
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 -d > android/app/google-services.json
+
+      - name: Compute version code and name
+        id: version
+        env:
+          INPUT_VERSION_CODE: ${{ inputs.version_code }}
+          INPUT_VERSION_NAME: ${{ inputs.version_name }}
+        run: |
+          BUILD_EPOCH="$(date +%s)"
+
+          if [[ -n "$INPUT_VERSION_NAME" ]]; then
+            VERSION_NAME="$INPUT_VERSION_NAME"
+          else
+            VERSION_NAME="$(grep versionName android/app/build.gradle.kts \
+              | head -1 | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+          fi
+
+          if [[ -n "$INPUT_VERSION_CODE" ]]; then
+            VERSION_CODE="$INPUT_VERSION_CODE"
+          else
+            VERSION_CODE="$BUILD_EPOCH"
+          fi
+
+          echo "Using versionName=${VERSION_NAME}, versionCode=${VERSION_CODE}"
+          echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version_code=${VERSION_CODE}" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed AAB
+        working-directory: android
+        env:
+          KEYSTORE_PATH: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          ./gradlew bundleRelease \
+            -PversionCode="${{ steps.version.outputs.version_code }}" \
+            -PversionName="${{ steps.version.outputs.version_name }}" \
+            -PbaseUrl="https://api.voxquieta.org/"
+
+      - name: Set up Ruby for Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: android
+
+      - name: Install Fastlane
+        working-directory: android
+        run: gem install fastlane --no-document
+
+      - name: Decode Google Play JSON key
+        run: |
+          echo "${{ secrets.GOOGLE_PLAY_JSON_KEY }}" | base64 --decode > /tmp/google-play-key.json
+
+      - name: Stage latest CHANGELOG entry as release notes
+        run: |
+          set -e
+          mkdir -p android/fastlane/metadata/android/en-US/changelogs
+          awk '
+            /^## / { n++; if (n == 1) next; if (n == 2) exit }
+            n == 1 { print }
+          ' CHANGELOG.md | head -c 500 \
+            > android/fastlane/metadata/android/en-US/changelogs/default.txt
+          if [ ! -s android/fastlane/metadata/android/en-US/changelogs/default.txt ]; then
+            echo "Bug fixes and improvements." \
+              > android/fastlane/metadata/android/en-US/changelogs/default.txt
+          fi
+          echo "--- release notes ---"
+          cat android/fastlane/metadata/android/en-US/changelogs/default.txt
+          echo
+
+      - name: Upload to Play Store (closed testing / alpha track)
+        working-directory: android
+        env:
+          GOOGLE_PLAY_JSON_KEY_FILE: /tmp/google-play-key.json
+          RELEASE_STATUS: ${{ inputs.release_status || 'completed' }}
+          FASTLANE_HIDE_TIMESTAMP: "true"
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          SUPPLY_VERBOSE: "true"
+        run: |
+          set -o pipefail
+          fastlane alpha --verbose 2>&1 | tee /tmp/fastlane.log
+
+      - name: Upload Fastlane log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fastlane-log-closed-testing-${{ github.run_id }}
+          path: |
+            /tmp/fastlane.log
+            android/fastlane/report.xml
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: app-release-closed-testing-${{ steps.version.outputs.version_name }}.aab
+          path: android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 90

--- a/.github/workflows/android-closed-testing.yml
+++ b/.github/workflows/android-closed-testing.yml
@@ -13,7 +13,9 @@ on:
         required: false
         type: string
       track:
-        description: "Closed testing track to publish to. Run the workflow once and check the 'List available Play Store tracks' step to confirm the exact API trackId for custom tracks."
+        description:
+          "Closed testing track to publish to. Run the workflow once and check the 'List available Play Store tracks'
+          step to confirm the exact API trackId for custom tracks."
         required: false
         type: choice
         default: "alpha"

--- a/.github/workflows/android-closed-testing.yml
+++ b/.github/workflows/android-closed-testing.yml
@@ -12,6 +12,14 @@ on:
         description: "Override versionName (empty = read from build.gradle.kts)."
         required: false
         type: string
+      track:
+        description: "Closed testing track to publish to. Run the workflow once and check the 'List available Play Store tracks' step to confirm the exact API trackId for custom tracks."
+        required: false
+        type: choice
+        default: "alpha"
+        options:
+          - alpha
+          - extend testing
       release_status:
         description: "Release status: 'completed' (live to testers) or 'draft'."
         required: false
@@ -21,7 +29,7 @@ on:
           - completed
           - draft
 
-run-name: "Android Closed Testing (${{ inputs.release_status || 'completed' }})"
+run-name: "Android Closed Testing → ${{ inputs.track || 'alpha' }} (${{ inputs.release_status || 'completed' }})"
 
 permissions:
   contents: read
@@ -103,6 +111,41 @@ jobs:
         run: |
           echo "${{ secrets.GOOGLE_PLAY_JSON_KEY }}" | base64 --decode > /tmp/google-play-key.json
 
+      - name: List available Play Store tracks
+        continue-on-error: true
+        run: |
+          pip install --quiet google-auth google-api-python-client
+          python3 << 'PYEOF'
+          import json
+          from google.oauth2 import service_account
+          from googleapiclient.discovery import build
+
+          with open('/tmp/google-play-key.json') as f:
+              creds_data = json.load(f)
+
+          creds = service_account.Credentials.from_service_account_info(
+              creds_data,
+              scopes=['https://www.googleapis.com/auth/androidpublisher']
+          )
+          service = build('androidpublisher', 'v3', credentials=creds)
+
+          # A temporary edit is required by the API to list tracks.
+          edit = service.edits().insert(packageName='org.voxquieta').execute()
+          edit_id = edit['id']
+
+          tracks = service.edits().tracks().list(
+              packageName='org.voxquieta', editId=edit_id
+          ).execute()
+
+          print("Available Play Store tracks (use trackId value in the track dropdown):")
+          for t in sorted(tracks.get('tracks', []), key=lambda x: x['track']):
+              print(f"  trackId: \"{t['track']}\"")
+
+          # Abandon the edit — no changes committed to Play Console.
+          service.edits().delete(packageName='org.voxquieta', editId=edit_id).execute()
+          print("Edit abandoned — no changes committed.")
+          PYEOF
+
       - name: Stage latest CHANGELOG entry as release notes
         run: |
           set -e
@@ -120,17 +163,18 @@ jobs:
           cat android/fastlane/metadata/android/en-US/changelogs/default.txt
           echo
 
-      - name: Upload to Play Store (closed testing / alpha track)
+      - name: Upload to Play Store (closed testing)
         working-directory: android
         env:
           GOOGLE_PLAY_JSON_KEY_FILE: /tmp/google-play-key.json
+          CLOSED_TESTING_TRACK: ${{ inputs.track || 'alpha' }}
           RELEASE_STATUS: ${{ inputs.release_status || 'completed' }}
           FASTLANE_HIDE_TIMESTAMP: "true"
           FASTLANE_SKIP_UPDATE_CHECK: "true"
           SUPPLY_VERBOSE: "true"
         run: |
           set -o pipefail
-          fastlane alpha --verbose 2>&1 | tee /tmp/fastlane.log
+          fastlane closed_testing --verbose 2>&1 | tee /tmp/fastlane.log
 
       - name: Upload Fastlane log on failure
         if: failure()

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -12,6 +12,7 @@ on:
         options:
           - validate
           - internal
+          - alpha
           - beta
           - production
       version_code:

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -41,6 +41,21 @@ platform :android do
     )
   end
 
+  desc "Upload AAB to a named closed testing track (set CLOSED_TESTING_TRACK env var; defaults to 'alpha')"
+  lane :closed_testing do
+    upload_to_play_store(
+      track: ENV.fetch("CLOSED_TESTING_TRACK", "alpha"),
+      aab: "app/build/outputs/bundle/release/app-release.aab",
+      release_status: release_status_for("completed"),
+      skip_upload_apk: true,
+      skip_upload_metadata: false,
+      skip_upload_changelogs: false,
+      skip_upload_images: false,
+      skip_upload_screenshots: false,
+      changes_not_sent_for_review: false,
+    )
+  end
+
   desc "Upload AAB to Play Store open testing (beta) track"
   lane :beta do
     upload_to_play_store(

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -26,7 +26,22 @@ platform :android do
     )
   end
 
-  desc "Upload AAB to Play Store closed beta track"
+  desc "Upload AAB to Play Store closed testing (alpha) track"
+  lane :alpha do
+    upload_to_play_store(
+      track: "alpha",
+      aab: "app/build/outputs/bundle/release/app-release.aab",
+      release_status: release_status_for("completed"),
+      skip_upload_apk: true,
+      skip_upload_metadata: false,
+      skip_upload_changelogs: false,
+      skip_upload_images: false,
+      skip_upload_screenshots: false,
+      changes_not_sent_for_review: false,
+    )
+  end
+
+  desc "Upload AAB to Play Store open testing (beta) track"
   lane :beta do
     upload_to_play_store(
       track: "beta",


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow for publishing Android builds to Google Play Store closed testing tracks, along with supporting Fastlane configuration updates.

## Key Changes
- **New workflow**: `.github/workflows/android-closed-testing.yml`
  - Builds signed AAB (Android App Bundle) with configurable version code and name
  - Publishes to Play Store closed testing tracks (alpha, extended testing, or custom)
  - Supports draft or completed release status
  - Includes version computation (Unix epoch timestamp as default version code)
  - Extracts release notes from CHANGELOG.md (max 500 characters)
  - Lists available Play Store tracks for reference
  - Uploads build artifacts and Fastlane logs on failure

- **Updated Fastlane configuration**: `android/fastlane/Fastfile`
  - Added `alpha` lane for closed testing on alpha track
  - Added `closed_testing` lane for flexible track selection via `CLOSED_TESTING_TRACK` environment variable
  - Updated `beta` lane description to clarify it's for open testing

- **Updated publish workflow**: `.github/workflows/android-publish.yml`
  - Added `alpha` as a new track option in the manual dispatch inputs

## Notable Implementation Details
- Version code defaults to Unix epoch timestamp if not provided
- Version name is extracted from `build.gradle.kts` if not provided
- Keystore and Google Play credentials are decoded from base64-encoded secrets
- The workflow includes a Python script to list available Play Store tracks for user reference
- Release notes are automatically staged from CHANGELOG.md with fallback text
- Fastlane logs and build artifacts are preserved for debugging on failure

https://claude.ai/code/session_01HVxDx1GZKo5AJqBF1rZvMY