### PR TITLE
fix(api): harden external API dependency paths after 2026-05-15 incident

### DIFF
--- a/api/providers/llama_guard.py
+++ b/api/providers/llama_guard.py
@@ -19,6 +19,7 @@ import httpx
 
 from config import settings
 from providers.azure_content_safety import ContentSafetyResult
+from utils.circuit_breaker import CircuitBreaker, CircuitOpenError
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,14 @@ class LlamaGuardProvider:
         self.api_key = api_key
         self.threshold = threshold  # unused but kept for interface consistency
         self.timeout = timeout
+        # Trip after 5 consecutive failures; cooldown 30s. When open,
+        # analyze_text() raises CircuitOpenError immediately so callers can
+        # fall back to the keyword filter without paying the 10s timeout.
+        self._breaker = CircuitBreaker(
+            name="llama_guard",
+            failure_threshold=5,
+            cooldown_seconds=30.0,
+        )
 
     def _parse_llama_guard_response(self, response_text: str) -> tuple[bool, list[str]]:
         """
@@ -192,10 +201,14 @@ class LlamaGuardProvider:
             ContentSafetyResult with decision
 
         Raises:
+            CircuitOpenError: If breaker is open (caller should use fallback immediately)
             httpx.HTTPError: If API call fails
             httpx.TimeoutException: If API call times out
         """
         text_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
+
+        if self._breaker.is_open():
+            raise CircuitOpenError("llama_guard circuit breaker open")
 
         # Format prompt with user message
         prompt = LLAMA_GUARD_PROMPT.format(user_message=text[:2000])
@@ -237,10 +250,12 @@ class LlamaGuardProvider:
                 # Parse response
                 is_safe, violated_categories = self._parse_llama_guard_response(response_text)
 
+                self._breaker.record_success()
                 # Map to result
                 return self._map_categories_to_result(is_safe, violated_categories, text_hash)
 
         except httpx.TimeoutException:
