### PR TITLE
fix(android): fix analytics over-counting and locale-revert-to-English bugs

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -77,8 +77,12 @@ class MainActivity : ComponentActivity() {
             elapsed < 700L && !backendReady
         }
 
-        // Log the app_open event on every cold start.
-        analyticsHelper.logEvent(AnalyticsHelper.EVENT_APP_OPEN)
+        // Log app_open only on a genuine cold start, not on Activity recreations
+        // triggered by locale changes (AppCompatDelegate.setApplicationLocales recreates
+        // the Activity on SDK < 33), rotation, or other config changes.
+        if (savedInstanceState == null) {
+            analyticsHelper.logEvent(AnalyticsHelper.EVENT_APP_OPEN)
+        }
 
         setContent {
             val viewModel: ChatViewModel = hiltViewModel()

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -665,13 +665,19 @@ class ChatViewModel @Inject constructor(
      * Updates the language locale in-memory, persists it via DataStore, and applies
      * it system-wide so every stringResource() reflects the new locale after the
      * Activity recreate that AppCompatDelegate.setApplicationLocales triggers.
+     *
+     * Persistence must complete before localeApplier.apply() triggers recreation.
+     * If apply() fires first, the init-block languageFlow collector sees the old
+     * DataStore value and overwrites _uiState back to the previous locale for the
+     * duration of the recreation window, causing a visible revert to the old language.
      */
     fun setLocale(locale: String) {
+        if (locale == _uiState.value.currentLocale) return
         Timber.tag("VoxLocale").i("ChatViewModel.setLocale(%s) called", locale)
         _uiState.update { it.copy(currentLocale = locale) }
-        localeApplier.apply(locale)
         viewModelScope.launch {
             languagePreferences.setLanguage(locale)
+            localeApplier.apply(locale)
         }
     }
 


### PR DESCRIPTION
## Summary

- **`app_open` fired on every Activity recreation, not just cold starts** — locale changes on SDK < 33 (and system-managed recreation on SDK ≥ 33) call `onCreate()` again, logging a spurious `app_open` each time. Fixed by guarding the log call with `savedInstanceState == null`.

- **Language change sometimes reverts to English** — a race between `setLocale()` and the `init`-block `languageFlow` collector in `ChatViewModel`. `setLocale()` updated `_uiState` to `"ar"` immediately, then queued the DataStore write async. Before that write landed, the collector fired with the still-old persisted value (`"en"`) and overwrote the state — right as Activity recreation was rebuilding the UI. Fixed by moving `localeApplier.apply()` inside the coroutine so it only fires *after* `setLanguage()` has committed to DataStore.

- **No-op locale changes** — added an early-return guard in `setLocale()` to skip unnecessary DataStore writes and Activity recreations when the user re-selects the current language.

## Test plan

- [ ] Cold-start the app: confirm exactly one `app_open` event in analytics
- [ ] Change language once: confirm one `app_open` after recreation, no revert to English
- [ ] Rapidly tap through several languages: confirm final language sticks, no English flash
- [ ] Re-select the already-active language: confirm no recreation / no duplicate analytics event
- [ ] Kill and relaunch the app: confirm the last-selected language is restored correctly on both SDK 30 and SDK 33+

https://claude.ai/code/session_01BEWmV7xypmatdTaQEgUYqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEWmV7xypmatdTaQEgUYqZ)_