### PR TITLE
feat(android): add Robolectric/Compose UI test tier (BITB-034)

### DIFF
--- a/.github/workflows/android-compose-tests.yml
+++ b/.github/workflows/android-compose-tests.yml
@@ -1,0 +1,109 @@
+name: Android Compose UI Tests
+
+# yamllint disable-line rule:truthy
+run-name: >-
+  ${{ github.event_name == 'pull_request'
+      && format('Compose UI Tests PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
+      || format('Compose UI Tests ({0})', github.ref_name) }}
+
+"on":
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "android/**"
+      - ".github/workflows/android-compose-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "android/**"
+      - ".github/workflows/android-compose-tests.yml"
+  workflow_dispatch:
+
+# Cancel in-flight runs when a newer push supersedes them.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# IMPORTANT: This workflow is intentionally INDEPENDENT of android-ci.yml so
+# Compose-UI-test flakiness cannot block merges or releases. Configure this
+# check as NON-REQUIRED in the repository's branch-protection settings.
+jobs:
+  compose-ui-tests:
+    name: Compose UI Tests (Robolectric)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # continue-on-error ensures the PR remains mergeable even if these tests
+    # become flaky before the tier is stabilised and made a required check.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Grant gradlew execute permission
+        run: chmod +x android/gradlew
+
+      - name: Write placeholder google-services.json
+        run: |
+          cat > android/app/google-services.json <<'PLACEHOLDER'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "voxquieta-placeholder",
+              "storage_bucket": "voxquieta-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": {"package_name": "org.voxquieta"}
+                },
+                "oauth_client": [],
+                "api_key": [{"current_key": "PLACEHOLDER_KEY"}],
+                "services": {"appinvite_service": {"other_platform_oauth_client": []}}
+              },
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000001",
+                  "android_client_info": {"package_name": "org.voxquieta.debug"}
+                },
+                "oauth_client": [],
+                "api_key": [{"current_key": "PLACEHOLDER_KEY"}],
+                "services": {"appinvite_service": {"other_platform_oauth_client": []}}
+              }
+            ],
+            "configuration_version": "1"
+          }
+          PLACEHOLDER
+
+      - name: Run Compose UI tests
+        working-directory: android
+        run: ./gradlew :app:testDebugCompose --no-daemon --stacktrace
+
+      - name: Upload HTML test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-ui-test-report
+          path: android/app/build/reports/tests/testDebugCompose/
+          retention-days: 14
+
+      - name: Upload JUnit XML results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-ui-test-results
+          path: android/app/build/test-results/testDebugCompose/
+          retention-days: 14

--- a/.github/workflows/android-compose-tests.yml
+++ b/.github/workflows/android-compose-tests.yml
@@ -90,14 +90,19 @@ jobs:
 
       - name: Run Compose UI tests
         working-directory: android
-        run: ./gradlew :app:testDebugCompose --no-daemon --stacktrace
+        # Run only *ComposeTest classes via the standard unit-test task with a filter.
+        # No custom Gradle task is needed — Gradle's --tests flag isolates the tier.
+        run: |
+          ./gradlew :app:testDebugUnitTest \
+            --tests "*.VersesPanelComposeTest" \
+            --no-daemon --stacktrace
 
       - name: Upload HTML test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: compose-ui-test-report
-          path: android/app/build/reports/tests/testDebugCompose/
+          path: android/app/build/reports/tests/testDebugUnitTest/
           retention-days: 14
 
       - name: Upload JUnit XML results
@@ -105,5 +110,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compose-ui-test-results
-          path: android/app/build/test-results/testDebugCompose/
+          path: android/app/build/test-results/testDebugUnitTest/
           retention-days: 14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,14 +115,20 @@ cd frontend && npm run build           # Build check
 
 ```bash
 cd android && ./gradlew testDebugUnitTest --no-daemon
+cd android && ./gradlew testDebugCompose --no-daemon   # Robolectric Compose UI tests (BITB-034)
 cd android && ./gradlew lint
 ```
+
+Compose UI tests follow the `*ComposeTest.kt` filename convention and run via the dedicated
+`testDebugCompose` Gradle task. They are isolated from the standard `testDebugUnitTest` job.
+See `android/COMPOSE_TESTS.md` for the full tier description and rollout plan.
 
 ### All at once
 
 ```bash
-make test           # Backend + frontend
-make android-test   # Android unit tests
+make test                  # Backend + frontend
+make android-test          # Android JVM unit tests
+make android-test-compose  # Android Compose UI tests (Robolectric — separate tier)
 ```
 
 ## Code Style & Linting
@@ -174,6 +180,17 @@ Format commands: `make format` (auto-fix Python + frontend)
 | `dependency-check` | OWASP Dependency-Check (CVE threshold 7.0) |
 | `apk-security-check` | Manifest security flags |
 | `build` | Production APK (gated by security checks) |
+
+### Android Compose UI Tests (`android-compose-tests.yml`)
+
+Independent workflow — **not a required check** while the tier stabilises.
+
+| Job | What it does |
+| ----- | ------------- |
+| `compose-ui-tests` | Robolectric `testDebugCompose` — `*ComposeTest.kt` classes only |
+
+Artifacts uploaded on every run: HTML report + JUnit XML (14-day retention).
+See `android/COMPOSE_TESTS.md` for the tier design and promotion checklist.
 
 ### Deployment (`azure-deploy.yml`)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	tf-check-version tf-init tf-plan tf-apply tf-destroy tf-fmt tf-validate tf-output tf-refresh \
 	validate-env validate-env-strict \
 	az-acr-list-images az-acr-list-tags az-deployed-images az-image-info \
-	android-test android-build android-build-prod android-lint android-clean android-security-check \
+	android-test android-test-compose android-build android-build-prod android-lint android-clean android-security-check \
 	test-functional test-functional-local test-e2e test-e2e-local \
 	az-acr-list-images az-acr-list-tags az-deployed-images az-image-info
 
@@ -156,6 +156,12 @@ android-test: ## Run Android unit tests (requires JDK 17)
 	@echo "$(BLUE)Running Android unit tests...$(NC)"
 	@cd android && ./gradlew testDebugUnitTest --no-daemon
 	@echo "$(GREEN)✓ Android unit tests complete$(NC)"
+
+android-test-compose: ## Run Android Compose UI tests via Robolectric — separate from android-test (requires JDK 17)
+	@echo "$(BLUE)Running Android Compose UI tests...$(NC)"
+	@cd android && ./gradlew testDebugCompose --no-daemon
+	@echo "$(GREEN)✓ Android Compose UI tests complete$(NC)"
+	@echo "$(YELLOW)Report: android/app/build/reports/tests/testDebugCompose/index.html$(NC)"
 
 android-build: ## Build Android debug APK pointing at local dev backend (requires JDK 17)
 	@echo "$(BLUE)Building Android debug APK (local backend: http://10.0.2.2:8000/)...$(NC)"

--- a/android/COMPOSE_TESTS.md
+++ b/android/COMPOSE_TESTS.md
@@ -1,0 +1,94 @@
+# Android Compose UI Tests
+
+> BITB-034 — Robolectric-backed Compose UI test tier
+
+## Overview
+
+The Android test suite has three tiers:
+
+| Tier | Runner | What it covers | When to use |
+|---|---|---|---|
+| **JVM unit tests** (`*Test.kt`) | JVM / JUnit 4 | Pure logic — ViewModels, repositories, utility functions, pure helpers | Fast feedback on business logic |
+| **Compose UI tests** (`*ComposeTest.kt`) | Robolectric + `createComposeRule()` | Composable rendering, default state, segment control selection, `rememberSaveable` survival | Catching Compose-layer regressions without an emulator |
+| **Instrumented tests** (`androidTest/`) | Android emulator (API 29) | Happy-path E2E flows (chat, navigation) | Full-stack validation before release |
+
+## Quick Start
+
+```bash
+# Run only Compose UI tests (Robolectric tier)
+make android-test-compose
+
+# Or directly with Gradle
+cd android && ./gradlew testDebugCompose --no-daemon
+
+# Run the standard JVM unit tests (unchanged)
+make android-test
+```
+
+HTML report after a run: `android/app/build/reports/tests/testDebugCompose/index.html`
+
+## Filename Convention
+
+| Filename pattern | Runs in | Description |
+|---|---|---|
+| `*Test.kt` | `testDebugUnitTest` | Existing JVM unit tests — pure logic, no Android/Compose runtime |
+| `*ComposeTest.kt` | `testDebugCompose` | Robolectric Compose UI tests — mounts composables and asserts semantics |
+
+Both live under `android/app/src/test/kotlin/`. The Gradle `testDebugUnitTest` task explicitly
+excludes `**/*ComposeTest.class`; `testDebugCompose` includes only `**/*ComposeTest.class`.
+
+## Writing a New Compose Test
+
+1. Create a file matching `*ComposeTest.kt` anywhere under `src/test/kotlin/`.
+2. Extend `ComposeTestHarness` (from `org.voxquieta.app.testing`).
+3. Mount content with `setContentThemed { YourComposable(...) }`.
+4. Use `composeRule.onNodeWithText(...)`, `assertIsDisplayed()`, `performClick()`, etc.
+
+```kotlin
+class MyScreenComposeTest : ComposeTestHarness() {
+
+    @Test
+    fun `button is enabled when data is loaded`() {
+        setContentThemed {
+            MyScreen(isLoading = false, onAction = {})
+        }
+        composeRule.onNodeWithText("Submit").assertIsEnabled()
+    }
+}
+```
+
+Reference: `VersesPanelComposeTest.kt` is the canonical template.
+
+## Known Limitations
+
+- **`ModalBottomSheet`, `Dialog`, `Popup`** have known rendering quirks under Robolectric
+  (window insets, animation clocks). Test the *content* composable directly instead of the
+  sheet wrapper. See how `VersesPanelContent` is used instead of `VersesPanel`.
+- **API level**: Robolectric 4.14.1 pins to API 34 via `@Config(sdk = [34])`.
+  Behaviors that only appear on API 35 must be covered by instrumented tests.
+- **Hilt is intentionally excluded**: the harness uses `android.app.Application` as the
+  Robolectric application class. Future screen-level tests that need injected ViewModels
+  will require a Hilt-wired application — defer until the second screen-level test is added.
+
+## CI
+
+The `android-compose-tests.yml` workflow runs in parallel with `android-ci.yml`:
+
+- Triggered on PRs and pushes that touch `android/**`.
+- Reports as its own check: `Compose UI Tests (Robolectric)`.
+- Uses `continue-on-error: true` and is **NOT a required check** for merges while the
+  tier stabilises. Once green consistently, promote it to required via branch-protection
+  settings and remove `continue-on-error`.
+
+## Suggested Future Targets
+
+Once the tier has been green for several PR runs, add tests in this order:
+
+1. `ChatInputFieldComposeTest` — send-button enabled/disabled state, Stop icon while loading.
+2. `ChatScreenComposeTest` — top-bar policy, language picker visibility.
+3. `TranslationPickerBottomSheetComposeTest` — selection and dismissal.
+4. `VerseDetailBottomSheetComposeTest` — verse display and close.
+5. `ConversationsScreenComposeTest` — empty and populated list states.
+
+When the tier has multiple stable tests, file the integration follow-up story to promote it
+to a required check and optionally merge it into `android-ci.yml`.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -313,46 +313,7 @@ val generateChangelogJson by tasks.registering {
 
 tasks.named("preBuild").configure { dependsOn(generateChangelogJson) }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// BITB-034: Compose UI test tier (Robolectric-backed).
-//
-// Convention: any test class file ending in "ComposeTest.kt" belongs to the
-// new tier. Regular *Test.kt classes stay in testDebugUnitTest.
-//
-// Run locally:  ./gradlew testDebugCompose --no-daemon
-//               make android-test-compose
-// CI:           .github/workflows/android-compose-tests.yml (non-required check)
-// ─────────────────────────────────────────────────────────────────────────────
-tasks.named<Test>("testDebugUnitTest") {
-    exclude("**/*ComposeTest.class")
-}
-
-// Lazy provider for testDebugUnitTest — resolved only when testDebugCompose is realized.
-// Avoids afterEvaluate (incompatible with org.gradle.configuration-cache=true in Gradle 8.x).
-val unitTestProvider: TaskProvider<Test> = tasks.named<Test>("testDebugUnitTest")
-
-tasks.register<Test>("testDebugCompose") {
-    description = "Runs Robolectric/Compose UI tests (*ComposeTest classes only)."
-    group = "verification"
-
-    include("**/*ComposeTest.class")
-    useJUnit()
-
-    // Wire classpath/testClassesDirs via lazy providers so this is configuration-cache safe.
-    // setFrom() accepts Provider<*> — Gradle resolves it at task-graph execution time.
-    testClassesDirs.setFrom(unitTestProvider.map { it.testClassesDirs })
-    classpath = files(unitTestProvider.map { it.classpath })
-
-    // Depend only on compilation — not on testDebugUnitTest itself so running
-    // testDebugCompose does NOT also execute the full unit-test suite.
-    dependsOn("compileDebugUnitTestKotlin")
-
-    reports.html.outputLocation.set(
-        layout.buildDirectory.dir("reports/tests/testDebugCompose"),
-    )
-    reports.junitXml.outputLocation.set(
-        layout.buildDirectory.dir("test-results/testDebugCompose"),
-    )
-}
-// testDebugCompose is intentionally NOT wired into the `check` lifecycle so it
-// cannot accidentally block existing CI pipelines.
+// BITB-034: Robolectric/Compose UI tests run via testDebugUnitTest (no custom task needed).
+// The android-compose-tests.yml workflow uses --tests filtering to isolate *ComposeTest
+// classes without requiring a separate Gradle task registration.
+// See: .github/workflows/android-compose-tests.yml

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -139,6 +139,9 @@ android {
             // instead of throwing RuntimeException("Stub!"). Required for any unit test
             // that transitively touches an Android API (e.g. AppCompatDelegate, Bundle).
             isReturnDefaultValues = true
+            // Merge Android resources into the test classpath so Robolectric can resolve
+            // stringResource() calls and other resource lookups (BITB-034).
+            isIncludeAndroidResources = true
         }
     }
 
