### PR TITLE
fix(frontend): prevent horizontal overflow on narrow mobile viewports

### DIFF
--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -97,7 +97,7 @@ export default async function LocaleLayout({
         <NextIntlClientProvider messages={messages}>
           <Providers>
             <ErrorBoundary>
-              <div className="min-h-screen bg-gradient-to-b from-primary-50 to-white flex flex-col">
+              <div className="min-h-screen bg-gradient-to-b from-primary-50 to-white flex flex-col overflow-x-hidden">
                 <div className="flex-1">{children}</div>
                 <Footer />
               </div>

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -686,7 +686,7 @@ export default function Home() {
   return (
     <main className="flex h-dvh">
       {/* Main Chat Area */}
-      <div className="flex-1 min-w-0 flex flex-col max-w-4xl mx-auto">
+      <div className="flex-1 min-w-0 w-full flex flex-col max-w-4xl mx-auto overflow-x-hidden">
         {/* Header */}
         <header className="sticky top-0 z-10 bg-white/80 backdrop-blur-sm border-b border-primary-100 px-3 py-3 sm:px-6 sm:py-4">
           <div className="flex items-center justify-between">
@@ -712,7 +712,7 @@ export default function Home() {
                   onChange={(e) => handleTranslationChange(e.target.value)}
                   disabled={translations.length === 0}
                   aria-label={tHeader("bibleVersion")}
-                  className={`text-sm border border-gray-200 rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 ${
+                  className={`text-sm border border-gray-200 rounded-lg px-2 py-1.5 max-w-[8rem] sm:max-w-none truncate focus:outline-none focus:ring-2 focus:ring-primary-500 ${
                     translations.length === 0
                       ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                       : "bg-white text-gray-600"

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8,6 +8,10 @@
   --background-end-rgb: 255, 255, 255;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(


### PR DESCRIPTION
## Summary

Fixes the actual mobile-web bug that PR #596 misdiagnosed: the page horizontally overflows narrow phone viewports, clipping the verse-references FAB off the right edge and forcing users to pan to reach the right edge of the chat.

Root cause: the header's Bible-version `<select>` has an intrinsic width driven by its longest localized option label (e.g. `Italiano - CEI 2008`), which pushed the header row wider than the viewport on phones < ~390 px. `body { overflow-x: hidden }` was set but not paired on `html`, which is unreliable across mobile browsers.

PR #596 proposed relocating the FAB from `bottom-28 right-4` to `top-20 right-4`, but the top-right area is already occupied by the language switcher and Bible-version select — that move would have created a new collision instead of fixing the underlying overflow. #596 has been closed.

## Changes

- `frontend/src/app/[locale]/page.tsx`
  - Bible-version `<select>` capped at `max-w-[8rem] truncate` on mobile; full width returns at the `sm:` breakpoint.
  - Main chat container gets `w-full overflow-x-hidden` as a defensive guard.
  - FAB position is unchanged (`bottom-28 right-4 z-40`).
- `frontend/src/app/[locale]/layout.tsx` — `overflow-x-hidden` on the layout wrapper.
- `frontend/src/app/globals.css` — `overflow-x: hidden` added on `html`, paired with the existing rule on `body`.

## Test plan

- [ ] Frontend unit tests pass (`cd frontend && npm ci && npx vitest run`) — not run in this ephemeral container (`node_modules` not installed); changes are className/CSS only.
- [ ] Open the web app on a phone (or Chrome DevTools at 360×800, 390×844, 414×896): page does not scroll horizontally; FAB at bottom-right is fully visible without panning.
- [ ] Send a message that returns scripture context: the FAB renders, and tapping it opens the slide-over within the viewport.
- [ ] Bible-version `<select>` is reachable on mobile and shows truncated label; full label visible at `sm:` and above.
- [ ] Desktop (`lg:` and above) layout unchanged — sidebar present, FAB hidden.

Refs #596 (closed).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Xck1hqTjyBk1HAALXDXjS)_