### PR TITLE
fix(ops): route contact form and diagnostic emails to support@voxquieta.org

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
     smtp2go_api_key: str | None = None  # SMTP2GO API key
     smtp2go_sender_email: str = "noreply@voxquieta.org"
     smtp2go_sender_name: str = "Vox Quieta"
-    contact_notification_email: str = "contact@voxquieta.org"
+    contact_notification_email: str = "support@voxquieta.org"
 
     # Production frontend URL (used for CORS, access audit, and Referer headers)
     # Change this when migrating to a new domain.

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -126,7 +126,7 @@ custom_domain_backend  = "api.voxquieta.org"
 smtp2go_enabled            = true
 smtp2go_sender_email       = "noreply@voxquieta.org"
 smtp2go_sender_name        = "Vox Quieta"
-contact_notification_email = "contact@voxquieta.org"
+contact_notification_email = "support@voxquieta.org"
 
 # -----------------------------------------------------------------------------
 # Cloudflare Turnstile (Bot Protection)

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -466,7 +466,7 @@ variable "smtp2go_sender_name" {
 variable "contact_notification_email" {
   description = "Email address to receive contact form notifications"
   type        = string
-  default     = "contact@voxquieta.org"
+  default     = "support@voxquieta.org"
 }
 
 # -----------------------------------------------------------------------------

--- a/docs/BACKLOG_STORIES/BITB-032-route-support-emails-to-dedicated-inbox.md
+++ b/docs/BACKLOG_STORIES/BITB-032-route-support-emails-to-dedicated-inbox.md
@@ -1,5 +1,7 @@
 # BITB-032: Route Support/Diagnostic Emails to `support@voxquieta.org`
 
+**Status:** ✅ Done — code change merged; activate by provisioning `support@voxquieta.org` mailbox and applying Terraform.
+
 ## User Story
 
 As the product team, I want contact-form submissions and diagnostic bug


### PR DESCRIPTION
## Summary

- Change `contact_notification_email` default from `contact@voxquieta.org` to `support@voxquieta.org` in `api/config.py`
- Update Terraform default in `deployment/variables.tf` to match
- Update `deployment/terraform.tfvars` to the new address so the next `terraform apply` routes emails correctly

## Why

Contact-form submissions and diagnostic bug reports currently land in the general `contact@voxquieta.org` inbox. Routing them to `support@voxquieta.org` separates support/diagnostic traffic from general inbound mail and makes triaging easier.

## ⚠️ Merge gate

**Do not merge until `support@voxquieta.org` exists (or is aliased) at the mail provider.** The `CONTACT_NOTIFICATION_EMAIL` env var overrides the default in all deployed environments — you can set it independently of this PR if the mailbox is already live and the Terraform state has not been re-applied yet.

## Test plan

- [ ] Verify `api/config.py` default is `support@voxquieta.org`
- [ ] Verify `deployment/variables.tf` default is `support@voxquieta.org`
- [ ] Verify `deployment/terraform.tfvars` value is `support@voxquieta.org`
- [ ] After provisioning mailbox: confirm a contact-form submission arrives at `support@voxquieta.org`
- [ ] Confirm no other env-var or secrets-manager override still points to `contact@voxquieta.org`

Closes BITB-032.

https://claude.ai/code/session_01C3enBtdZKHrVvxUafv5xiG

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3enBtdZKHrVvxUafv5xiG)_