### PR TITLE
feat(ops): blocked-sample exporter + pg_cron TTL purge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help venv install-hooks setup-dev lint test format check-all clean \
 	tf-check-version tf-init tf-plan tf-apply tf-destroy tf-fmt tf-validate tf-output tf-refresh \
-	validate-env validate-env-strict \
+	validate-env validate-env-strict export-blocked-samples \
 	az-acr-list-images az-acr-list-tags az-deployed-images az-image-info \
 	android-test android-test-compose android-build android-build-prod android-lint android-clean android-security-check \
 	test-functional test-functional-local test-e2e test-e2e-local \
@@ -244,6 +244,9 @@ validate-env-strict: install-deps ## Validate env vars (strict mode - warnings a
 	@echo "$(BLUE)Validating environment variables (strict mode)...$(NC)"
 	@$(CURDIR)/$(PYTHON) scripts/validate-env.py --strict
 	@echo "$(GREEN)✓ Environment validation complete$(NC)"
+
+export-blocked-samples: install-deps ## Export captured blocked-message samples (read-only). Usage: make export-blocked-samples ARGS="--format csv --since 2026-05-01". Requires DATABASE_URL.
+	@$(CURDIR)/$(PYTHON) scripts/export_blocked_samples.py $(ARGS)
 
 clean: ## Clean build artifacts and caches
 	@echo "$(BLUE)Cleaning build artifacts...$(NC)"

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -374,7 +374,17 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_client" {
 resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.main.id
-  value     = "vector,uuid-ossp"
+  value     = "vector,uuid-ossp,pg_cron"
+}
+
+# Run pg_cron jobs against the application database (default is `postgres`).
+# Used by scripts/migrations/005_schedule_blocked_samples_purge.sql to TTL
+# the blocked_message_samples table without depending on app restarts.
+resource "azurerm_postgresql_flexible_server_configuration" "cron_database_name" {
+  name       = "cron.database_name"
+  server_id  = azurerm_postgresql_flexible_server.main.id
+  value      = var.db_name
+  depends_on = [azurerm_postgresql_flexible_server_configuration.extensions]
 }
 
 # -----------------------------------------------------------------------------

