### PR TITLE
chore(config): remove dangling GEMINI.md symlink and groom backlog (BITB-015)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/docs/BACKLOG_STORIES/BITB-015-consolidate-agent-configuration.md
+++ b/docs/BACKLOG_STORIES/BITB-015-consolidate-agent-configuration.md
@@ -1,7 +1,7 @@
 # BITB-015: Consolidate Agent Configuration
 
 **Priority:** P1 (High)
-**Status:** 🎯 Todo
+**Status:** ✅ Done (GEMINI.md dangling symlink removed 2026-05-24; PO prompt in opencode.json; CLAUDE.md deleted)
 **Size:** S (< 3 hours)
 **Created:** 2026-03-04
 

--- a/docs/BACKLOG_STORIES/BITB-023-android-gemini-agent.md
+++ b/docs/BACKLOG_STORIES/BITB-023-android-gemini-agent.md
@@ -1,7 +1,7 @@
 # BITB-023: Add Gemini 2.5 Pro Android Agent to opencode.json
 
 **Priority:** P1 (High)
-**Status:** 🎯 Todo
+**Status:** ✅ Done (PR #609 merged 2026-05-24 — android-gemini agent backed by Qwen3 Coder via OpenRouter added to opencode.json)
 **Size:** S (< 2 hours)
 **Created:** 2026-03-06
 

--- a/docs/BACKLOG_STORIES/BITB-024-fix-contact-turnstile-token.md
+++ b/docs/BACKLOG_STORIES/BITB-024-fix-contact-turnstile-token.md
@@ -1,5 +1,7 @@
 # BITB-024: Fix Contact Form Turnstile Token Expiry
 
+**Status:** ✅ Done (turnstile.tsx has expired-callback nulling token + auto-refresh + retry/backoff + awaitToken; verified 2026-05-24)
+
 ## User Story
 
 As a user, I want to submit the contact form so that I can report bugs and request features.

--- a/docs/BACKLOG_STORIES/BITB-025-verse-linking-android.md
+++ b/docs/BACKLOG_STORIES/BITB-025-verse-linking-android.md
@@ -1,5 +1,7 @@
 # BITB-025: Verify and Fix Verse Linking in Android Chat
 
+**Status:** ✅ Done (buildVerseRefRegex/verseRefRegex wired into ChatMessageItem with ParseVerseLinkTest + VerseRefLinkTest; verified 2026-05-24)
+
 ## User Story
 
 As a user, I want to tap on Bible verse references in chat messages to see the full chapter, so I can read the complete context.

--- a/docs/BACKLOG_STORIES/BITB-026-android-settings-improvements.md
+++ b/docs/BACKLOG_STORIES/BITB-026-android-settings-improvements.md
@@ -1,5 +1,7 @@
 # BITB-026: Android Settings UX Improvements
 
+**Status:** ✅ Done (SettingsScreen.kt already has read-only translation row, clear-history button with confirm dialog, reordered sections; verified 2026-05-24)
+
 ## User Story
 
 As an Android user, I want the Settings screen to be clean and purposeful, so that I can find global preferences quickly without redundant controls that already exist in the chat screen.

--- a/docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md
+++ b/docs/BACKLOG_STORIES/BITB-028-pipeline-path-filters.md
@@ -1,5 +1,7 @@
 # BITB-028: Skip Irrelevant CI Pipelines on Doc-Only / Story-Only Changes
 
+**Status:** ✅ Done (test_update.yml already has path filters added in PR #577 on 2026-05-17; verified 2026-05-24)
+
 ## User Story
 
 As a contributor, I want CI to skip pipelines that have nothing to do with my change (e.g. backend + frontend + integration tests when I only added a story under `docs/BACKLOG_STORIES/`), so that PRs that touch only documentation don't burn ~15 minutes of runner time and don't show a wall of unrelated failed/queued checks.

--- a/docs/BACKLOG_STORIES/BITB-030-android-chat-language-picker.md
+++ b/docs/BACKLOG_STORIES/BITB-030-android-chat-language-picker.md
@@ -1,6 +1,6 @@
 # BITB-030: ChatScreen Top App Bar Cleanup — Language + Bible Version Only
 
-**Status:** 🚧 In Progress
+**Status:** ✅ Done (ChatTopBarPolicy.kt enforces Language + Bible version only; extras moved to drawer; verified 2026-05-24)
 **Priority:** P3
 **Size:** S (< 4 hours)
 **Created:** 2026-05-10

--- a/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
+++ b/docs/BACKLOG_STORIES/BITB-031-android-settings-changelog.md
@@ -1,6 +1,6 @@
 # BITB-031: Android Settings — "What's New" / Changelog Screen
 
-**Status:** 🚧 In Progress (PR #546 open — 2026-05-13)
+**Status:** ✅ Done (PR #546 merged 2026-05-13 — What's New / Changelog screen added to Settings)
 
 ## User Story
 

--- a/docs/BACKLOG_STORIES/BITB-033-android-rename-post-send-cancel-button.md
+++ b/docs/BACKLOG_STORIES/BITB-033-android-rename-post-send-cancel-button.md
@@ -1,5 +1,7 @@
 # BITB-033: Android — Rename Post-Send "Cancel" Button to "Done"
 
+**Status:** ✅ Done (DiagnosticReportBottomSheet.kt:120 and ContactFormBottomSheet.kt:141 already use R.string.action_done; verified 2026-05-24)
+
 ## User Story
 
 As an Android user who has just sent a diagnostic report or a contact

--- a/docs/BACKLOG_STORIES/BITB-034-android-compose-ui-test-tier.md
+++ b/docs/BACKLOG_STORIES/BITB-034-android-compose-ui-test-tier.md
@@ -1,7 +1,7 @@
 # BITB-034: Android — Add Robolectric/Compose UI Test Tier
 
 **Priority:** P2 (Medium — closes a regression gap exposed by #551, not user-blocking)
-**Status:** 📋 Ready
+**Status:** ✅ Done (android-compose-tests.yml workflow active + androidTest/ files present including MainActivityTest and HiltTestRunner; verified 2026-05-24)
 **Size:** M (4-6 hours)
 **Created:** 2026-05-14
 **Updated:** 2026-05-15


### PR DESCRIPTION
## Summary

- **Remove `GEMINI.md`** — the file was a symlink to `CLAUDE.md`, which was deleted when agent prompts moved into `opencode.json` (BITB-015). The orphaned dangling symlink breaks any tool that dereferences it (e.g. Gemini CLI). Removing it completes BITB-015.
- **Backlog grooming** — the Opus planning agent verified 9 backlog stories whose implementations are already in the codebase but whose status files still read "Todo" or "In Progress". This PR marks them Done so future planning sessions don't collide with already-shipped work.

## Stories marked Done

| Story | Evidence |
|---|---|
| BITB-015 | PO prompt in `opencode.json`; `CLAUDE.md` deleted; `GEMINI.md` dangling symlink now removed |
| BITB-023 | PR #609 merged — `android-gemini` agent in `opencode.json` |
| BITB-024 (turnstile) | `turnstile.tsx` has `expired-callback`, auto-refresh, retry/backoff, `awaitToken` |
| BITB-025 | `buildVerseRefRegex`/`verseRefRegex` wired into `ChatMessageItem`; `ParseVerseLinkTest` + `VerseRefLinkTest` present |
| BITB-026 | `SettingsScreen.kt` has read-only translation row, clear-history button + confirm dialog, reordered sections |
| BITB-028 (pipeline) | `test_update.yml` already has `paths:` filters on `api/**`, `frontend/**`, etc. (PR #577) |
| BITB-030 | `ChatTopBarPolicy.kt` enforces Language + Bible version only; extras in drawer |
| BITB-031 | PR #546 merged — What's New / Changelog screen in Settings |
| BITB-033 | Both bottom-sheet success buttons already use `R.string.action_done` |
| BITB-034 | `android-compose-tests.yml` active + `androidTest/` files present |

## Test plan

- [x] `git ls-files GEMINI.md` → empty (symlink removed from index)
- [x] `ls GEMINI.md` → "No such file or directory"
- [x] Pre-commit hooks pass (only doc changes; no code modified)
- [x] No runtime code references `GEMINI.md`

https://claude.ai/code/session_01X6nzqNL81FVBZ9ufLskxLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6nzqNL81FVBZ9ufLskxLs)_