+            self._breaker.record_failure()
             logger.warning(
                 "Llama Guard API timeout",
                 extra={"text_hash": text_hash, "timeout": self.timeout},
@@ -248,7 +263,11 @@ class LlamaGuardProvider:
             raise
 
         except httpx.HTTPError as e:
-            logger.error(
+            self._breaker.record_failure()
+            # Demoted from ERROR to WARNING: the caller has a keyword fallback,
+            # so a transient HTTP failure is not by itself an alertable error.
+            # The metric counter in content_safety.py is the alert signal.
+            logger.warning(
                 "Llama Guard API error",
                 extra={
                     "text_hash": text_hash,

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -4,11 +4,13 @@ OpenRouter provides access to various LLMs including free models via an OpenAI-c
 """
 
 import time
-from typing import AsyncIterator, cast
+from typing import Any, AsyncIterator, cast
 
-from openai import APIStatusError, AsyncOpenAI, RateLimitError
+import httpx
+from openai import APIStatusError, APITimeoutError, AsyncOpenAI, RateLimitError
 from openai.types.chat import ChatCompletionChunk
 
+from utils.circuit_breaker import CircuitBreaker
 from utils.logging_config import get_logger
 from utils.metrics import (
     llm_fallback_counter,
@@ -16,11 +18,36 @@ from utils.metrics import (
     llm_tokens_per_second_histogram,
     llm_total_duration_histogram,
     llm_ttft_histogram,
+    openrouter_fallback_counter,
 )
 
 from .base import ChatMessage, LLMProvider, LLMResponse
 
 logger = get_logger(__name__)
+
+
+class _BreakerOpen(Exception):
+    """Sentinel: circuit breaker tripped, do not call the primary model."""
+
+
+def _classify_failure(e: Exception) -> str:
+    """Categorize a failure for metric labelling."""
+    if isinstance(e, _BreakerOpen):
+        return "breaker_open"
+    if isinstance(e, RateLimitError):
+        return "rate_limit"
+    if isinstance(e, (APITimeoutError, httpx.TimeoutException)):
+        return "timeout"
+    if isinstance(e, APIStatusError):
+        status = getattr(e, "status_code", None)
+        if status == 404:
+            return "model_404"
+        if status == 503:
+            return "upstream_503"
+        if status == 429:
+            return "rate_limit"
+        return f"api_status_{status}"
+    return "other"
 
 
 class OpenRouterProvider(LLMProvider):
@@ -59,11 +86,22 @@ class OpenRouterProvider(LLMProvider):
         self.fallback_models = fallback_models or []
         self.allow_fallbacks = allow_fallbacks
         self.preferred_min_throughput_p50 = preferred_min_throughput_p50
-        # Disable SDK auto-retry for rate limits - we handle fallbacks ourselves
+        # Explicit timeouts so we never hang on a stuck upstream.
+        # connect 5s catches DNS/TCP issues fast; read 60s is generous enough
+        # for streaming first-token latency on slower free-tier models.
         self._client = AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
-            max_retries=0,
+            timeout=httpx.Timeout(60.0, connect=5.0),
+            max_retries=2,
+        )
+        # Breaker trips after 5 consecutive primary-model failures within the
+        # cooldown window. When open, chat()/chat_stream() jump straight to
+        # the fallback list instead of paying the primary-call timeout.
+        self._breaker = CircuitBreaker(
+            name="openrouter_primary",
+            failure_threshold=5,
+            cooldown_seconds=30.0,
         )
         logger.info(
             f"OpenRouterProvider initialized: model={model}, "
@@ -154,6 +192,9 @@ class OpenRouterProvider(LLMProvider):
             if "no model" in error_msg or "model not found" in error_msg:
                 logger.warning(f"Model unavailable error: {e}")
                 return True
+        if isinstance(e, (APITimeoutError, httpx.TimeoutException)):
+            logger.warning(f"OpenRouter primary call timed out: {e}")
+            return True
         return False
 
     def _should_try_fallback(self, e: Exception) -> bool:
@@ -183,7 +224,19 @@ class OpenRouterProvider(LLMProvider):
         else:
             model_to_use, extra_body = self._get_model_and_extra_body()
 
+        # If the breaker is open, skip the primary call entirely and jump
+        # straight to the fallback list. This trades fidelity for not paying
+        # the primary timeout on every request during a sustained outage.
+        breaker_skip_primary = (
+            self._breaker.is_open()
+            and self.fallback_models
+            and self.allow_fallbacks
+            and not model_override
+        )
+
         try:
+            if breaker_skip_primary:
+                raise _BreakerOpen()
             response = await self._client.chat.completions.create(
                 model=model_to_use,
                 messages=converted_messages,  # type: ignore[arg-type]
@@ -191,9 +244,12 @@ class OpenRouterProvider(LLMProvider):
                 max_tokens=max_tokens,
                 extra_body=extra_body,
             )
-        except (RateLimitError, APIStatusError) as e:
+            self._breaker.record_success()
+        except (RateLimitError, APIStatusError, APITimeoutError, _BreakerOpen) as e:
             # Client-side fallback as safety net (most cases handled by OpenRouter server-side)
-            should_fallback = self._should_try_fallback(e)
+            should_fallback = isinstance(e, _BreakerOpen) or self._should_try_fallback(e)
+            if not isinstance(e, _BreakerOpen):
+                self._breaker.record_failure()
 
             if (
                 should_fallback
@@ -201,9 +257,17 @@ class OpenRouterProvider(LLMProvider):
                 and self.allow_fallbacks
                 and not model_override
             ):
-                logger.warning(
-                    f"Server-side routing failed, trying client-side fallback. "
-                    f"Model={model_to_use}, Error: {e}"
+                if not isinstance(e, _BreakerOpen):
+                    logger.warning(
+                        f"Server-side routing failed, trying client-side fallback. "
+                        f"Model={model_to_use}, Error: {e}"
+                    )
+                openrouter_fallback_counter.add(
+                    1,
+                    {
+                        "reason": _classify_failure(e),
+                        "stream": "false",
+                    },
                 )
                 for fallback_model in self.fallback_models:
                     try:
@@ -214,6 +278,8 @@ class OpenRouterProvider(LLMProvider):
                             temperature=temperature,
                             max_tokens=max_tokens,
                         )
+                        # Fallback success path — keep at INFO, not ERROR, so
+                        # the log-based alert doesn't fire on every hiccup.
                         logger.info(f"Client-side fallback to {fallback_model} succeeded")
                         # Return response with the fallback model name
                         content = response.choices[0].message.content or ""
@@ -232,14 +298,24 @@ class OpenRouterProvider(LLMProvider):
                             f"Client-side fallback {fallback_model} failed: {fallback_error}"
                         )
                         continue
-                # All fallbacks exhausted
+                # All fallbacks exhausted — this *is* an error condition
+                logger.error(
+                    "All OpenRouter models unavailable. primary=%s fallbacks=%s",
+                    self.model,
+                    self.fallback_models,
+                )
                 raise RuntimeError(
                     "All models unavailable or rate limited. "
                     f"Primary: {self.model}, "
                     f"Fallbacks: {self.fallback_models}. "
                     "Check model names at https://openrouter.ai/models"
-                ) from e
+                ) from (e if not isinstance(e, _BreakerOpen) else None)
             else:
+                if isinstance(e, _BreakerOpen):
+                    # Breaker open but no fallbacks available — surface as a clear error
+                    raise RuntimeError(
+                        "OpenRouter circuit breaker open and no fallback models configured"
+                    )
                 # No fallbacks configured or not a recoverable error
                 raise
 
@@ -315,6 +391,23 @@ class OpenRouterProvider(LLMProvider):
         current_model = model_to_use
         fallback_index = 0
 
+        # If the breaker is open, skip primary and start at first fallback.
+        if (
+            self._breaker.is_open()
+            and self.fallback_models
+            and self.allow_fallbacks
+            and not model_override
+        ):
+            logger.info(
+                "OpenRouter breaker open; skipping primary, starting at first fallback"
+            )
+            current_model = self.fallback_models[0]
+            fallback_index = 1
+            extra_body = None
+            openrouter_fallback_counter.add(
+                1, {"reason": "breaker_open", "stream": "true"}
+            )
+
         while True:
             try:
                 stream = cast(
@@ -358,18 +451,26 @@ class OpenRouterProvider(LLMProvider):
                     )
                 if used_fallback:
                     llm_fallback_counter.add(1, {"provider": "openrouter", "model": current_model})
+                # Successful stream — primary succeeded (or we recovered) → reset breaker.
+                if current_model == model_to_use:
+                    self._breaker.record_success()
 
                 return  # Success, exit the generator
 
-            except (RateLimitError, APIStatusError) as e:
+            except (RateLimitError, APIStatusError, APITimeoutError) as e:
                 # Client-side fallback as safety net (most cases handled by OpenRouter server-side)
                 should_fallback = self._should_try_fallback(e)
+                if current_model == model_to_use:
+                    self._breaker.record_failure()
 
                 if not should_fallback:
                     # Not a recoverable error, re-raise
                     raise
 
                 logger.warning(f"Server-side routing failed in streaming: {e}")
+                openrouter_fallback_counter.add(
+                    1, {"reason": _classify_failure(e), "stream": "true"}
+                )
 
                 # Try next fallback model
                 if (
@@ -384,7 +485,12 @@ class OpenRouterProvider(LLMProvider):
                     logger.info(f"Client-side streaming fallback to: {current_model}")
                     continue
                 else:
-                    # No more fallbacks
+                    # No more fallbacks — this is a real failure
+                    logger.error(
+                        "All OpenRouter streaming models unavailable. tried=%s,%s",
+                        model_to_use,
+                        self.fallback_models[:fallback_index],
+                    )
                     raise RuntimeError(
                         "All models unavailable in streaming. "
                         f"Tried: {model_to_use}, {self.fallback_models[:fallback_index]}. "
@@ -448,6 +554,21 @@ class OpenRouterProvider(LLMProvider):
         Note: This makes a minimal API call to verify connectivity.
         Uses native models array with provider preferences if configured.
         """
+        result = await self.health_check_detailed()
+        return result["healthy"]
+
+    async def health_check_detailed(self) -> dict[str, Any]:
+        """
+        Structured health check — distinguishes 404 (model gone) from
+        timeout / network failure, so /health/ready can surface the cause.
+        """
+        # Breaker state is itself a useful signal.
+        if self._breaker.is_open():
+            return {
+                "healthy": False,
+                "reason": "breaker_open",
+                "breaker_state": self._breaker.state,
+            }
         try:
             model_to_use, extra_body = self._get_model_and_extra_body()
             response = await self._client.chat.completions.create(
@@ -456,9 +577,18 @@ class OpenRouterProvider(LLMProvider):
                 max_tokens=10,
                 extra_body=extra_body,
             )
-            return response is not None
-        except Exception:
-            return False
+            return {
+                "healthy": response is not None,
+                "reason": "ok" if response is not None else "empty_response",
+                "breaker_state": self._breaker.state,
+            }
+        except Exception as e:
+            return {
+                "healthy": False,
+                "reason": _classify_failure(e),
+                "breaker_state": self._breaker.state,
+                "error": str(e),
+            }
 
     async def close(self) -> None:
         """Close the OpenAI HTTP client."""

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -26,13 +26,13 @@ from .base import ChatMessage, LLMProvider, LLMResponse
 logger = get_logger(__name__)
 
 
-class _BreakerOpen(Exception):
+class _BreakerOpenError(Exception):
     """Sentinel: circuit breaker tripped, do not call the primary model."""
 
 
 def _classify_failure(e: Exception) -> str:
     """Categorize a failure for metric labelling."""
-    if isinstance(e, _BreakerOpen):
+    if isinstance(e, _BreakerOpenError):
         return "breaker_open"
     if isinstance(e, RateLimitError):
         return "rate_limit"
@@ -201,7 +201,7 @@ class OpenRouterProvider(LLMProvider):
         """Check if we should try fallback models for this error."""
         return self._is_rate_limit_error(e) or self._is_model_unavailable_error(e)
 
-    async def chat(
+    async def chat(  # noqa: C901
         self,
         messages: list[ChatMessage],
         temperature: float = 0.7,
@@ -236,7 +236,7 @@ class OpenRouterProvider(LLMProvider):
 
         try:
             if breaker_skip_primary:
-                raise _BreakerOpen()
+                raise _BreakerOpenError()
             response = await self._client.chat.completions.create(
                 model=model_to_use,
                 messages=converted_messages,  # type: ignore[arg-type]
@@ -245,10 +245,10 @@ class OpenRouterProvider(LLMProvider):
                 extra_body=extra_body,
             )
             self._breaker.record_success()
-        except (RateLimitError, APIStatusError, APITimeoutError, _BreakerOpen) as e:
+        except (RateLimitError, APIStatusError, APITimeoutError, _BreakerOpenError) as e:
             # Client-side fallback as safety net (most cases handled by OpenRouter server-side)
-            should_fallback = isinstance(e, _BreakerOpen) or self._should_try_fallback(e)
-            if not isinstance(e, _BreakerOpen):
+            should_fallback = isinstance(e, _BreakerOpenError) or self._should_try_fallback(e)
+            if not isinstance(e, _BreakerOpenError):
                 self._breaker.record_failure()
 
             if (
@@ -257,7 +257,7 @@ class OpenRouterProvider(LLMProvider):
                 and self.allow_fallbacks
                 and not model_override
             ):
-                if not isinstance(e, _BreakerOpen):
+                if not isinstance(e, _BreakerOpenError):
                     logger.warning(
                         f"Server-side routing failed, trying client-side fallback. "
                         f"Model={model_to_use}, Error: {e}"
@@ -309,9 +309,9 @@ class OpenRouterProvider(LLMProvider):
                     f"Primary: {self.model}, "
                     f"Fallbacks: {self.fallback_models}. "
                     "Check model names at https://openrouter.ai/models"
-                ) from (e if not isinstance(e, _BreakerOpen) else None)
+                ) from (e if not isinstance(e, _BreakerOpenError) else None)
             else:
-                if isinstance(e, _BreakerOpen):
+                if isinstance(e, _BreakerOpenError):
                     # Breaker open but no fallbacks available — surface as a clear error
                     raise RuntimeError(
                         "OpenRouter circuit breaker open and no fallback models configured"
@@ -398,15 +398,11 @@ class OpenRouterProvider(LLMProvider):
             and self.allow_fallbacks
             and not model_override
         ):
-            logger.info(
-                "OpenRouter breaker open; skipping primary, starting at first fallback"
-            )
+            logger.info("OpenRouter breaker open; skipping primary, starting at first fallback")
             current_model = self.fallback_models[0]
             fallback_index = 1
             extra_body = None
-            openrouter_fallback_counter.add(
-                1, {"reason": "breaker_open", "stream": "true"}
-            )
+            openrouter_fallback_counter.add(1, {"reason": "breaker_open", "stream": "true"})
 
         while True:
             try:

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -254,23 +254,47 @@ async def readiness_probe():
     """
     Readiness probe for Kubernetes/orchestration.
 
-    Returns 200 if the app can serve requests (dependencies are available).
-    Returns 503 if critical dependencies are unavailable.
+    Returns 200 if the app can serve requests, 503 only if critical
+    dependencies are unavailable.
 
-    Use this for traffic routing - if this fails, stop sending traffic.
+    Lenient by design: returns 200 when LLM **or** embedding is unhealthy
+    (single-dependency degradation should not bounce the pod). Returns 503
+    only when the database is unhealthy, or when **both** LLM and embedding
+    are down. The response body always lists each dependency's state so
+    Azure can scrape it for dependency-failure alerts (in addition to the
+    metric-based alerts on `llama_guard_fallback_total` /
+    `openrouter_fallback_total`).
     """
-    # Only check database for readiness - it's the critical dependency
-    # LLM/Embedding can fail gracefully
-    db_health = await check_database_health()
+    db_health, llm_health, embedding_health = await asyncio.gather(
+        check_database_health(),
+        check_llm_health(),
+        check_embedding_health(),
+    )
 
-    if db_health.status == "unhealthy":
+    dependencies = {
+        "database": db_health.status,
+        "llm": llm_health.status,
+        "embedding": embedding_health.status,
+    }
+
+    db_down = db_health.status == "unhealthy"
+    both_inference_down = (
+        llm_health.status == "unhealthy" and embedding_health.status == "unhealthy"
+    )
+
+    if db_down or both_inference_down:
         return JSONResponse(
             status_code=503,
             content={
                 "status": "not_ready",
-                "reason": "database_unavailable",
-                "error": db_health.error,
+                "reason": "database_unavailable" if db_down else "inference_unavailable",
+                "dependencies": dependencies,
+                "error": db_health.error if db_down else None,
             },
         )
 
-    return {"status": "ready", "database_latency_ms": db_health.latency_ms}
+    return {
+        "status": "ready",
+        "database_latency_ms": db_health.latency_ms,
+        "dependencies": dependencies,
+    }

--- a/api/tests/test_providers.py
+++ b/api/tests/test_providers.py
@@ -493,9 +493,9 @@ async def test_llama_guard_timeout_trips_breaker():
         await provider.analyze_text("hello world")
 
 
-def test_content_safety_narrow_exception_handling():
+@pytest.mark.asyncio
+async def test_content_safety_narrow_exception_handling():
     """Non-network errors from Llama Guard must propagate, not be swallowed."""
-    import asyncio
     from unittest.mock import AsyncMock, MagicMock
 
     from utils.content_safety import ContentSafetyService
@@ -507,6 +507,4 @@ def test_content_safety_narrow_exception_handling():
     service._get_llama_guard_provider = MagicMock(return_value=fake_provider)
 
     with pytest.raises(ValueError):
-        asyncio.get_event_loop().run_until_complete(
-            service._check_stage2_llama_guard("hi", "en", 0.0)
-        )
+        await service._check_stage2_llama_guard("hi", "en", 0.0)

--- a/api/tests/test_providers.py
+++ b/api/tests/test_providers.py
@@ -384,3 +384,131 @@ def test_openrouter_should_try_fallback():
         body={},
     )
     assert provider._should_try_fallback(rate_error) is True
+
+
+# ── Post-incident hardening tests (2026-05-15) ────────────────────────────
+
+
+def test_circuit_breaker_opens_after_threshold():
+    """Breaker should open after N consecutive failures and short-circuit calls."""
+    from utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(name="test", failure_threshold=3, cooldown_seconds=60.0)
+    assert cb.is_open() is False
+    for _ in range(2):
+        cb.record_failure()
+    assert cb.is_open() is False  # not yet at threshold
+    cb.record_failure()
+    assert cb.is_open() is True
+    # Success after cooldown closes the breaker
+    cb._opened_at -= 120.0  # simulate cooldown elapsed
+    assert cb.is_open() is False  # transitions to half-open
+    cb.record_success()
+    assert cb.state == "closed"
+
+
+def test_circuit_breaker_half_open_failure_reopens():
+    from utils.circuit_breaker import CircuitBreaker
+
+    cb = CircuitBreaker(name="test2", failure_threshold=1, cooldown_seconds=60.0)
+    cb.record_failure()
+    assert cb.state == "open"
+    cb._opened_at -= 120.0
+    cb.is_open()  # transitions to half-open
+    assert cb.state == "half_open"
+    cb.record_failure()
+    assert cb.state == "open"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_fallback_on_404_no_error_log(caplog):
+    """When primary returns 404 and a fallback succeeds, no ERROR-level log fires."""
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    from openai import APIStatusError
+
+    provider = OpenRouterProvider(
+        api_key="sk-or-v1-test-key",  # pragma: allowlist secret
+        model="primary-model",
+        fallback_models=["fallback-1"],
+    )
+
+    mock_response_404 = MagicMock()
+    mock_response_404.status_code = 404
+    mock_response_404.headers = {}
+    err = APIStatusError(message="Not found", response=mock_response_404, body={})
+
+    # Successful fallback response
+    success_response = MagicMock()
+    success_response.choices = [MagicMock()]
+    success_response.choices[0].message.content = "hello"
+    success_response.choices[0].finish_reason = "stop"
+    success_response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+    success_response.model = "fallback-1"
+
+    provider._client.chat.completions.create = AsyncMock(
+        side_effect=[err, success_response]
+    )
+
+    from providers.base import ChatMessage
+
+    with caplog.at_level(logging.WARNING):
+        result = await provider.chat([ChatMessage(role="user", content="hi")])
+
+    assert result.model == "fallback-1"
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records == [], f"unexpected ERROR logs: {error_records}"
+
+
+@pytest.mark.asyncio
+async def test_llama_guard_timeout_trips_breaker():
+    """Repeated Llama Guard timeouts should trip the circuit breaker."""
+    from unittest.mock import AsyncMock, patch
+
+    import httpx
+
+    from providers.llama_guard import LlamaGuardProvider
+
+    provider = LlamaGuardProvider(
+        api_key="sk-or-v1-test-key",  # pragma: allowlist secret
+        timeout=1,
+    )
+
+    # Patch the post call to always time out. provider.analyze_text creates a
+    # new AsyncClient inside an `async with`, so we patch the class method.
+    with patch.object(
+        httpx.AsyncClient,
+        "post",
+        new=AsyncMock(side_effect=httpx.TimeoutException("timed out")),
+    ):
+        for _ in range(provider._breaker.failure_threshold):
+            with pytest.raises(httpx.TimeoutException):
+                await provider.analyze_text("hello world")
+
+    assert provider._breaker.state == "open"
+
+    # Once open, the next call raises CircuitOpenError without an HTTP attempt
+    from utils.circuit_breaker import CircuitOpenError
+
+    with pytest.raises(CircuitOpenError):
+        await provider.analyze_text("hello world")
+
+
+def test_content_safety_narrow_exception_handling():
+    """Non-network errors from Llama Guard must propagate, not be swallowed."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    from utils.content_safety import ContentSafetyService
+
+    service = ContentSafetyService()
+
+    fake_provider = MagicMock()
+    fake_provider.analyze_text = AsyncMock(side_effect=ValueError("programmer bug"))
+    service._get_llama_guard_provider = MagicMock(return_value=fake_provider)
+
+    with pytest.raises(ValueError):
+        asyncio.get_event_loop().run_until_complete(
+            service._check_stage2_llama_guard("hi", "en", 0.0)
+        )

--- a/api/tests/test_providers.py
+++ b/api/tests/test_providers.py
@@ -447,9 +447,7 @@ async def test_openrouter_fallback_on_404_no_error_log(caplog):
     success_response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
     success_response.model = "fallback-1"
 
-    provider._client.chat.completions.create = AsyncMock(
-        side_effect=[err, success_response]
-    )
+    provider._client.chat.completions.create = AsyncMock(side_effect=[err, success_response])
 
     from providers.base import ChatMessage
 

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -318,23 +318,32 @@ class TestReadinessProbe:
     """Tests for readiness_probe endpoint."""
 
     @pytest.mark.asyncio
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
     @patch("routes.health.check_database_health")
-    async def test_ready(self, mock_db_health):
+    async def test_ready(self, mock_db_health, mock_llm_health, mock_embedding_health):
         from routes.health import ComponentHealth, readiness_probe
 
         mock_db_health.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
+        mock_llm_health.return_value = ComponentHealth(status="healthy", latency_ms=10.0)
+        mock_embedding_health.return_value = ComponentHealth(status="healthy", latency_ms=8.0)
         result = await readiness_probe()
         assert result["status"] == "ready"
         assert result["database_latency_ms"] == 5.0
+        assert result["dependencies"]["database"] == "healthy"
 
     @pytest.mark.asyncio
+    @patch("routes.health.check_embedding_health")
+    @patch("routes.health.check_llm_health")
     @patch("routes.health.check_database_health")
-    async def test_not_ready(self, mock_db_health):
+    async def test_not_ready(self, mock_db_health, mock_llm_health, mock_embedding_health):
         from routes.health import ComponentHealth, readiness_probe
 
         mock_db_health.return_value = ComponentHealth(
             status="unhealthy", error="Connection refused"
         )
+        mock_llm_health.return_value = ComponentHealth(status="healthy")
+        mock_embedding_health.return_value = ComponentHealth(status="healthy")
         result = await readiness_probe()
         assert result.status_code == 503
         body = result.body

--- a/api/utils/circuit_breaker.py
+++ b/api/utils/circuit_breaker.py
@@ -95,7 +95,5 @@ class CircuitBreaker:
             new_state.value,
             self._consecutive_failures,
         )
-        circuit_breaker_state_counter.add(
-            1, {"breaker": self.name, "to_state": new_state.value}
-        )
+        circuit_breaker_state_counter.add(1, {"breaker": self.name, "to_state": new_state.value})
         self._state = new_state

--- a/api/utils/circuit_breaker.py
+++ b/api/utils/circuit_breaker.py
@@ -1,0 +1,101 @@
+"""
+Minimal in-process circuit breaker for external API call paths.
+
+Built for two callers — OpenRouter and Llama Guard — to short-circuit
+requests when a dependency is known-down, so we skip the per-request timeout
+instead of paying it on every call during an outage.
+"""
+
+from __future__ import annotations
+
+import time
+from enum import Enum
+from threading import Lock
+
+from utils.logging_config import get_logger
+from utils.metrics import circuit_breaker_state_counter
+
+logger = get_logger(__name__)
+
+
+class CircuitOpenError(Exception):
+    """Raised by callers when a breaker is open and the call is short-circuited."""
+
+
+class _State(str, Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreaker:
+    """
+    Failure-count based breaker.
+
+    - CLOSED: calls flow through; consecutive failures increment a counter.
+    - OPEN: after `failure_threshold` consecutive failures, calls are
+      short-circuited via `is_open()` until `cooldown_seconds` elapses.
+    - HALF_OPEN: the next call is allowed through as a probe; success closes
+      the breaker, failure re-opens it.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        failure_threshold: int = 5,
+        cooldown_seconds: float = 30.0,
+    ):
+        self.name = name
+        self.failure_threshold = failure_threshold
+        self.cooldown_seconds = cooldown_seconds
+        self._state = _State.CLOSED
+        self._consecutive_failures = 0
+        self._opened_at: float = 0.0
+        self._lock = Lock()
+
+    @property
+    def state(self) -> str:
+        return self._state.value
+
+    def is_open(self) -> bool:
+        """Return True if the call should be short-circuited."""
+        with self._lock:
+            if self._state == _State.OPEN:
+                if time.monotonic() - self._opened_at >= self.cooldown_seconds:
+                    self._transition(_State.HALF_OPEN)
+                    return False
+                return True
+            return False
+
+    def record_success(self) -> None:
+        with self._lock:
+            if self._state != _State.CLOSED:
+                self._transition(_State.CLOSED)
+            self._consecutive_failures = 0
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            if self._state == _State.HALF_OPEN:
+                self._open()
+            elif self._consecutive_failures >= self.failure_threshold:
+                self._open()
+
+    def _open(self) -> None:
+        self._opened_at = time.monotonic()
+        self._transition(_State.OPEN)
+
+    def _transition(self, new_state: _State) -> None:
+        if new_state == self._state:
+            return
+        logger.info(
+            "Circuit breaker %s: %s -> %s (consecutive_failures=%d)",
+            self.name,
+            self._state.value,
+            new_state.value,
+            self._consecutive_failures,
+        )
+        circuit_breaker_state_counter.add(
+            1, {"breaker": self.name, "to_state": new_state.value}
+        )
+        self._state = new_state

--- a/api/utils/content_safety.py
+++ b/api/utils/content_safety.py
@@ -27,11 +27,30 @@ import hashlib
 import time
 from dataclasses import dataclass, field
 
+import httpx
+
 from config import settings
+from utils.circuit_breaker import CircuitOpenError
 from utils.logging_config import get_logger
+from utils.metrics import llama_guard_fallback_counter
 from utils.security import MultiLanguageContentFilter
 
 logger = get_logger(__name__)
+
+
+def _classify_llama_guard_failure(e: Exception) -> str:
+    """Categorize a Llama Guard failure for fallback-metric labelling."""
+    if isinstance(e, CircuitOpenError):
+        return "breaker_open"
+    if isinstance(e, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(e, httpx.HTTPStatusError):
+        status = getattr(e.response, "status_code", None)
+        return f"http_{status}" if status else "http_error"
+    if isinstance(e, httpx.HTTPError):
+        # Covers RemoteDisconnected → httpx.RemoteProtocolError, etc.
+        return type(e).__name__.lower()
+    return "other"
 
 
 @dataclass
@@ -329,9 +348,16 @@ class ContentSafetyService:
             # For hybrid mode, continue to Azure (Stage 3)
             return None
 
-        except Exception as e:
-            logger.warning("Llama Guard API unavailable, falling back: %s", e)
-            # Fallback to full keyword filter
+        except (httpx.TimeoutException, httpx.HTTPError, CircuitOpenError) as e:
+            # Narrow: only fall back on known transient/network/breaker failures.
+            # Anything else (programmer error, ValueError, etc.) propagates.
+            reason = _classify_llama_guard_failure(e)
+            llama_guard_fallback_counter.add(1, {"reason": reason})
+            logger.warning(
+                "Llama Guard unavailable (%s), falling back to keyword filter: %s",
+                reason,
+                e,
+            )
             return self._full_keyword_fallback(text, language, start)
 
     async def _check_stage2_openai_moderation(

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -130,3 +130,24 @@ api_access_counter = meter.create_counter(
     description="Total API requests by source classification (official/unofficial)",
     unit="1",
 )
+
+# ── External dependency resilience metrics ───────────────────────────────
+# These exist so log-based alerts can be replaced with metric-based alerts:
+# alert when the fallback rate spikes, not when ERROR logs appear.
+llama_guard_fallback_counter = meter.create_counter(
+    name="llama_guard.fallback_total",
+    description="Count of Llama Guard failures that fell back to the keyword filter",
+    unit="1",
+)
+
+openrouter_fallback_counter = meter.create_counter(
+    name="openrouter.fallback_total",
+    description="Count of OpenRouter primary-model failures that triggered client-side fallback",
+    unit="1",
+)
+
+circuit_breaker_state_counter = meter.create_counter(
+    name="circuit_breaker.state_transitions",
+    description="Circuit breaker state transitions (open/half_open/closed)",
+    unit="1",
+)


### PR DESCRIPTION
## Summary

Response to the 2026-05-15 Sev2 Azure observability report
(`bible-app-backend-error-logs`, 07:23–07:33 UTC). OpenRouter 404s and
Llama Guard unavailability produced `ERROR`-level logs that fired the
log-based alert even though existing fallbacks kept HTTP responses
successful. The real issue was alert noise + missing resilience, not
failed requests (the report itself shows "No failed requests, No
dependency failures, No platform issue").

- New `api/utils/circuit_breaker.py` — small in-process breaker, wired
  into OpenRouter primary calls and Llama Guard so callers skip the
  upstream timeout when a dependency is known-down.
- OpenRouter: explicit `httpx.Timeout(60.0, connect=5.0)`, restored
  `max_retries=2`, demoted successful-fallback logs from `ERROR` →
  `WARNING`/`INFO`, new `health_check_detailed()` that distinguishes
  404 / timeout / breaker-open.
- Llama Guard: narrowed broad `except Exception` in
  `utils/content_safety.py` to `httpx.TimeoutException` /
  `httpx.HTTPError` / `CircuitOpenError`; non-network errors now
  propagate instead of being silently swallowed.
- New OTEL metrics (`llama_guard_fallback_total`,
  `openrouter_fallback_total`, `circuit_breaker_state_transitions`) so
  Azure can alert on fallback *rate* rather than raw error log volume.
- `/health/ready` now reports per-dependency status; returns 503 only
  when DB is down or **both** LLM and embedding are down (lenient by
  design — single dependency degradation should not bounce the pod).

## Test plan

- [x] `python -m py_compile` on every changed file
- [ ] `pytest api/tests/test_providers.py -k "circuit_breaker or openrouter_fallback or llama_guard_timeout or content_safety_narrow"`
- [ ] Local run: `curl localhost:8000/health/ready` returns 200 with
      JSON body listing each dependency
- [ ] Replay incident scenario (mock OpenRouter 404 + Llama Guard 503
      for 60s) and confirm zero `ERROR`-level lines reach the
      `bible_app` logger while fallbacks succeed
- [ ] One-shot, manual: `az containerapp revision show -n bible-app-backend --revision bible-app-backend---0000008` to verify the revision was the active traffic target during the incident

## Out of scope (intentionally deferred)

- Slow-query investigation — needs the actual query identified from
  incident logs first; no speculative indexes in this PR.
- Azure alert-rule changes — metrics exposed here are what the new
  alerts should consume, but the alert wiring lives in infra config
  outside this repo.

https://claude.ai/code/session_01RB8TQypBHeXJHkqzXdtE2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01RB8TQypBHeXJHkqzXdtE2S)_