--- a/docs/HOW-TO-EXPORT-BLOCKED-SAMPLES.md
+++ b/docs/HOW-TO-EXPORT-BLOCKED-SAMPLES.md
@@ -1,0 +1,121 @@
+# How to Export Blocked-Message Samples
+
+When the safety system blocks a user message, the backend can write a
+privacy-minimal record into the `blocked_message_samples` table so we can
+tune the filter against real traffic. This doc covers how the capture is
+gated and how to retrieve the rows.
+
+See also: [`api/feedback/blocked_samples.py`](../api/feedback/blocked_samples.py),
+[`api/feedback/models.py`](../api/feedback/models.py),
+the public [Privacy Policy](../frontend/public/legal/privacy-policy.md).
+
+## What is captured
+
+Each row is one blocked message (or a deduplicated group of identical
+blocked messages):
+
+| Column            | Meaning                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| `id`              | Surrogate primary key.                                         |
+| `created_at`      | UTC timestamp the row was written.                             |
+| `expires_at`      | TTL — row is purged after this instant.                        |
+| `stage`           | Which safety stage blocked: `keyword` or `content_safety`.     |
+| `categories`      | Provider categories (JSON list or dict).                       |
+| `severity`        | Provider severity score (when available).                      |
+| `language`        | Detected ISO language code (when available).                   |
+| `message_text`    | The message, **capped** at `BLOCKED_SAMPLE_MAX_CHARS` (500).   |
+| `message_sha256`  | Full-message sha256, used for dedup.                           |
+| `session_id_hash` | sha256 of the session id (no raw id, IP, account, or UA).      |
+| `hit_count`       | Number of times this exact message has been blocked.           |
+| `reviewed`        | Operator flag — set to `true` after using the row for tuning.  |
+
+## Privacy guardrails
+
+These are enforced in code, not just by convention:
+
+- No raw IP, user id, or user-agent is ever stored.
+- `session_id_hash` is a one-way hash.
+- `message_text` is truncated to at most `BLOCKED_SAMPLE_MAX_CHARS` chars.
+- Identical messages are deduplicated by sha256; repeats bump `hit_count`
+  instead of writing new rows, so a single user cannot be amplified.
+- Rows older than `BLOCKED_SAMPLE_RETENTION_DAYS` (default **30**) are
+  deleted on app startup.
+- Capture is **off by default**. Operators opt in per environment with
+  `BLOCKED_SAMPLE_CAPTURE_ENABLED=true`.
+
+## Enabling capture (operator)
+
+Set these on the backend deployment:
+
+```bash
+BLOCKED_SAMPLE_CAPTURE_ENABLED=true     # default false
+BLOCKED_SAMPLE_RETENTION_DAYS=30        # default 30
+BLOCKED_SAMPLE_MAX_CHARS=500            # default 500
+```
+
+The table is created automatically by `init_db()` on first startup once
+the model is registered (no migration step required).
+
+## Exporting rows
+
+The exporter is **read-only** and connects to the same database via
+`DATABASE_URL` as the API.
+
+### With make
+
+```bash
+# Latest 100 rows as JSON to stdout
+DATABASE_URL=postgresql://... make export-blocked-samples ARGS="--limit 100"
+
+# Keyword-stage blocks since 2026-05-01, CSV to a file
+DATABASE_URL=postgresql://... make export-blocked-samples \
+    ARGS="--stage keyword --since 2026-05-01 --format csv --output keyword.csv"
+
+# Italian-language blocks not yet reviewed
+DATABASE_URL=postgresql://... make export-blocked-samples \
+    ARGS="--language it --unreviewed"
+```
+
+### Directly
+
+```bash
+DATABASE_URL=postgresql://... \
+    python scripts/export_blocked_samples.py --help
+```
+
+Filters:
+
+| Flag                       | Meaning                                            |
+| -------------------------- | -------------------------------------------------- |
+| `--stage <name>`           | `keyword`, `content_safety`, …                     |
+| `--language <iso>`         | e.g. `en`, `it`, `ar`.                             |
+| `--since YYYY-MM-DD`       | Inclusive lower bound on `created_at`.             |
+| `--until YYYY-MM-DD`       | Exclusive upper bound on `created_at`.             |
+| `--reviewed` / `--unreviewed` | Filter by the `reviewed` flag.                  |
+| `--limit N`                | Max rows.                                          |
+| `--format json\|csv`       | Output format (default JSON).                      |
+| `--output FILE`            | Write to file instead of stdout.                   |
+
+## Marking rows as reviewed
+
+After a row has been used for tuning, set `reviewed = true` so future
+exports can skip it with `--unreviewed`. There's no admin endpoint —
+do it from the database client of your choice:
+
+```sql
+UPDATE blocked_message_samples
+SET reviewed = true
+WHERE id IN (1, 2, 3);
+```
+
+## Operational notes
+
+- The exporter does only `SELECT` queries. It will not modify rows or
+  trigger TTL purges.
+- Purges run on app startup. To force one without restarting, call
+  `purge_expired_blocked_samples()` from a Python REPL with `DATABASE_URL`
+  configured, or just `DELETE FROM blocked_message_samples WHERE
+  expires_at < now();` from SQL.
+- The table holds at most one row per distinct message within the
+  retention window, so volume is bounded by the variety of blocked
+  messages, not by traffic.

--- a/docs/HOW-TO-EXPORT-BLOCKED-SAMPLES.md
+++ b/docs/HOW-TO-EXPORT-BLOCKED-SAMPLES.md
@@ -112,10 +112,31 @@ WHERE id IN (1, 2, 3);
 
 - The exporter does only `SELECT` queries. It will not modify rows or
   trigger TTL purges.
-- Purges run on app startup. To force one without restarting, call
-  `purge_expired_blocked_samples()` from a Python REPL with `DATABASE_URL`
-  configured, or just `DELETE FROM blocked_message_samples WHERE
-  expires_at < now();` from SQL.
+- Expired rows are deleted by a `pg_cron` job that runs daily at 03:15
+  UTC (`scripts/migrations/005_schedule_blocked_samples_purge.sql`).
+  The app-side startup purge in `api/main.py` is kept as a backstop so
+  rows are also cleaned up after a deploy or restart.
+- To force a purge between scheduled runs:
+
+  ```sql
+  DELETE FROM blocked_message_samples WHERE expires_at < now();
+  ```
+
 - The table holds at most one row per distinct message within the
   retention window, so volume is bounded by the variety of blocked
   messages, not by traffic.
