### PR TITLE
build(android): align closed-testing version with repo manifest

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,6 +18,22 @@ android {
     fun gradleProp(name: String, default: String): String =
         (project.findProperty(name) as String?)?.takeIf { it.isNotBlank() } ?: default
 
+    // Read the canonical version from the release-please manifest at the
+    // repo root. Keeps the Android closed-testing track in sync with the
+    // rest of the repo without needing CI to inject `-PversionName=...`.
+    val manifestVersionName: String = run {
+        val manifestFile = rootProject.projectDir.parentFile?.resolve(".release-please-manifest.json")
+        val fallback = "1.0.0"
+        if (manifestFile == null || !manifestFile.exists()) {
+            fallback
+        } else {
+            val text = manifestFile.readText(Charsets.UTF_8)
+            // Single-source manifest shape: { ".": "1.8.0" }
+            val match = Regex("""\"\.\"\s*:\s*\"([^\"]+)\"""").find(text)
+            match?.groupValues?.get(1) ?: fallback
+        }
+    }
+
     // Resolve release signing inputs once, treating blanks as absent.
     val releaseKeystorePath = (System.getenv("KEYSTORE_PATH")
         ?: (project.findProperty("KEYSTORE_PATH") as String?))?.takeIf { it.isNotBlank() }
@@ -46,7 +62,8 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = (project.findProperty("versionCode") as String?)?.toIntOrNull() ?: 1
-        versionName = (project.findProperty("versionName") as String?) ?: "1.0.0"
+        versionName = (project.findProperty("versionName") as String?)?.takeIf { it.isNotBlank() }
+            ?: manifestVersionName
 
         testInstrumentationRunner = "org.voxquieta.app.HiltTestRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- `android/app/build.gradle.kts` now reads `versionName` from the repo-root `.release-please-manifest.json` (currently `1.8.0`) as the fallback, instead of a hardcoded `"1.0.0"` literal.
- CI override via `-PversionName=…` still wins, so existing release plumbing is untouched.

## Why
The closed-testing track was being uploaded as `1.0.0` even though release-please had already advanced the repo to `1.8.0`. The Gradle fallback was stale because nothing in the build pipeline pointed at the single source of truth. Reading the manifest at configure time keeps the Play Console track in sync without needing CI to inject a version flag.

## Related
Split from the original combined branch:
- Companion: warm blocked-message notification (`claude/improve-blocked-message-notification-cIqRV`, #593).
- Companion: capture blocked messages for tuning (`claude/capture-blocked-messages-for-tuning`, #594).

## Test plan
- [ ] Run `./gradlew :app:assembleDebug` and confirm the resulting APK's `versionName` is `1.8.0` (e.g. via `aapt dump badging`).
- [ ] Confirm `./gradlew :app:assembleDebug -PversionName=1.8.1` still produces `1.8.1` (CI override path).
- [ ] Upload to the Play Console closed-testing track (or dry-run) and confirm it shows `1.8.0`.

https://claude.ai/code/session_01RK6TA6kQwh8KaQZKbYYPZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RK6TA6kQwh8KaQZKbYYPZA)_