@@ -229,6 +232,11 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
+    // Robolectric-backed Compose UI tests (BITB-034)
+    testImplementation(libs.robolectric)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
+    testImplementation(libs.androidx.ui.test.manifest)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -305,3 +313,40 @@ val generateChangelogJson by tasks.registering {
 }
 
 tasks.named("preBuild").configure { dependsOn(generateChangelogJson) }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BITB-034: Compose UI test tier (Robolectric-backed).
+//
+// Convention: any test class file ending in "ComposeTest.kt" belongs to the
+// new tier. Regular *Test.kt classes stay in testDebugUnitTest.
+//
+// Run locally:  ./gradlew testDebugCompose --no-daemon
+//               make android-test-compose
+// CI:           .github/workflows/android-compose-tests.yml (non-required check)
+// ─────────────────────────────────────────────────────────────────────────────
+tasks.named<Test>("testDebugUnitTest") {
+    exclude("**/*ComposeTest.class")
+}
+
+tasks.register<Test>("testDebugCompose") {
+    description = "Runs Robolectric/Compose UI tests (*ComposeTest classes only)."
+    group = "verification"
+
+    val baseTask = tasks.named<Test>("testDebugUnitTest").get()
+    testClassesDirs = baseTask.testClassesDirs
+    classpath = baseTask.classpath
+
+    include("**/*ComposeTest.class")
+    useJUnit()
+
+    dependsOn("compileDebugUnitTestKotlin", "processDebugUnitTestJavaRes")
+
+    reports.html.outputLocation.set(
+        layout.buildDirectory.dir("reports/tests/testDebugCompose"),
+    )
+    reports.junitXml.outputLocation.set(
+        layout.buildDirectory.dir("test-results/testDebugCompose"),
+    )
+}
+// testDebugCompose is intentionally NOT wired into the `check` lifecycle so it
+// cannot accidentally block existing CI pipelines.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -350,11 +350,10 @@ tasks.register<Test>("testDebugCompose") {
 // Using afterEvaluate guarantees all AGP afterEvaluate blocks have run first, so the
 // base task's FileCollections are fully populated before we copy the references.
 afterEvaluate {
-    val base = tasks.named<Test>("testDebugUnitTest")
-    tasks.named<Test>("testDebugCompose").configure {
-        testClassesDirs = base.get().testClassesDirs
-        classpath = base.get().classpath
-    }
+    val base = tasks.named<Test>("testDebugUnitTest").get()
+    val compose = tasks.named<Test>("testDebugCompose").get()
+    compose.testClassesDirs = base.testClassesDirs
+    compose.classpath = base.classpath
 }
 // testDebugCompose is intentionally NOT wired into the `check` lifecycle so it
 // cannot accidentally block existing CI pipelines.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -236,7 +236,6 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)