+
+## Enabling the pg_cron job (one-time, operator)
+
+1. `deployment/main.tf` already adds `pg_cron` to the `azure.extensions`
+   parameter and points `cron.database_name` at the app database.
+   Apply the Terraform plan and restart the Postgres flexible server
+   when prompted by Azure.
+2. Run `scripts/migrations/005_schedule_blocked_samples_purge.sql` as
+   a superuser to register the schedule. The migration is idempotent.
+3. Verify with:
+
+   ```sql
+   SELECT jobname, schedule FROM cron.job
+   WHERE jobname = 'purge-blocked-message-samples';
+   ```

--- a/scripts/export_blocked_samples.py
+++ b/scripts/export_blocked_samples.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Export rows from the blocked_message_samples table for safety-filter tuning.
+
+Read-only. Connects via DATABASE_URL (same convention as api/config.py)
+and prints rows to stdout (or --output) as JSON or CSV.
+
+The table is populated by the backend when settings.blocked_sample_capture_enabled
+is true. Rows expire after settings.blocked_sample_retention_days (default 30
+days) and are purged on app startup. See docs/HOW-TO-EXPORT-BLOCKED-SAMPLES.md.
+
+Usage:
+    python scripts/export_blocked_samples.py --help
+    python scripts/export_blocked_samples.py --format csv --since 2026-05-01
+    DATABASE_URL=postgresql://... python scripts/export_blocked_samples.py \\
+        --stage keyword --limit 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import os
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Reuse the SQLAlchemy model defined in the api package without forcing a
+# packaging change. The repo layout has api/ as a top-level directory.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "api"))
+
+from feedback.models import BlockedMessageSample  # noqa: E402
+from sqlalchemy import create_engine, select  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+FIELDS = [
+    "id",
+    "created_at",
+    "expires_at",
+    "stage",
+    "categories",
+    "severity",
+    "language",
+    "message_text",
+    "message_sha256",
+    "session_id_hash",
+    "hit_count",
+    "reviewed",
+]
+
+
+def parse_date(value: str) -> datetime:
+    """Accept YYYY-MM-DD or full ISO 8601 and return a UTC-aware datetime."""
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            f"Invalid date {value!r}: expected YYYY-MM-DD or ISO 8601"
+        ) from e
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def sync_database_url(url: str) -> str:
+    """Strip the async asyncpg driver so the script can use sync SQLAlchemy."""
+    if url.startswith("postgresql+asyncpg://"):
+        return url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    return url
+
+
+def row_to_dict(row: BlockedMessageSample) -> dict[str, Any]:
+    return {f: getattr(row, f) for f in FIELDS}
+
+
+def to_json_safe(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return value
+
+
+def build_query(args: argparse.Namespace):
+    stmt = select(BlockedMessageSample).order_by(BlockedMessageSample.created_at.desc())
+    if args.stage:
+        stmt = stmt.where(BlockedMessageSample.stage == args.stage)
+    if args.language:
+        stmt = stmt.where(BlockedMessageSample.language == args.language)
+    if args.since:
+        stmt = stmt.where(BlockedMessageSample.created_at >= args.since)
+    if args.until:
+        stmt = stmt.where(BlockedMessageSample.created_at < args.until)
+    if args.reviewed is True:
+        stmt = stmt.where(BlockedMessageSample.reviewed.is_(True))
+    elif args.reviewed is False:
+        stmt = stmt.where(BlockedMessageSample.reviewed.is_(False))
+    if args.limit:
+        stmt = stmt.limit(args.limit)
+    return stmt
+
+
+def emit_json(rows: list[dict[str, Any]], stream: io.TextIOBase) -> None:
+    json.dump(
+        [{k: to_json_safe(v) for k, v in row.items()} for row in rows],
+        stream,
+        ensure_ascii=False,
+        indent=2,
+    )
+    stream.write("\n")
+
+
+def emit_csv(rows: list[dict[str, Any]], stream: io.TextIOBase) -> None:
+    writer = csv.DictWriter(stream, fieldnames=FIELDS)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(
+            {
+                k: (
+                    json.dumps(v, ensure_ascii=False)
+                    if isinstance(v, (dict, list))
+                    else to_json_safe(v)
+                )
+                for k, v in row.items()
+            }
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export rows from blocked_message_samples (read-only).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--format", choices=("json", "csv"), default="json")
+    parser.add_argument(
+        "--stage",
+        help='Filter by stage (e.g. "keyword", "content_safety").',
+    )
+    parser.add_argument("--language", help="Filter by detected language (ISO code).")
+    parser.add_argument(
+        "--since",
+        type=parse_date,
+        help="Include rows created at or after this date (YYYY-MM-DD).",
+    )
+    parser.add_argument(
+        "--until",
+        type=parse_date,
+        help="Exclude rows created at or after this date (YYYY-MM-DD).",
+    )
+    parser.add_argument("--limit", type=int, help="Maximum rows to return.")
+    reviewed = parser.add_mutually_exclusive_group()
+    reviewed.add_argument(
+        "--reviewed",
+        dest="reviewed",
+        action="store_true",
+        default=None,
+        help="Only rows marked reviewed=true.",
+    )
+    reviewed.add_argument(
+        "--unreviewed",
+        dest="reviewed",
+        action="store_false",
+        help="Only rows marked reviewed=false.",
+    )
+    parser.add_argument(
+        "--output",
+        type=argparse.FileType("w", encoding="utf-8"),
+        default=sys.stdout,
+        help="Write to file instead of stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        parser.error("DATABASE_URL is not set in the environment.")
+
+    engine = create_engine(sync_database_url(url), future=True)
+    with Session(engine) as session:
+        rows = [row_to_dict(r) for r in session.execute(build_query(args)).scalars()]
+
+    if args.format == "json":
+        emit_json(rows, args.output)
+    else:
+        emit_csv(rows, args.output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrations/005_schedule_blocked_samples_purge.sql
+++ b/scripts/migrations/005_schedule_blocked_samples_purge.sql
@@ -1,0 +1,49 @@
+-- Migration 005: Schedule daily TTL purge for blocked_message_samples
+-- Date: 2026-05-19
+-- Purpose: Replace startup-only purge with a pg_cron-driven daily DELETE
+--          so expired rows are reclaimed even when the API container does
+--          not restart for long stretches.
+--
+-- Prerequisites (operator-level, one-time):
+--   1. Add `pg_cron` to the `azure.extensions` server parameter
+--      (see deployment/main.tf). Restart the Postgres flexible server.
+--   2. Set the `cron.database_name` server parameter to the app database
+--      (e.g. `bibledb`) so cron jobs run against the right DB. Restart.
+--   3. Run this migration as a superuser (cron schema is owned by
+--      `azure_pg_admin` on Azure flexible server).
+--
+-- Behaviour:
+--   - The job runs daily at 03:15 UTC and deletes any row whose
+--     `expires_at` is in the past. Rows live up to
+--     `BLOCKED_SAMPLE_RETENTION_DAYS` (default 30) past creation.
+--   - The application-side startup purge in api/main.py is kept as a
+--     belt-and-braces backstop; both can run safely (DELETE is idempotent).
+--
+-- Idempotency:
+--   - `CREATE EXTENSION IF NOT EXISTS` is safe to re-run.
+--   - `cron.unschedule` is wrapped in a DO block so re-running this
+--     migration just replaces the schedule without errors.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Drop any prior schedule with the same name before re-creating, so this
+-- migration can be re-applied to change the cadence without leaving
+-- duplicate jobs behind.
+DO $$
+BEGIN
+    PERFORM cron.unschedule('purge-blocked-message-samples')
+    FROM cron.job
+    WHERE jobname = 'purge-blocked-message-samples';
+END
+$$;
+
+SELECT cron.schedule(
+    'purge-blocked-message-samples',
+    '15 3 * * *',
+    $cmd$DELETE FROM blocked_message_samples WHERE expires_at < now()$cmd$
+);
+
+-- Verify
+SELECT jobid, jobname, schedule, command
+FROM cron.job
+WHERE jobname = 'purge-blocked-message-samples';

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -147,3 +147,58 @@ The `TOPIC_BOOST_FACTOR` controls the multiplicative boost per matching topic:
 
 - `0.2` = 20% boost per topic (default)
 - Example: verse with 2 matching topics → `score * 1.4`
+
+---
+
+## Migration 005: Schedule daily purge of `blocked_message_samples`
+
+**File:** `005_schedule_blocked_samples_purge.sql`
+**Date:** 2026-05-19
+**Purpose:** Replace startup-only TTL with a `pg_cron`-driven daily DELETE
+so expired `blocked_message_samples` rows are reclaimed even when the API
+container does not restart for long stretches.
+
+### Prerequisites
+
+1. `pg_cron` must be allow-listed via the `azure.extensions` server
+   parameter (`deployment/main.tf` already includes it alongside
+   `vector,uuid-ossp`). Restart the Postgres flexible server after
+   updating this parameter.
+2. `cron.database_name` must point at the app database (managed by the
+   `cron_database_name` resource in `deployment/main.tf`). Restart again.
+3. Run the migration as a superuser:
+
+```bash
+psql $DATABASE_URL -f scripts/migrations/005_schedule_blocked_samples_purge.sql
+```
+
+### Behaviour
+
+- Job name: `purge-blocked-message-samples`
+- Schedule: `15 3 * * *` (daily, 03:15 UTC)
+- Statement: `DELETE FROM blocked_message_samples WHERE expires_at < now()`
+- Idempotent: re-running the migration replaces any existing schedule of
+  the same name.
+- The app-side startup purge in `api/main.py` is kept as a backstop.
+
+### Rollback (Migration 005)
+
+```sql
+SELECT cron.unschedule('purge-blocked-message-samples');
+-- Optional: remove pg_cron from azure.extensions in Terraform.
+```
+
+### Verify
+
+```sql
+SELECT jobid, jobname, schedule, command
+FROM cron.job
+WHERE jobname = 'purge-blocked-message-samples';
+
+-- Recent runs:
+SELECT runid, jobid, status, start_time, end_time, return_message
+FROM cron.job_run_details
+WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'purge-blocked-message-samples')
+ORDER BY start_time DESC
+LIMIT 5;
+```


### PR DESCRIPTION
## Summary

Follow-up to #594. The captured `blocked_message_samples` rows had no operator-friendly retrieval path and the TTL purge only ran on container startup. This PR closes both gaps.

- **Read-only exporter**: `scripts/export_blocked_samples.py` connects via `DATABASE_URL` and prints rows to stdout or `--output` as JSON or CSV. Filterable by `--stage`, `--language`, `--since`, `--until`, `--limit`, `--reviewed` / `--unreviewed`. Reuses the existing `BlockedMessageSample` SQLAlchemy model.
- **Makefile target**: `make export-blocked-samples ARGS="..."` wraps the script with the same `ARGS=` passthrough convention used elsewhere in the Makefile.
- **pg_cron TTL purge**: `scripts/migrations/005_schedule_blocked_samples_purge.sql` registers a daily job (03:15 UTC) that `DELETE`s expired rows so the app no longer depends on container restarts to reclaim them. The app-side startup purge stays as a backstop. Terraform now allow-lists `pg_cron` via `azure.extensions` and sets `cron.database_name` to the app DB.
- **Documentation**: `docs/HOW-TO-EXPORT-BLOCKED-SAMPLES.md` covers privacy guardrails, enabling capture, the TTL path, exporting, filter examples, and marking rows reviewed. `scripts/migrations/README.md` gets a section for migration 005 with verification queries and rollback.

## Test plan

- [ ] `python scripts/export_blocked_samples.py --help` renders all flags.
- [ ] With capture enabled and a known blocked message, `make export-blocked-samples ARGS="--limit 5"` returns the captured row in JSON; `--format csv` returns the same row as CSV.
- [ ] Filter combinations (`--stage keyword`, `--language it`, `--since 2026-05-01`, `--unreviewed`) narrow the result set as expected.
- [ ] Apply the Terraform plan to the dev environment, restart the Postgres flexible server, then run `psql $DATABASE_URL -f scripts/migrations/005_schedule_blocked_samples_purge.sql`. Confirm with `SELECT jobname, schedule FROM cron.job WHERE jobname = 'purge-blocked-message-samples';`.
- [ ] Insert a row with `expires_at = now() - interval '1 day'`, wait for or trigger the cron run, and confirm it is deleted.

https://claude.ai/code/session_01RK6TA6kQwh8KaQZKbYYPZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RK6TA6kQwh8KaQZKbYYPZA)_