### PR TITLE
chore: disable header-max-length and fix duplicate rule in commitlint config

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -3,13 +3,14 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
-    "body-max-line-length": [2, "always", 200],
     "type-enum": [
       2,
       "always",
       ["feat", "fix", "perf", "revert", "docs", "chore", "build", "ci", "refactor", "test", "style", "merge"],
     ],
-    // Disable line-length check on commit body — URLs frequently exceed 100 chars.
+    // Disable line-length checks — URLs and Dependabot group-update titles
+    // frequently exceed the 100-char default from config-conventional.
+    "header-max-length": [0],
     "body-max-line-length": [0],
   },
 };


### PR DESCRIPTION
## Problem

Dependabot group-update PR titles (111–121 chars) were failing the `Lint PR Title` CI check because `@commitlint/config-conventional` defaults `header-max-length` to 100 chars and this project's `commitlint.config.cjs` did not override it.

Additionally, `body-max-line-length` was defined twice in the config — the second entry won, but this was confusing.

## Changes

- Set `"header-max-length": [0]` to disable the limit (consistent with `body-max-line-length: [0]` already present)
- Remove the duplicate `body-max-line-length` entry

## Why

URLs and Dependabot group-update titles routinely exceed 100 chars. Enforcing a hard limit breaks CI for valid dependency-bump PRs and provides little practical value in this project.

---
_Generated by [Claude Code](https://claude.ai/code/session_018HgafCVRqnEvmLLk4E6Jhh)_