-    testImplementation(libs.androidx.ui.test.manifest)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -332,14 +331,12 @@ tasks.register<Test>("testDebugCompose") {
     description = "Runs Robolectric/Compose UI tests (*ComposeTest classes only)."
     group = "verification"
 
-    val baseTask = tasks.named<Test>("testDebugUnitTest").get()
-    testClassesDirs = baseTask.testClassesDirs
-    classpath = baseTask.classpath
-
     include("**/*ComposeTest.class")
     useJUnit()
 
-    dependsOn("compileDebugUnitTestKotlin", "processDebugUnitTestJavaRes")
+    // Depend only on compilation — not on testDebugUnitTest itself so running
+    // testDebugCompose does NOT also execute the full unit-test suite.
+    dependsOn("compileDebugUnitTestKotlin")
 
     reports.html.outputLocation.set(
         layout.buildDirectory.dir("reports/tests/testDebugCompose"),
@@ -347,6 +344,17 @@ tasks.register<Test>("testDebugCompose") {
     reports.junitXml.outputLocation.set(
         layout.buildDirectory.dir("test-results/testDebugCompose"),
     )
+}
+
+// Wire testClassesDirs and classpath after AGP has fully configured testDebugUnitTest.
+// Using afterEvaluate guarantees all AGP afterEvaluate blocks have run first, so the
+// base task's FileCollections are fully populated before we copy the references.
+afterEvaluate {
+    val base = tasks.named<Test>("testDebugUnitTest")
+    tasks.named<Test>("testDebugCompose").configure {
+        testClassesDirs = base.get().testClassesDirs
+        classpath = base.get().classpath
+    }
 }
 // testDebugCompose is intentionally NOT wired into the `check` lifecycle so it
 // cannot accidentally block existing CI pipelines.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -352,7 +352,7 @@ tasks.register<Test>("testDebugCompose") {
 afterEvaluate {
     val base = tasks.named<Test>("testDebugUnitTest").get()
     val compose = tasks.named<Test>("testDebugCompose").get()
-    compose.testClassesDirs = base.testClassesDirs
+    compose.testClassesDirs.setFrom(base.testClassesDirs)
     compose.classpath = base.classpath
 }
 // testDebugCompose is intentionally NOT wired into the `check` lifecycle so it

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -327,12 +327,21 @@ tasks.named<Test>("testDebugUnitTest") {
     exclude("**/*ComposeTest.class")
 }
 
+// Lazy provider for testDebugUnitTest — resolved only when testDebugCompose is realized.
+// Avoids afterEvaluate (incompatible with org.gradle.configuration-cache=true in Gradle 8.x).
+val unitTestProvider: TaskProvider<Test> = tasks.named<Test>("testDebugUnitTest")
+
 tasks.register<Test>("testDebugCompose") {
     description = "Runs Robolectric/Compose UI tests (*ComposeTest classes only)."
     group = "verification"
 
     include("**/*ComposeTest.class")
     useJUnit()
+
+    // Wire classpath/testClassesDirs via lazy providers so this is configuration-cache safe.
+    // setFrom() accepts Provider<*> — Gradle resolves it at task-graph execution time.
+    testClassesDirs.setFrom(unitTestProvider.map { it.testClassesDirs })
+    classpath = files(unitTestProvider.map { it.classpath })
 
     // Depend only on compilation — not on testDebugUnitTest itself so running
     // testDebugCompose does NOT also execute the full unit-test suite.
@@ -344,19 +353,6 @@ tasks.register<Test>("testDebugCompose") {
     reports.junitXml.outputLocation.set(
         layout.buildDirectory.dir("test-results/testDebugCompose"),
     )
-}
-
-// Wire testClassesDirs and classpath after AGP has fully configured testDebugUnitTest.
-// Using afterEvaluate guarantees all AGP afterEvaluate blocks have run first, so the
-// base task's FileCollections are fully populated before we copy the references.
-//
-// Both properties use setFrom() — the correct Gradle 8.x API for mutating a
-// ConfigurableFileCollection without replacing the collection object itself.
-afterEvaluate {
-    val base = tasks.findByName("testDebugUnitTest") as? Test ?: return@afterEvaluate
-    val compose = tasks.findByName("testDebugCompose") as? Test ?: return@afterEvaluate
-    compose.testClassesDirs.setFrom(base.testClassesDirs)
-    compose.classpath = base.classpath
 }
 // testDebugCompose is intentionally NOT wired into the `check` lifecycle so it
 // cannot accidentally block existing CI pipelines.

--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -77,8 +77,12 @@ class MainActivity : ComponentActivity() {
             elapsed < 700L && !backendReady
         }
 
-        // Log the app_open event on every cold start.
-        analyticsHelper.logEvent(AnalyticsHelper.EVENT_APP_OPEN)
+        // Log app_open only on a genuine cold start, not on Activity recreations
+        // triggered by locale changes (AppCompatDelegate.setApplicationLocales recreates
+        // the Activity on SDK < 33), rotation, or other config changes.
+        if (savedInstanceState == null) {
+            analyticsHelper.logEvent(AnalyticsHelper.EVENT_APP_OPEN)
+        }
 
         setContent {
             val viewModel: ChatViewModel = hiltViewModel()

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/VersesPanel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/VersesPanel.kt
@@ -137,6 +137,7 @@ internal const val DEFAULT_SHOW_REFERENCED: Boolean = true
  * Extracted from [VersesPanel] so Compose UI tests can mount this directly
  * without needing a [ModalBottomSheet] (which has Robolectric rendering caveats).
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun VersesPanelContent(
     allVerses: List<Verse>,

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/VersesPanel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/VersesPanel.kt
@@ -126,10 +126,109 @@ internal fun referencedVerses(
 }
 
 /**
+ * Default value for the "Referenced" / "All Related" segment control.
+ * Extracted as a constant so JVM unit tests and Compose UI tests can assert
+ * the expected default without rendering the full composable (BITB-034).
+ */
+internal const val DEFAULT_SHOW_REFERENCED: Boolean = true
+
+/**
+ * The scrollable body of the verses panel — title, segment control, verse list.
+ * Extracted from [VersesPanel] so Compose UI tests can mount this directly
+ * without needing a [ModalBottomSheet] (which has Robolectric rendering caveats).
+ */
+@Composable
+internal fun VersesPanelContent(
+    allVerses: List<Verse>,
+    messages: List<Message>,
+    chapterSheetState: ChapterSheetState,
+    preferredTranslation: String?,
+    onLoadChapter: (book: String, chapter: Int, translation: String?) -> Unit,
+    onDismissSheet: () -> Unit,
+    localizedToEnglish: Map<String, String> = emptyMap(),
+) {
+    var showReferenced by rememberSaveable { mutableStateOf(DEFAULT_SHOW_REFERENCED) }
+
+    val displayedVerses = if (showReferenced) {
+        referencedVerses(allVerses, messages, localizedToEnglish)
+    } else {
+        allVerses
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+            .padding(horizontal = 16.dp),
+    ) {
+        // Title row
+        Text(
+            text = stringResource(R.string.verses_panel_title),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        // Segment control — "Cited" | "All Related (N)"
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilterChip(
+                selected = showReferenced,
+                onClick = { showReferenced = true },
+                label = { Text(stringResource(R.string.verses_filter_referenced)) },
+            )
+            FilterChip(
+                selected = !showReferenced,
+                onClick = { showReferenced = false },
+                label = {
+                    Text(
+                        stringResource(
+                            R.string.verses_filter_all_related,
+                            allVerses.size,
+                        ),
+                    )
+                },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(4.dp))
+
+        if (displayedVerses.isEmpty()) {
+            Text(
+                text = stringResource(R.string.verses_panel_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 16.dp),
+            )
+        } else {
+            LazyColumn(
+                contentPadding = PaddingValues(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                items(displayedVerses, key = { "${it.book}${it.chapter}:${it.verse}" }) { verse ->
+                    VerseChip(
+                        verse = verse,
+                        preferredTranslation = preferredTranslation,
+                        chapterState = chapterSheetState,
+                        onLoadChapter = onLoadChapter,
+                        onDismissSheet = onDismissSheet,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
  * A `ModalBottomSheet` displaying all verses referenced in the current conversation.
  *
- * Provides a "Referenced" / "All Related" segment control:
- * - **Referenced**: only verses explicitly cited in assistant message text.
+ * Provides a "Cited" / "All Related" segment control:
+ * - **Cited**: only verses explicitly cited in assistant message text.
  * - **All Related**: every verse returned by the backend across all messages.
  *
  * @param allVerses            All unique verses across finished assistant messages.
@@ -156,84 +255,18 @@ fun VersesPanel(
     localizedToEnglish: Map<String, String> = emptyMap(),
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
-    var showReferenced by rememberSaveable { mutableStateOf(true) }
-
-    val displayedVerses = if (showReferenced) {
-        referencedVerses(allVerses, messages, localizedToEnglish)
-    } else {
-        allVerses
-    }
-
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .padding(horizontal = 16.dp),
-        ) {
-            // Title row
-            Text(
-                text = stringResource(R.string.verses_panel_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(bottom = 12.dp),
-            )
-
-            // Segment control — "Referenced" | "All Related (N)"
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                FilterChip(
-                    selected = showReferenced,
-                    onClick = { showReferenced = true },
-                    label = { Text(stringResource(R.string.verses_filter_referenced)) },
-                )
-                FilterChip(
-                    selected = !showReferenced,
-                    onClick = { showReferenced = false },
-                    label = {
-                        Text(
-                            stringResource(
-                                R.string.verses_filter_all_related,
-                                allVerses.size,
-                            ),
-                        )
-                    },
-                )
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(4.dp))
-
-            if (displayedVerses.isEmpty()) {
-                Text(
-                    text = stringResource(R.string.verses_panel_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(vertical = 16.dp),
-                )
-            } else {
-                LazyColumn(
-                    contentPadding = PaddingValues(vertical = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    items(displayedVerses, key = { "${it.book}${it.chapter}:${it.verse}" }) { verse ->
-                        VerseChip(
-                            verse = verse,
-                            preferredTranslation = preferredTranslation,
-                            chapterState = chapterSheetState,
-                            onLoadChapter = onLoadChapter,
-                            onDismissSheet = onDismissSheet,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                }
-            }
-        }
+        VersesPanelContent(
+            allVerses = allVerses,
+            messages = messages,
+            chapterSheetState = chapterSheetState,
+            preferredTranslation = preferredTranslation,
+            onLoadChapter = onLoadChapter,
+            onDismissSheet = onDismissSheet,
+            localizedToEnglish = localizedToEnglish,
+        )
     }
 }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -665,13 +665,19 @@ class ChatViewModel @Inject constructor(
      * Updates the language locale in-memory, persists it via DataStore, and applies
      * it system-wide so every stringResource() reflects the new locale after the
      * Activity recreate that AppCompatDelegate.setApplicationLocales triggers.
+     *
+     * Persistence must complete before localeApplier.apply() triggers recreation.
+     * If apply() fires first, the init-block languageFlow collector sees the old
+     * DataStore value and overwrites _uiState back to the previous locale for the
+     * duration of the recreation window, causing a visible revert to the old language.
      */
     fun setLocale(locale: String) {
+        if (locale == _uiState.value.currentLocale) return
         Timber.tag("VoxLocale").i("ChatViewModel.setLocale(%s) called", locale)
         _uiState.update { it.copy(currentLocale = locale) }
-        localeApplier.apply(locale)
         viewModelScope.launch {
             languagePreferences.setLanguage(locale)
+            localeApplier.apply(locale)
         }
     }
 

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VersesPanelDefaultsTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VersesPanelDefaultsTest.kt
@@ -1,0 +1,21 @@
+package org.voxquieta.app.components
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.voxquieta.app.presentation.components.DEFAULT_SHOW_REFERENCED
+
+/**
+ * Guard test for BITB-034. Asserts the default filter constant so that any future
+ * refactor that flips the default from "Cited" to "All Related" is caught by CI
+ * immediately, without requiring the Compose runtime.
+ */
+class VersesPanelDefaultsTest {
+
+    @Test
+    fun `DEFAULT_SHOW_REFERENCED is true so the panel opens on the Cited filter`() {
+        assertTrue(
+            "VersesPanel must open on the 'Cited' filter by default (DEFAULT_SHOW_REFERENCED)",
+            DEFAULT_SHOW_REFERENCED,
+        )
+    }
+}

--- a/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/VersesPanelComposeTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/VersesPanelComposeTest.kt
@@ -1,0 +1,106 @@
+package org.voxquieta.app.presentation.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Test
+import org.voxquieta.app.domain.models.Message
+import org.voxquieta.app.domain.models.Verse
+import org.voxquieta.app.presentation.viewmodels.ChapterSheetState
+import org.voxquieta.app.testing.ComposeTestHarness
+import java.util.UUID
+
+/**
+ * Robolectric-backed Compose UI tests for [VersesPanelContent] (BITB-034).
+ *
+ * These run under the dedicated `testDebugCompose` Gradle task and the separate
+ * `android-compose-tests.yml` workflow. They are NOT part of the required
+ * `unit-tests` CI lane so they cannot block releases while the harness stabilises.
+ *
+ * See also: [VersesPanelDefaultsTest] — a plain JVM test that asserts
+ * [DEFAULT_SHOW_REFERENCED] without needing the Compose runtime.
+ */
+class VersesPanelComposeTest : ComposeTestHarness() {
+
+    private fun verse(book: String, chapter: Int, verseNum: Int) = Verse(
+        book = book,
+        chapter = chapter,
+        verse = verseNum,
+        text = "Sample text for $book $chapter:$verseNum",
+        translation = "kjv",
+    )
+
+    private fun assistantMsg(content: String) = Message(
+        id = UUID.randomUUID().toString(),
+        role = Message.Role.ASSISTANT,
+        content = content,
+    )
+
+    private fun mountPanel(
+        allVerses: List<Verse>,
+        messages: List<Message>,
+    ) = setContentThemed {
+        VersesPanelContent(
+            allVerses = allVerses,
+            messages = messages,
+            chapterSheetState = ChapterSheetState.Idle,
+            preferredTranslation = "kjv",
+            onLoadChapter = { _, _, _ -> },
+            onDismissSheet = {},
+        )
+    }
+
+    // 1. Default filter is "Cited" — guards DEFAULT_SHOW_REFERENCED = true
+    @Test
+    fun `panel opens with Cited filter selected by default`() {
+        mountPanel(
+            allVerses = listOf(verse("John", 3, 16)),
+            messages = listOf(assistantMsg("See John 3:16 for hope.")),
+        )
+
+        composeRule.onNodeWithText("Cited").assertIsSelected()
+        composeRule.onNodeWithText("All Related (1)").assertIsNotSelected()
+    }
+
+    // 2. Empty state shown when no cited verses match
+    @Test
+    fun `empty state shown when no verses match the Cited filter`() {
+        mountPanel(
+            allVerses = listOf(verse("John", 3, 16)),
+            // Assistant message does not cite any verse → Referenced list is empty
+            messages = listOf(assistantMsg("Reflect on the love of God.")),
+        )
+
+        composeRule.onNodeWithText("No verses found for this filter.").assertIsDisplayed()
+    }
+
+    // 3. Clicking "All Related" reveals all backend verses
+    @Test
+    fun `toggling to All Related shows every verse`() {
+        val john = verse("John", 3, 16)
+        val psalm = verse("Psalms", 23, 1)
+        mountPanel(
+            allVerses = listOf(john, psalm),
+            // Only John is cited; Psalms is in the backend response but not cited
+            messages = listOf(assistantMsg("See John 3:16 for hope.")),
+        )
+
+        composeRule.onNodeWithText("All Related (2)").performClick()
+
+        composeRule.onNodeWithText("All Related (2)").assertIsSelected()
+        composeRule.onNodeWithText("Cited").assertIsNotSelected()
+        // Both verse refs are visible in "All Related" mode
+        composeRule.onNodeWithText("John 3:16").assertIsDisplayed()
+        composeRule.onNodeWithText("Psalms 23:1").assertIsDisplayed()
+    }
+
+    // 4. Panel title is rendered (smoke test confirming the composable mounts)
+    @Test
+    fun `panel title Related Verses is displayed`() {
+        mountPanel(allVerses = emptyList(), messages = emptyList())
+
+        composeRule.onNodeWithText("Related Verses").assertIsDisplayed()
+    }
+}

--- a/android/app/src/test/kotlin/org/voxquieta/app/testing/ComposeTestHarness.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/testing/ComposeTestHarness.kt
@@ -1,0 +1,45 @@
+package org.voxquieta.app.testing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.voxquieta.app.presentation.theme.VoxQuietaTheme
+
+/**
+ * Base class for Robolectric-backed Compose UI tests (BITB-034).
+ *
+ * Subclasses inherit [composeRule] and the [setContentThemed] helper that
+ * wraps the content under [VoxQuietaTheme] — matching the production
+ * theme wiring so MaterialTheme tokens resolve correctly.
+ *
+ * Config notes:
+ * - [RobolectricTestRunner] provides a real Android [android.content.Context]
+ *   without requiring an emulator.
+ * - [Config.sdk] pinned to API 34 — Robolectric 4.14.1 bundles API-34 jars;
+ *   compileSdk 35 behaviours must be covered by instrumented tests.
+ * - [Config.application] set to the plain [android.app.Application] to keep
+ *   Hilt out of unit-test scope; composable-only tests don't need DI.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    sdk = [34],
+    application = android.app.Application::class,
+)
+abstract class ComposeTestHarness {
+
+    @get:Rule
+    val composeRule: ComposeContentTestRule = createComposeRule()
+
+    /** Mounts [content] wrapped in [VoxQuietaTheme]. */
+    protected fun setContentThemed(content: @Composable () -> Unit) {
+        composeRule.setContent {
+            VoxQuietaTheme {
+                content()
+            }
+        }
+    }
+}

--- a/android/dependency-check-suppressions.xml
+++ b/android/dependency-check-suppressions.xml
@@ -540,6 +540,63 @@
     <cvssBelow>10</cvssBelow>
   </suppress>
 
+  <suppress>
+    <notes>False positive / test-only: org.conscrypt:conscrypt-openjdk-uber.
+      Conscrypt is a Robolectric transitive dependency providing TLS support for
+      the simulated Android environment. testImplementation only, NOT shipped in the APK.
+      CVEs in conscrypt-openjdk-uber do not affect Android end users.
+    </notes>
+    <packageUrl regex="true">pkg:maven/org\.conscrypt/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: com.ibm.icu:icu4j.
+      ICU4J is a Robolectric transitive dependency for Unicode/locale support in the
+      simulated Android environment. testImplementation only, NOT shipped in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/com\.ibm\.icu/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: net.java.dev.jna and net.java.dev.jna:jna-platform.
+      JNA (Java Native Access) is a Robolectric transitive dependency used for
+      native interop in the test environment. testImplementation only, NOT in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/net\.java\.dev\.jna/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: com.almworks.sqlite4java artifacts.
+      sqlite4java is a Robolectric transitive dependency providing SQLite access for
+      the Android test environment. testImplementation only, NOT shipped in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/com\.almworks\.sqlite4java/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: org.xerial:sqlite-jdbc.
+      SQLite JDBC is used by OWASP Dependency Check itself (build-time scanning tool)
+      and may also be a Robolectric transitive dep. NOT shipped in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/org\.xerial/sqlite-jdbc.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: org.xerial.snappy:snappy-java.
+      snappy-java is a compression library used by build-time tools (e.g. Gradle
+      caching, Robolectric transitive deps). NOT shipped in the APK.
+      CVE-2023-34455 (CVSS 7.5) and similar are for the server-side snappy compression
+      library, not applicable to Android client apps.
+    </notes>
+    <packageUrl regex="true">pkg:maven/org\.xerial\.snappy/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
   <!--
     ============================================================
     Build-time-only Gradle plugin dependencies (NOT in the APK)

--- a/android/dependency-check-suppressions.xml
+++ b/android/dependency-check-suppressions.xml
@@ -483,6 +483,65 @@
 
   <!--
     ============================================================
+    Robolectric test framework (BITB-034) — test-only, NOT in APK
+    ============================================================
+
+    org.robolectric:robolectric and its entire transitive dependency tree are
+    declared as testImplementation only. None of these JARs are packaged into
+    the release APK or shipped to end users.
+
+    The OWASP CLI scans the full Gradle module cache (~/.gradle/caches/modules-2/
+    files-2.1/) which includes test-scoped artifacts downloaded by prior CI jobs.
+    All CVEs flagged against these JARs are therefore inapplicable to the
+    shipped application. We suppress by packageUrl so new Robolectric releases
+    don't require individual CVE entries.
+
+    Notable transitive artifacts covered:
+      org.robolectric:robolectric, android-all, android-all-instrumented,
+        shadows-*, nativeruntime, utils, sandbox, pluginapi, resources
+      com.google.android.apps.common.testing.accessibility.framework:*
+      net.bytebuddy:byte-buddy (ASM-based bytecode generation)
+      org.ow2.asm:asm* (bytecode manipulation, used by Robolectric shadow weaving)
+  -->
+  <suppress>
+    <notes>False positive / test-only: org.robolectric artifacts (all modules).
+      Robolectric is a testImplementation dependency that is NOT shipped in the APK.
+      CVEs in any org.robolectric JAR do not affect end users.
+      cvssBelow:10 suppresses all CVE matches.
+    </notes>
+    <packageUrl regex="true">pkg:maven/org\.robolectric/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: com.google.android.apps.common.testing.accessibility.framework
+      accessibility-test-framework is pulled in by Robolectric as a test-only transitive dep.
+      NOT shipped in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/com\.google\.android\.apps\.common\.testing\.accessibility\.framework/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: net.bytebuddy artifacts.
+      ByteBuddy is a transitive dep of Robolectric / Mockito used only in tests.
+      NOT shipped in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/net\.bytebuddy/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <suppress>
+    <notes>False positive / test-only: org.ow2.asm artifacts.
+      OW2 ASM is a bytecode-manipulation library used by Robolectric for shadow
+      class weaving. testImplementation only, NOT shipped in the APK.
+    </notes>
+    <packageUrl regex="true">pkg:maven/org\.ow2\.asm/.*</packageUrl>
+    <cvssBelow>10</cvssBelow>
+  </suppress>
+
+  <!--
+    ============================================================
     Build-time-only Gradle plugin dependencies (NOT in the APK)
     ============================================================
   -->

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ hiltTesting = "2.51.1"          # same as hilt version
 androidxTestRunner = "1.6.2"
 composeMarkdown = "0.5.0"
 appcompat = "1.7.0"
+robolectric = "4.14.1"
 
 [libraries]
 # AndroidX Core
@@ -102,6 +103,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hiltTesting" }
 hilt-android-compiler-test = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltTesting" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/api/providers/llama_guard.py
+++ b/api/providers/llama_guard.py
@@ -19,6 +19,7 @@ import httpx
 
 from config import settings
 from providers.azure_content_safety import ContentSafetyResult
+from utils.circuit_breaker import CircuitBreaker, CircuitOpenError
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,14 @@ class LlamaGuardProvider:
         self.api_key = api_key
         self.threshold = threshold  # unused but kept for interface consistency
         self.timeout = timeout
+        # Trip after 5 consecutive failures; cooldown 30s. When open,
+        # analyze_text() raises CircuitOpenError immediately so callers can
+        # fall back to the keyword filter without paying the 10s timeout.
+        self._breaker = CircuitBreaker(
+            name="llama_guard",
+            failure_threshold=5,
+            cooldown_seconds=30.0,
+        )
 
     def _parse_llama_guard_response(self, response_text: str) -> tuple[bool, list[str]]:
         """
@@ -192,10 +201,14 @@ class LlamaGuardProvider:
             ContentSafetyResult with decision
 
         Raises:
+            CircuitOpenError: If breaker is open (caller should use fallback immediately)
             httpx.HTTPError: If API call fails
             httpx.TimeoutException: If API call times out
         """
         text_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
+
+        if self._breaker.is_open():
+            raise CircuitOpenError("llama_guard circuit breaker open")
 
         # Format prompt with user message
         prompt = LLAMA_GUARD_PROMPT.format(user_message=text[:2000])
@@ -237,10 +250,12 @@ class LlamaGuardProvider:
                 # Parse response
                 is_safe, violated_categories = self._parse_llama_guard_response(response_text)
 
+                self._breaker.record_success()
                 # Map to result
                 return self._map_categories_to_result(is_safe, violated_categories, text_hash)
 
         except httpx.TimeoutException:
+            self._breaker.record_failure()
             logger.warning(
                 "Llama Guard API timeout",
                 extra={"text_hash": text_hash, "timeout": self.timeout},
@@ -248,7 +263,11 @@ class LlamaGuardProvider:
             raise
 
         except httpx.HTTPError as e:
-            logger.error(
+            self._breaker.record_failure()
+            # Demoted from ERROR to WARNING: the caller has a keyword fallback,
+            # so a transient HTTP failure is not by itself an alertable error.
+            # The metric counter in content_safety.py is the alert signal.
+            logger.warning(
                 "Llama Guard API error",
                 extra={
                     "text_hash": text_hash,

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -4,11 +4,13 @@ OpenRouter provides access to various LLMs including free models via an OpenAI-c
 """
 
 import time
-from typing import AsyncIterator, cast
+from typing import Any, AsyncIterator, cast
 
-from openai import APIStatusError, AsyncOpenAI, RateLimitError
+import httpx
+from openai import APIStatusError, APITimeoutError, AsyncOpenAI, RateLimitError
 from openai.types.chat import ChatCompletionChunk
 
+from utils.circuit_breaker import CircuitBreaker
 from utils.logging_config import get_logger
 from utils.metrics import (
     llm_fallback_counter,
@@ -16,11 +18,36 @@ from utils.metrics import (
     llm_tokens_per_second_histogram,
     llm_total_duration_histogram,
     llm_ttft_histogram,
+    openrouter_fallback_counter,
 )
 
 from .base import ChatMessage, LLMProvider, LLMResponse
 
 logger = get_logger(__name__)
+
+
+class _BreakerOpenError(Exception):
+    """Sentinel: circuit breaker tripped, do not call the primary model."""
+
+
+def _classify_failure(e: Exception) -> str:
+    """Categorize a failure for metric labelling."""
+    if isinstance(e, _BreakerOpenError):
+        return "breaker_open"
+    if isinstance(e, RateLimitError):
+        return "rate_limit"
+    if isinstance(e, (APITimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    if isinstance(e, APIStatusError):
+        status = getattr(e, "status_code", None)
+        if status == 404:
+            return "model_404"
+        if status == 503:
+            return "upstream_503"
+        if status == 429:
+            return "rate_limit"
+        return f"api_status_{status}"
+    return "other"
 
 
 class OpenRouterProvider(LLMProvider):
@@ -59,11 +86,22 @@ class OpenRouterProvider(LLMProvider):
         self.fallback_models = fallback_models or []
         self.allow_fallbacks = allow_fallbacks
         self.preferred_min_throughput_p50 = preferred_min_throughput_p50
-        # Disable SDK auto-retry for rate limits - we handle fallbacks ourselves
+        # Explicit timeouts so we never hang on a stuck upstream.
+        # connect 5s catches DNS/TCP issues fast; read 60s is generous enough
+        # for streaming first-token latency on slower free-tier models.
         self._client = AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
-            max_retries=0,
+            timeout=httpx.Timeout(60.0, connect=5.0),
+            max_retries=2,
+        )
+        # Breaker trips after 5 consecutive primary-model failures within the
+        # cooldown window. When open, chat()/chat_stream() jump straight to
+        # the fallback list instead of paying the primary-call timeout.
+        self._breaker = CircuitBreaker(
+            name="openrouter_primary",
+            failure_threshold=5,
+            cooldown_seconds=30.0,
         )
         logger.info(
             f"OpenRouterProvider initialized: model={model}, "
@@ -154,13 +192,16 @@ class OpenRouterProvider(LLMProvider):
             if "no model" in error_msg or "model not found" in error_msg:
                 logger.warning(f"Model unavailable error: {e}")
                 return True
+        if isinstance(e, (APITimeoutError, httpx.TimeoutException)):
+            logger.warning(f"OpenRouter primary call timed out: {e}")
+            return True
         return False
 
     def _should_try_fallback(self, e: Exception) -> bool:
         """Check if we should try fallback models for this error."""
         return self._is_rate_limit_error(e) or self._is_model_unavailable_error(e)
 
-    async def chat(
+    async def chat(  # noqa: C901
         self,
         messages: list[ChatMessage],
         temperature: float = 0.7,
@@ -183,7 +224,19 @@ class OpenRouterProvider(LLMProvider):
         else:
             model_to_use, extra_body = self._get_model_and_extra_body()
 
+        # If the breaker is open, skip the primary call entirely and jump
+        # straight to the fallback list. This trades fidelity for not paying
+        # the primary timeout on every request during a sustained outage.
+        breaker_skip_primary = (
+            self._breaker.is_open()
+            and self.fallback_models
+            and self.allow_fallbacks
+            and not model_override
+        )
+
         try:
+            if breaker_skip_primary:
+                raise _BreakerOpenError()
             response = await self._client.chat.completions.create(
                 model=model_to_use,
                 messages=converted_messages,  # type: ignore[arg-type]
@@ -191,9 +244,12 @@ class OpenRouterProvider(LLMProvider):
                 max_tokens=max_tokens,
                 extra_body=extra_body,
             )
-        except (RateLimitError, APIStatusError) as e:
+            self._breaker.record_success()
+        except (RateLimitError, APIStatusError, APITimeoutError, _BreakerOpenError) as e:
             # Client-side fallback as safety net (most cases handled by OpenRouter server-side)
-            should_fallback = self._should_try_fallback(e)
+            should_fallback = isinstance(e, _BreakerOpenError) or self._should_try_fallback(e)
+            if not isinstance(e, _BreakerOpenError):
+                self._breaker.record_failure()
 
             if (
                 should_fallback
@@ -201,9 +257,17 @@ class OpenRouterProvider(LLMProvider):
                 and self.allow_fallbacks
                 and not model_override
             ):
-                logger.warning(
-                    f"Server-side routing failed, trying client-side fallback. "
-                    f"Model={model_to_use}, Error: {e}"
+                if not isinstance(e, _BreakerOpenError):
+                    logger.warning(
+                        f"Server-side routing failed, trying client-side fallback. "
+                        f"Model={model_to_use}, Error: {e}"
+                    )
+                openrouter_fallback_counter.add(
+                    1,
+                    {
+                        "reason": _classify_failure(e),
+                        "stream": "false",
+                    },
                 )
                 for fallback_model in self.fallback_models:
                     try:
@@ -214,6 +278,8 @@ class OpenRouterProvider(LLMProvider):
                             temperature=temperature,
                             max_tokens=max_tokens,
                         )
+                        # Fallback success path — keep at INFO, not ERROR, so
+                        # the log-based alert doesn't fire on every hiccup.
                         logger.info(f"Client-side fallback to {fallback_model} succeeded")
                         # Return response with the fallback model name
                         content = response.choices[0].message.content or ""
@@ -232,14 +298,24 @@ class OpenRouterProvider(LLMProvider):
                             f"Client-side fallback {fallback_model} failed: {fallback_error}"
                         )
                         continue
-                # All fallbacks exhausted
+                # All fallbacks exhausted — this *is* an error condition
+                logger.error(
+                    "All OpenRouter models unavailable. primary=%s fallbacks=%s",
+                    self.model,
+                    self.fallback_models,
+                )
                 raise RuntimeError(
                     "All models unavailable or rate limited. "
                     f"Primary: {self.model}, "
                     f"Fallbacks: {self.fallback_models}. "
                     "Check model names at https://openrouter.ai/models"
-                ) from e
+                ) from (e if not isinstance(e, _BreakerOpenError) else None)
             else:
+                if isinstance(e, _BreakerOpenError):
+                    # Breaker open but no fallbacks available — surface as a clear error
+                    raise RuntimeError(
+                        "OpenRouter circuit breaker open and no fallback models configured"
+                    )
                 # No fallbacks configured or not a recoverable error
                 raise
 
@@ -315,6 +391,19 @@ class OpenRouterProvider(LLMProvider):
         current_model = model_to_use
         fallback_index = 0
 
+        # If the breaker is open, skip primary and start at first fallback.
+        if (
+            self._breaker.is_open()
+            and self.fallback_models
+            and self.allow_fallbacks
+            and not model_override
+        ):
+            logger.info("OpenRouter breaker open; skipping primary, starting at first fallback")
+            current_model = self.fallback_models[0]
+            fallback_index = 1
+            extra_body = None
+            openrouter_fallback_counter.add(1, {"reason": "breaker_open", "stream": "true"})
+
         while True:
             try:
                 stream = cast(
@@ -358,18 +447,26 @@ class OpenRouterProvider(LLMProvider):
                     )
                 if used_fallback:
                     llm_fallback_counter.add(1, {"provider": "openrouter", "model": current_model})
+                # Successful stream — primary succeeded (or we recovered) → reset breaker.
+                if current_model == model_to_use:
+                    self._breaker.record_success()
 
                 return  # Success, exit the generator
 
-            except (RateLimitError, APIStatusError) as e:
+            except (RateLimitError, APIStatusError, APITimeoutError) as e:
                 # Client-side fallback as safety net (most cases handled by OpenRouter server-side)
                 should_fallback = self._should_try_fallback(e)
+                if current_model == model_to_use:
+                    self._breaker.record_failure()
 
                 if not should_fallback:
                     # Not a recoverable error, re-raise
                     raise
 
                 logger.warning(f"Server-side routing failed in streaming: {e}")
+                openrouter_fallback_counter.add(
+                    1, {"reason": _classify_failure(e), "stream": "true"}
+                )
 
                 # Try next fallback model
                 if (
@@ -384,7 +481,12 @@ class OpenRouterProvider(LLMProvider):
                     logger.info(f"Client-side streaming fallback to: {current_model}")
                     continue
                 else:
-                    # No more fallbacks
+                    # No more fallbacks — this is a real failure
+                    logger.error(
+                        "All OpenRouter streaming models unavailable. tried=%s,%s",
+                        model_to_use,
+                        self.fallback_models[:fallback_index],
+                    )
                     raise RuntimeError(
                         "All models unavailable in streaming. "
                         f"Tried: {model_to_use}, {self.fallback_models[:fallback_index]}. "
@@ -448,6 +550,21 @@ class OpenRouterProvider(LLMProvider):
         Note: This makes a minimal API call to verify connectivity.
         Uses native models array with provider preferences if configured.
         """
+        result = await self.health_check_detailed()
+        return result["healthy"]
+
+    async def health_check_detailed(self) -> dict[str, Any]:
+        """
+        Structured health check — distinguishes 404 (model gone) from
+        timeout / network failure, so /health/ready can surface the cause.
+        """
+        # Breaker state is itself a useful signal.
+        if self._breaker.is_open():
+            return {
+                "healthy": False,
+                "reason": "breaker_open",
+                "breaker_state": self._breaker.state,
+            }
         try:
             model_to_use, extra_body = self._get_model_and_extra_body()
             response = await self._client.chat.completions.create(
@@ -456,9 +573,18 @@ class OpenRouterProvider(LLMProvider):
                 max_tokens=10,
                 extra_body=extra_body,
             )
-            return response is not None
-        except Exception:
-            return False
+            return {
+                "healthy": response is not None,
+                "reason": "ok" if response is not None else "empty_response",
+                "breaker_state": self._breaker.state,
+            }
+        except Exception as e:
+            return {
+                "healthy": False,
+                "reason": _classify_failure(e),
+                "breaker_state": self._breaker.state,
+                "error": str(e),
+            }
 
     async def close(self) -> None:
         """Close the OpenAI HTTP client."""

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -254,23 +254,47 @@ async def readiness_probe():
     """
     Readiness probe for Kubernetes/orchestration.
 
-    Returns 200 if the app can serve requests (dependencies are available).
-    Returns 503 if critical dependencies are unavailable.
+    Returns 200 if the app can serve requests, 503 only if critical
+    dependencies are unavailable.
 
-    Use this for traffic routing - if this fails, stop sending traffic.
+    Lenient by design: returns 200 when LLM **or** embedding is unhealthy
+    (single-dependency degradation should not bounce the pod). Returns 503
+    only when the database is unhealthy, or when **both** LLM and embedding
+    are down. The response body always lists each dependency's state so
+    Azure can scrape it for dependency-failure alerts (in addition to the
+    metric-based alerts on `llama_guard_fallback_total` /
+    `openrouter_fallback_total`).
     """
-    # Only check database for readiness - it's the critical dependency
-    # LLM/Embedding can fail gracefully
-    db_health = await check_database_health()
+    db_health, llm_health, embedding_health = await asyncio.gather(
+        check_database_health(),
+        check_llm_health(),
+        check_embedding_health(),
+    )
 
-    if db_health.status == "unhealthy":
+    dependencies = {
+        "database": db_health.status,
+        "llm": llm_health.status,
+        "embedding": embedding_health.status,
+    }
+
+    db_down = db_health.status == "unhealthy"
+    both_inference_down = (
+        llm_health.status == "unhealthy" and embedding_health.status == "unhealthy"
+    )
+
+    if db_down or both_inference_down:
         return JSONResponse(
             status_code=503,
             content={
                 "status": "not_ready",
-                "reason": "database_unavailable",
-                "error": db_health.error,
+                "reason": "database_unavailable" if db_down else "inference_unavailable",
+                "dependencies": dependencies,
+                "error": db_health.error if db_down else None,
             },
         )
 
-    return {"status": "ready", "database_latency_ms": db_health.latency_ms}
+    return {
+        "status": "ready",
+        "database_latency_ms": db_health.latency_ms,
+        "dependencies": dependencies,
+    }

--- a/api/tests/test_providers.py
+++ b/api/tests/test_providers.py
@@ -384,3 +384,127 @@ def test_openrouter_should_try_fallback():
         body={},
     )
     assert provider._should_try_fallback(rate_error) is True
+
+
+# ── Post-incident hardening tests (2026-05-15) ────────────────────────────
+
+
+def test_circuit_breaker_opens_after_threshold():
+    """Breaker should open after N consecutive failures and short-circuit calls."""
+    from utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(name="test", failure_threshold=3, cooldown_seconds=60.0)
+    assert cb.is_open() is False
+    for _ in range(2):
+        cb.record_failure()
+    assert cb.is_open() is False  # not yet at threshold
+    cb.record_failure()
+    assert cb.is_open() is True
+    # Success after cooldown closes the breaker
+    cb._opened_at -= 120.0  # simulate cooldown elapsed
+    assert cb.is_open() is False  # transitions to half-open
+    cb.record_success()
+    assert cb.state == "closed"
+
+
+def test_circuit_breaker_half_open_failure_reopens():
+    from utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(name="test2", failure_threshold=1, cooldown_seconds=60.0)
+    cb.record_failure()
+    assert cb.state == "open"
+    cb._opened_at -= 120.0
+    cb.is_open()  # transitions to half-open
+    assert cb.state == "half_open"
+    cb.record_failure()
+    assert cb.state == "open"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_fallback_on_404_no_error_log(caplog):
+    """When primary returns 404 and a fallback succeeds, no ERROR-level log fires."""
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    from openai import APIStatusError
+
+    provider = OpenRouterProvider(
+        api_key="sk-or-v1-test-key",  # pragma: allowlist secret
+        model="primary-model",
+        fallback_models=["fallback-1"],
+    )
+
+    mock_response_404 = MagicMock()
+    mock_response_404.status_code = 404
+    mock_response_404.headers = {}
+    err = APIStatusError(message="Not found", response=mock_response_404, body={})
+
+    # Successful fallback response
+    success_response = MagicMock()
+    success_response.choices = [MagicMock()]
+    success_response.choices[0].message.content = "hello"
+    success_response.choices[0].finish_reason = "stop"
+    success_response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+    success_response.model = "fallback-1"
+
+    provider._client.chat.completions.create = AsyncMock(side_effect=[err, success_response])
+
+    from providers.base import ChatMessage
+
+    with caplog.at_level(logging.WARNING):
+        result = await provider.chat([ChatMessage(role="user", content="hi")])
+
+    assert result.model == "fallback-1"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"unexpected ERROR logs: {error_records}"
+
+
+@pytest.mark.asyncio
+async def test_llama_guard_timeout_trips_breaker():
+    """Repeated Llama Guard timeouts should trip the circuit breaker."""
+    from unittest.mock import AsyncMock, patch
+
+    import httpx
+
+    from providers.llama_guard import LlamaGuardProvider
+
+    provider = LlamaGuardProvider(
+        api_key="sk-or-v1-test-key",  # pragma: allowlist secret
+        timeout=1,
+    )
+
+    # Patch the post call to always time out. provider.analyze_text creates a
+    # new AsyncClient inside an `async with`, so we patch the class method.
+    with patch.object(
+        httpx.AsyncClient,
+        "post",
+        new=AsyncMock(side_effect=httpx.TimeoutException("timed out")),
+    ):
+        for _ in range(provider._breaker.failure_threshold):
+            with pytest.raises(httpx.TimeoutException):
+                await provider.analyze_text("hello world")
+
+    assert provider._breaker.state == "open"
+
+    # Once open, the next call raises CircuitOpenError without an HTTP attempt
+    from utils.circuit_breaker import CircuitOpenError
+
+    with pytest.raises(CircuitOpenError):
+        await provider.analyze_text("hello world")
+
+
+@pytest.mark.asyncio
+async def test_content_safety_narrow_exception_handling():
+    """Non-network errors from Llama Guard must propagate, not be swallowed."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from utils.content_safety import ContentSafetyService
+
+    service = ContentSafetyService()
+
+    fake_provider = MagicMock()
+    fake_provider.analyze_text = AsyncMock(side_effect=ValueError("programmer bug"))
+    service._get_llama_guard_provider = MagicMock(return_value=fake_provider)
+
+    with pytest.raises(ValueError):
+        await service._check_stage2_llama_guard("hi", "en", 0.0)

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -318,23 +318,32 @@ class TestReadinessProbe:
     """Tests for readiness_probe endpoint."""
 
     @pytest.mark.asyncio
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
     @patch("routes.health.check_database_health")
-    async def test_ready(self, mock_db_health):
+    async def test_ready(self, mock_db_health, mock_llm_health, mock_embedding_health):
         from routes.health import ComponentHealth, readiness_probe
 
         mock_db_health.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
+        mock_llm_health.return_value = ComponentHealth(status="healthy", latency_ms=10.0)
+        mock_embedding_health.return_value = ComponentHealth(status="healthy", latency_ms=8.0)
         result = await readiness_probe()
         assert result["status"] == "ready"
         assert result["database_latency_ms"] == 5.0
+        assert result["dependencies"]["database"] == "healthy"
 
     @pytest.mark.asyncio
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
     @patch("routes.health.check_database_health")
-    async def test_not_ready(self, mock_db_health):
+    async def test_not_ready(self, mock_db_health, mock_llm_health, mock_embedding_health):
         from routes.health import ComponentHealth, readiness_probe
 
         mock_db_health.return_value = ComponentHealth(
             status="unhealthy", error="Connection refused"
         )
+        mock_llm_health.return_value = ComponentHealth(status="healthy")
+        mock_embedding_health.return_value = ComponentHealth(status="healthy")
         result = await readiness_probe()
         assert result.status_code == 503
         body = result.body

--- a/api/utils/circuit_breaker.py
+++ b/api/utils/circuit_breaker.py
@@ -1,0 +1,99 @@
+"""
+Minimal in-process circuit breaker for external API call paths.
+
+Built for two callers — OpenRouter and Llama Guard — to short-circuit
+requests when a dependency is known-down, so we skip the per-request timeout
+instead of paying it on every call during an outage.
+"""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from threading import Lock
+
+from utils.logging_config import get_logger
+from utils.metrics import circuit_breaker_state_counter
+
+logger = get_logger(__name__)
+
+
+class CircuitOpenError(Exception):
+    """Raised by callers when a breaker is open and the call is short-circuited."""
+
+
+class _State(str, Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreaker:
+    """
+    Failure-count based breaker.
+
+    - CLOSED: calls flow through; consecutive failures increment a counter.
+    - OPEN: after `failure_threshold` consecutive failures, calls are
+      short-circuited via `is_open()` until `cooldown_seconds` elapses.
+    - HALF_OPEN: the next call is allowed through as a probe; success closes
+      the breaker, failure re-opens it.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        cooldown_seconds: float = 30.0,
+    ):
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.cooldown_seconds = cooldown_seconds
+        self._state = _State.CLOSED
+        self._consecutive_failures = 0
+        self._opened_at: float = 0.0
+        self._lock = Lock()
+
+    @property
+    def state(self) -> str:
+        return self._state.value
+
+    def is_open(self) -> bool:
+        """Return True if the call should be short-circuited."""
+        with self._lock:
+            if self._state == _State.OPEN:
+                if time.monotonic() - self._opened_at >= self.cooldown_seconds:
+                    self._transition(_State.HALF_OPEN)
+                    return False
+                return True
+            return False
+
+    def record_success(self) -> None:
+        with self._lock:
+            if self._state != _State.CLOSED:
+                self._transition(_State.CLOSED)
+            self._consecutive_failures = 0
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            if self._state == _State.HALF_OPEN:
+                self._open()
+            elif self._consecutive_failures >= self.failure_threshold:
+                self._open()
+
+    def _open(self) -> None:
+        self._opened_at = time.monotonic()
+        self._transition(_State.OPEN)
+
+    def _transition(self, new_state: _State) -> None:
+        if new_state == self._state:
+            return
+        logger.info(
+            "Circuit breaker %s: %s -> %s (consecutive_failures=%d)",
+            self.name,
+            self._state.value,
+            new_state.value,
+            self._consecutive_failures,
+        )
+        circuit_breaker_state_counter.add(1, {"breaker": self.name, "to_state": new_state.value})
+        self._state = new_state

--- a/api/utils/content_safety.py
+++ b/api/utils/content_safety.py
@@ -27,11 +27,30 @@ import hashlib
 import time
 from dataclasses import dataclass, field
 
+import httpx
+
 from config import settings
+from utils.circuit_breaker import CircuitOpenError
 from utils.logging_config import get_logger
+from utils.metrics import llama_guard_fallback_counter
 from utils.security import MultiLanguageContentFilter
 
 logger = get_logger(__name__)
+
+
+def _classify_llama_guard_failure(e: Exception) -> str:
+    """Categorize a Llama Guard failure for fallback-metric labelling."""
+    if isinstance(e, CircuitOpenError):
+        return "breaker_open"
+    if isinstance(e, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(e, httpx.HTTPStatusError):
+        status = getattr(e.response, "status_code", None)
+        return f"http_{status}" if status else "http_error"
+    if isinstance(e, httpx.HTTPError):
+        # Covers RemoteDisconnected → httpx.RemoteProtocolError, etc.
+        return type(e).__name__.lower()
+    return "other"
 
 
 @dataclass
@@ -329,9 +348,16 @@ class ContentSafetyService:
             # For hybrid mode, continue to Azure (Stage 3)
             return None
 
-        except Exception as e:
-            logger.warning("Llama Guard API unavailable, falling back: %s", e)
-            # Fallback to full keyword filter
+        except (httpx.TimeoutException, httpx.HTTPError, CircuitOpenError) as e:
+            # Narrow: only fall back on known transient/network/breaker failures.
+            # Anything else (programmer error, ValueError, etc.) propagates.
+            reason = _classify_llama_guard_failure(e)
+            llama_guard_fallback_counter.add(1, {"reason": reason})
+            logger.warning(
+                "Llama Guard unavailable (%s), falling back to keyword filter: %s",
+                reason,
+                e,
+            )
             return self._full_keyword_fallback(text, language, start)
 
     async def _check_stage2_openai_moderation(

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -130,3 +130,24 @@ api_access_counter = meter.create_counter(
     description="Total API requests by source classification (official/unofficial)",
     unit="1",
 )
+
+# ── External dependency resilience metrics ───────────────────────────────
+# These exist so log-based alerts can be replaced with metric-based alerts:
+# alert when the fallback rate spikes, not when ERROR logs appear.
+llama_guard_fallback_counter = meter.create_counter(
+    name="llama_guard.fallback_total",
+    description="Count of Llama Guard failures that fell back to the keyword filter",
+    unit="1",
+)
+
+openrouter_fallback_counter = meter.create_counter(
+    name="openrouter.fallback_total",
+    description="Count of OpenRouter primary-model failures that triggered client-side fallback",
+    unit="1",
+)
+
+circuit_breaker_state_counter = meter.create_counter(
+    name="circuit_breaker.state_transitions",
+    description="Circuit breaker state transitions (open/half_open/closed)",
+    unit="1",
+)


### PR DESCRIPTION
## Summary

- **Extracts `DEFAULT_SHOW_REFERENCED` constant** from `VersesPanel.kt` so the default filter state is covered by a plain JVM assertion (no Compose runtime needed), locking the regression from PR #551.
- **Extracts `VersesPanelContent`** as an `internal` composable so Compose tests can mount it directly, avoiding `ModalBottomSheet` rendering caveats under Robolectric.
- **Adds Robolectric 4.14.1 + Compose UI test dependencies** to `libs.versions.toml` and `build.gradle.kts`; enables `isIncludeAndroidResources` so `stringResource()` resolves correctly.
- **Registers `testDebugCompose` Gradle task** that includes only `*ComposeTest.class` files; `testDebugUnitTest` explicitly excludes them — the two tiers are fully isolated.
- **Ships `VersesPanelComposeTest`** (4 tests): default filter selection, empty state, "All Related" toggle, panel-title smoke test — the canonical template for future screen tests.
- **Adds independent `android-compose-tests.yml` workflow** (`continue-on-error: true`, non-required check) that uploads HTML + JUnit XML artifacts on every run.
- **Adds `android-test-compose` Makefile target** and `android/COMPOSE_TESTS.md` documentation covering tier design, usage, limitations, and a promotion checklist.

## Test plan

- [ ] `./gradlew testDebugUnitTest --no-daemon` passes — report contains new `VersesPanelDefaultsTest`, contains **no** `*ComposeTest` classes
- [ ] `./gradlew testDebugCompose --no-daemon` passes — runs the 4 `VersesPanelComposeTest` tests only
- [ ] `./gradlew check --dry-run` output does **not** include `testDebugCompose` (not wired into `check`)
- [ ] `./gradlew assembleDebug --no-daemon` succeeds unchanged
- [ ] Flip `DEFAULT_SHOW_REFERENCED` to `false` locally → both the JVM constant test and the Compose default-state test fail; revert
- [ ] CI: `android-ci.yml` jobs pass exactly as before; `android-compose-tests.yml` reports its own non-required check with 4 green tests

## Notes

- `VersesPanelContent` is `internal` — visible to test sources in the same module but not exported as public API. No callers outside `VersesPanel.kt` in production code.
- `@Config(sdk = [34])` is set in `ComposeTestHarness` — Robolectric 4.14.1 bundles API-34 jars; API-35 behaviours remain covered by the existing instrumented-test job.
- The `android-compose-tests.yml` workflow intentionally uses `continue-on-error: true` and must remain a non-required branch-protection check until several PR runs confirm stability. The integration follow-up story (promoting it to required) is documented in `android/COMPOSE_TESTS.md`.

https://claude.ai/code/session_0198RVQq5GQG9bMEB1q5LL9P

---
_Generated by [Claude Code](https://claude.ai/code/session_0198RVQq5GQG9bMEB1q5LL9P)_