### PR TITLE
fix(android): restore Compose test tier isolation (BITB-034)

### DIFF
--- a/.github/workflows/android-compose-tests.yml
+++ b/.github/workflows/android-compose-tests.yml
@@ -90,11 +90,12 @@ jobs:
 
       - name: Run Compose UI tests
         working-directory: android
-        # Run only *ComposeTest classes via the standard unit-test task with a filter.
-        # No custom Gradle task is needed — Gradle's --tests flag isolates the tier.
-        # The "*ComposeTest" wildcard matches any class following the BITB-034 naming convention.
+        # -PcomposeTestsOnly disables the *ComposeTest exclusion that normally keeps these
+        # classes out of the required Unit Tests check. Combined with --tests "*ComposeTest"
+        # this runs only Compose UI tests without touching the standard unit-test tier.
         run: |
           ./gradlew :app:testDebugUnitTest \
+            -PcomposeTestsOnly \
             --tests "*ComposeTest" \
             --no-daemon --stacktrace
 

--- a/.github/workflows/android-compose-tests.yml
+++ b/.github/workflows/android-compose-tests.yml
@@ -92,9 +92,10 @@ jobs:
         working-directory: android
         # Run only *ComposeTest classes via the standard unit-test task with a filter.
         # No custom Gradle task is needed — Gradle's --tests flag isolates the tier.
+        # The "*ComposeTest" wildcard matches any class following the BITB-034 naming convention.
         run: |
           ./gradlew :app:testDebugUnitTest \
-            --tests "*.VersesPanelComposeTest" \
+            --tests "*ComposeTest" \
             --no-daemon --stacktrace
 
       - name: Upload HTML test report

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -331,9 +331,11 @@ val generateChangelogJson by tasks.registering {
 tasks.named("preBuild").configure { dependsOn(generateChangelogJson) }
 
 // BITB-034: Exclude *ComposeTest classes from the required unit-test check so Compose-UI
-// flakiness cannot block merges. tasks.matching().configureEach is lazy — it configures the
-// task whenever AGP registers it, avoiding the UnknownTaskException that tasks.named<Test>()
-// throws before AGP's afterEvaluate completes.
+// flakiness cannot block merges. The exclusion is skipped when -PcomposeTestsOnly is passed
+// so the compose-tests workflow can still target these classes via --tests "*ComposeTest".
+// tasks.matching().configureEach is lazy — safe to call before AGP registers the task.
 tasks.matching { it.name == "testDebugUnitTest" }.configureEach {
-    (this as Test).exclude("**/*ComposeTest.class")
+    if (!providers.gradleProperty("composeTestsOnly").isPresent) {
+        (this as Test).exclude("**/*ComposeTest.class")
+    }
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -330,7 +330,10 @@ val generateChangelogJson by tasks.registering {
 
 tasks.named("preBuild").configure { dependsOn(generateChangelogJson) }
 
-// BITB-034: Robolectric/Compose UI tests run via testDebugUnitTest (no custom task needed).
-// The android-compose-tests.yml workflow uses --tests filtering to isolate *ComposeTest
-// classes without requiring a separate Gradle task registration.
-// See: .github/workflows/android-compose-tests.yml
+// BITB-034: Exclude *ComposeTest classes from the required unit-test check so Compose-UI
+// flakiness cannot block merges. tasks.matching().configureEach is lazy — it configures the
+// task whenever AGP registers it, avoiding the UnknownTaskException that tasks.named<Test>()
+// throws before AGP's afterEvaluate completes.
+tasks.matching { it.name == "testDebugUnitTest" }.configureEach {
+    (this as Test).exclude("**/*ComposeTest.class")
+}


### PR DESCRIPTION
## Problem

PR #591 introduced a regression: the `*ComposeTest` exclusion from `testDebugUnitTest` was removed as part of a workaround for a Gradle task-registration crash. This broke tier isolation — the **required** Unit Tests CI check now runs Compose UI tests, meaning Compose flakiness can block merges (the opposite of the BITB-034 design intent).

A second issue: the compose-tests workflow used `--tests "*.VersesPanelComposeTest"` (hardcoded class name) instead of `--tests "*ComposeTest"`, so future `*ComposeTest` classes would be silently ignored.

## Fix

**`android/app/build.gradle.kts`**: Restore the `*ComposeTest` exclusion using `tasks.matching().configureEach` instead of `tasks.named<Test>()`.

`tasks.matching().configureEach` is lazy — it configures the task whenever AGP registers it, avoiding the `UnknownTaskException` that `tasks.named<Test>("testDebugUnitTest")` throws when called at build-script top level (before AGP's own `afterEvaluate` has registered the task).

**`.github/workflows/android-compose-tests.yml`**: Widen the filter from `"*.VersesPanelComposeTest"` to `"*ComposeTest"` so all classes following the BITB-034 naming convention are automatically included.

## Test plan

- [ ] Unit Tests check runs `testDebugUnitTest` — confirm `*ComposeTest` classes are excluded (no Robolectric setup overhead in required check)
- [ ] Compose UI Tests check runs `testDebugUnitTest --tests "*ComposeTest"` — confirm `VersesPanelComposeTest` executes
- [ ] Android Lint passes
- [ ] OWASP Dependency Check passes

https://claude.ai/code/session_01PALoHrYxueycEUDwKcPqGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PALoHrYxueycEUDwKcPqGC)_