### PR TITLE
build(deps-backend): bump fastapi from 0.136.0 to 0.136.1 and uvicorn from 0.44.0 to 0.46.0

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,6 @@
 # Web Framework
-fastapi==0.136.0
-uvicorn[standard]==0.44.0
+fastapi==0.136.1
+uvicorn[standard]==0.46.0
 pydantic==2.13.3
 pydantic-settings==2.14.0
 


### PR DESCRIPTION
Replaces Dependabot PR #444 which could not be cleanly squash-merged because its base had diverged after the sequential pydantic/anthropic/azure-monitor merges.\n\nBumps:\n- `fastapi` 0.136.0 → 0.136.1\n- `uvicorn[standard]` 0.44.0 → 0.46.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn4wqdn7tNMXn6DAqgZEbr)_