### PR TITLE
fix(android): show the raster PNG launcher icon on all API levels

### DIFF
--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,17 +5,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
-    <!--
-        Wrap all artwork in a group that scales it into the adaptive-icon
-        safe zone (inner ~66dp). Without this, launchers crop the Bible at
-        the bottom of the viewport and only the rays remain visible.
-    -->
-    <group
-        android:pivotX="54"
-        android:pivotY="54"
-        android:scaleX="0.80"
-        android:scaleY="0.80">
-
     <!-- Halo glow at ray source (54, 20) -->
     <path
         android:fillColor="#F8D040"
@@ -70,5 +59,4 @@
     <path android:strokeColor="#C4A060" android:strokeWidth="0.5" android:strokeAlpha="0.45"
         android:pathData="M58,84.2 L93,84.5" />
 
-    </group>
 </vector>

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -5,6 +5,17 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
+    <!--
+        Wrap all artwork in a group that scales it into the adaptive-icon
+        safe zone (inner ~66dp). Without this, launchers crop the Bible at
+        the bottom of the viewport and only the rays remain visible.
+    -->
+    <group
+        android:pivotX="54"
+        android:pivotY="54"
+        android:scaleX="0.80"
+        android:scaleY="0.80">
+
     <!-- Halo glow at ray source (54, 20) -->
     <path
         android:fillColor="#F8D040"
@@ -59,4 +70,5 @@
     <path android:strokeColor="#C4A060" android:strokeWidth="0.5" android:strokeAlpha="0.45"
         android:pathData="M58,84.2 L93,84.5" />
 
+    </group>
 </vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Adaptive launcher icon (API 26+). -->
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
-</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Adaptive round launcher icon (API 26+). -->
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
-</adaptive-icon>


### PR DESCRIPTION
## Summary

Users on Android 8+ were still seeing an "old"-looking launcher icon: a mostly-empty brown card with halo and rays, and no Bible. Root cause was that `mipmap-anydpi-v26/ic_launcher.xml` defined an adaptive icon backed by the vector drawable in `drawable/ic_launcher_foreground.xml`, where the Bible artwork was drawn at `y=78–87` of the 108dp viewport — outside the adaptive-icon safe zone. Launcher masks (circle/squircle/rounded square) cropped the Bible off entirely.

Since the photorealistic raster PNGs in `mipmap-*dpi/ic_launcher.png` are the intended design, the fix is to delete the adaptive-icon XMLs so every Android version falls back to the PNGs.

## Changes

- Delete `android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml`
- Delete `android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml`

(The branch also contains an earlier scale-into-safe-zone attempt on the vector drawable and its revert, kept in history for context.)

## Trade-off

Without an adaptive icon, the app loses themed-icon support on Android 13+ and launcher parallax. The PNG already has a rounded-square card baked in, so visually it still looks like a proper app icon.

## Test plan

- [ ] Build a debug APK and install on an Android 8+ device/emulator
- [ ] Confirm the launcher shows the photorealistic Bible icon (not the brown-with-rays version)
- [ ] Verify on an Android < 8 device/emulator (raster PNG path unchanged)
- [ ] Clear launcher cache / reboot if the old icon is still cached


---
_Generated by [Claude Code](https://claude.ai/code/session_01F54HWpMnNBDFhJH4Tud5ZZ)_