### PR TITLE
feat(android): make tag publish track configurable and add production promotion

### DIFF
--- a/.github/workflows/android-promote.yml
+++ b/.github/workflows/android-promote.yml
@@ -1,0 +1,102 @@
+name: Android Promote
+
+# Promotes an already-uploaded versionCode from one Play Store track to
+# another WITHOUT rebuilding. Use this once the closed test has satisfied
+# Google's production gate (>=12 testers for >=14 continuous days): the exact
+# build testers approved is promoted to production, rather than a fresh AAB.
+#
+# Find the versionCode to promote in Play Console (or the AAB artifact name /
+# build log of the run that published it to the source track).
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      promote_version_code:
+        description: "versionCode of the build to promote (must already exist on the source track)."
+        required: true
+        type: string
+      promote_from:
+        description: "Source track the build currently lives on."
+        required: true
+        default: "extend testing"
+        type: string
+      promote_to:
+        description: "Destination track to promote into."
+        required: true
+        default: "production"
+        type: choice
+        options:
+          - production
+          - beta
+          - alpha
+      release_status:
+        description: "Release status on the destination track. 'draft' = review in Play Console before going live."
+        required: false
+        default: "draft"
+        type: choice
+        options:
+          - draft
+          - completed
+      rollout:
+        description: "Phased rollout fraction (0.0-1.0). Only applied when release_status = completed."
+        required: false
+        default: "0.1"
+        type: string
+
+run-name: "Android Promote ${{ inputs.promote_version_code }}: ${{ inputs.promote_from }} → ${{ inputs.promote_to }}"
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: Promote build between tracks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby for Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: android
+
+      - name: Install Fastlane
+        working-directory: android
+        run: gem install fastlane --no-document
+
+      - name: Decode Google Play JSON key
+        run: |
+          echo "${{ secrets.GOOGLE_PLAY_JSON_KEY }}" | base64 --decode > /tmp/google-play-key.json
+
+      - name: Promote on Play Store
+        working-directory: android
+        env:
+          GOOGLE_PLAY_JSON_KEY_FILE: /tmp/google-play-key.json
+          PROMOTE_VERSION_CODE: ${{ inputs.promote_version_code }}
+          PROMOTE_FROM: ${{ inputs.promote_from }}
+          PROMOTE_TO: ${{ inputs.promote_to }}
+          RELEASE_STATUS: ${{ inputs.release_status }}
+          ROLLOUT: ${{ inputs.rollout }}
+          FASTLANE_HIDE_TIMESTAMP: "true"
+          FASTLANE_SKIP_UPDATE_CHECK: "true"
+          SUPPLY_VERBOSE: "true"
+        run: |
+          set -o pipefail
+          fastlane promote --verbose 2>&1 | tee /tmp/fastlane.log
+
+      - name: Upload Fastlane log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fastlane-log-promote-${{ github.run_id }}
+          path: |
+            /tmp/fastlane.log
+            android/fastlane/report.xml
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -264,19 +264,37 @@ jobs:
 
       - name: Determine Fastlane lane
         id: lane
+        # The Play Store track a tag publishes to is a *single dial*: the
+        # repository Actions variable ANDROID_AUTO_TRACK. Flip it in
+        # Repo → Settings → Secrets and variables → Actions → Variables to
+        # advance the app up the ladder (internal → <closed> → beta →
+        # production) with no code change. Empty/unset falls back to
+        # "internal" so the pipeline is safe by default. Reading a `vars.*`
+        # value needs no extra workflow permission.
+        #
+        # Track → lane mapping: the named tracks have dedicated lanes; any
+        # other value (e.g. a custom closed-testing trackId like
+        # "extend testing") routes through the closed_testing lane, which
+        # reads CLOSED_TESTING_TRACK (set in the upload step below).
+        env:
+          AUTO_TRACK: ${{ vars.ANDROID_AUTO_TRACK }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
-            # Tag pushes (release-please tags) go to the **internal** track
-            # until the app has an established production presence. Promoting
-            # straight to production for the first time triggers Play Console
-            # precondition errors (no prior production release to compare
-            # against) and is operationally risky — we want internal testers
-            # to validate each tag before any production rollout. Promote to
-            # beta/production manually via workflow_dispatch when ready.
-            echo "lane=internal" >> "$GITHUB_OUTPUT"
+            TRACK="${AUTO_TRACK:-internal}"
           else
-            echo "lane=${{ inputs.track }}" >> "$GITHUB_OUTPUT"
+            TRACK="${{ inputs.track }}"
           fi
+          echo "Resolving Play Store track '${TRACK}' to a Fastlane lane."
+          case "${TRACK}" in
+            internal|alpha|beta|production|validate)
+              echo "lane=${TRACK}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              # Custom closed-testing track (e.g. "extend testing").
+              echo "lane=closed_testing" >> "$GITHUB_OUTPUT"
+              echo "closed_track=${TRACK}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
 
       - name: Upload to Play Store
         working-directory: android
@@ -285,6 +303,9 @@ jobs:
           # Empty value falls through to the lane-specific default in Fastfile
           # (internal/beta = completed, production = draft).
           RELEASE_STATUS: ${{ inputs.release_status }}
+          # Set only when the resolved lane is closed_testing; the Fastfile's
+          # closed_testing lane reads this and defaults to "alpha" if empty.
+          CLOSED_TESTING_TRACK: ${{ steps.lane.outputs.closed_track }}
           # Hide noisy fastlane banner, skip auto-update check, and make
           # supply log the underlying google-api-client HTTP request/response.
           # When upload_to_play_store returns a generic "Precondition check

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -104,6 +104,34 @@ platform :android do
     upload_to_play_store(**params)
   end
 
+  desc "Promote an already-uploaded versionCode from one track to another (no rebuild)"
+  # Promotes the *exact* build that was validated on the source track to the
+  # destination track, instead of re-uploading a freshly-built AAB. This is the
+  # production path: the artifact that production users receive is bit-for-bit
+  # the one closed testers approved. Production starts as 'draft' by default so
+  # a human reviews it in Play Console before going live; ROLLOUT enables a
+  # phased rollout once the release is set to 'completed'.
+  lane :promote do
+    status = release_status_for("draft")
+    params = {
+      version_code: Integer(ENV.fetch("PROMOTE_VERSION_CODE")),
+      track: ENV.fetch("PROMOTE_FROM", "extend testing"),
+      track_promote_to: ENV.fetch("PROMOTE_TO", "production"),
+      track_promote_release_status: status,
+      skip_upload_aab: true,
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    }
+    # Play Store rejects rollout + draft together. Only attach a rollout
+    # percentage when the promoted release is actually going live.
+    params[:rollout] = ENV.fetch("ROLLOUT", "0.1") unless status == "draft"
+
+    upload_to_play_store(**params)
+  end
+
   desc "Dry-run validate against Play Store (no edit committed, no AAB uploaded)"
   # Useful after a manual Play Console cleanup: confirms auth, AAB integrity,
   # and edit-preconditions without actually committing any changes. Runs against

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -202,7 +202,7 @@ publish routes to the matching Fastlane lane:
 
 > **Current value:** `extend testing` — the app is in closed testing with the
 > extended group. Every release now reaches those testers automatically.
-
+>
 > **Confirming a custom trackId:** any value that is not
 > `internal`/`alpha`/`beta`/`production` is treated as a closed-testing track
 > and passed through verbatim. Make sure it matches the Play Console trackId

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -29,8 +29,12 @@ android-publish.yml fires on push: tags: v*.*.*
         │      are CHANGELOG + manifest only; the parent is the real shipping
         │      code and already has a green Android CI verdict)
         ▼
-Internal track uploaded to Google Play
+Uploaded to the Google Play track named by the
+ANDROID_AUTO_TRACK repo variable (default: internal)
 ```
+
+The track a tag publishes to is a **single dial** — the `ANDROID_AUTO_TRACK`
+Actions variable. See [The publishing ladder](#the-publishing-ladder) below.
 
 No manual `git tag` is required.
 **Do NOT push `vX.Y.Z` tags by hand** — release-please manages them, and the
@@ -136,7 +140,8 @@ as a repository secret:
 Once the secret is in place, every merge of a Release PR will:
 
 - Push a `vX.Y.Z` tag using the PAT
-- Trigger `android-publish.yml` → upload to the **internal** Play Store track
+- Trigger `android-publish.yml` → upload to the Play Store track named by the
+  `ANDROID_AUTO_TRACK` variable (see [The publishing ladder](#the-publishing-ladder))
 
 > Note: `.github/workflows/release-please.yml` currently sets
 > `skip-labeling: true` to avoid intermittent GitHub API denials on
@@ -165,22 +170,84 @@ On merge of the Release PR:
 
 1. release-please pushes tag `vX.Y.Z`
 2. `android-publish.yml` triggers on `push: tags: v[0-9]+.[0-9]+.[0-9]+`
-3. The workflow builds a signed AAB and uploads it to the **internal** track on
-   Google Play
+3. The workflow builds a signed AAB and uploads it to the track named by the
+   `ANDROID_AUTO_TRACK` repo variable (see below)
 
-### Manual promotion to beta / production
+### The publishing ladder
+
+A Google Play app climbs a ladder of tracks before reaching all users:
+
+```
+internal  →  closed testing (e.g. "extend testing")  →  beta (open)  →  production
+```
+
+Rather than hardcode which track tags publish to, the pipeline reads a single
+**Actions repository variable**, `ANDROID_AUTO_TRACK`. The tag-triggered
+publish routes to the matching Fastlane lane:
+
+| `ANDROID_AUTO_TRACK` value | Goes to |
+| -------------------------- | ------- |
+| _unset / empty_            | `internal` (safe default) |
+| `internal`                 | Internal testing |
+| `alpha`                    | Closed testing (built-in alpha track) |
+| `extend testing` (or any other custom trackId) | That closed testing track |
+| `beta`                     | Open testing |
+| `production`               | Production |
+
+**To advance the app up the ladder, change the variable — no code change:**
+
+1. Go to **Repo → Settings → Secrets and variables → Actions → Variables**.
+2. Edit (or create) `ANDROID_AUTO_TRACK` and set it to the target trackId.
+3. The next merged Release PR publishes straight to that track.
+
+> **Current value:** `extend testing` — the app is in closed testing with the
+> extended group. Every release now reaches those testers automatically.
+
+> **Confirming a custom trackId:** any value that is not
+> `internal`/`alpha`/`beta`/`production` is treated as a closed-testing track
+> and passed through verbatim. Make sure it matches the Play Console trackId
+> exactly. The **List available Play Store tracks** step in
+> `android-closed-testing.yml` prints the exact trackIds for the app.
+
+### Reaching production
+
+Google requires a (new) developer account to run a **closed test with at least
+12 testers for at least 14 continuous days** before the production track
+unlocks. Until that gate is satisfied, keep `ANDROID_AUTO_TRACK` on the closed
+track and let testers accumulate days.
+
+Once eligible, **promote the exact build that testers approved** — do not ship
+a freshly-built AAB to production. Use the **Android Promote** workflow
+(`android-promote.yml`), which runs the Fastfile `promote` lane and moves an
+existing `versionCode` between tracks without rebuilding:
+
+1. Find the `versionCode` of the build to promote (Play Console → the release
+   on the closed track, or the AAB artifact name / build log of the run that
+   published it).
+2. Go to **Repository → Actions → Android Promote → Run workflow**.
+3. Fill in `promote_version_code`, `promote_from` (default `extend testing`),
+   `promote_to` (default `production`), `release_status` (default `draft`), and
+   `rollout` (phased fraction, applied only when status is `completed`).
+4. With `draft`, review the staged release in Play Console, then set the
+   rollout live there (or re-run with `release_status: completed` and a
+   `rollout` fraction for a phased launch).
+
+### Manual one-off publish (workflow_dispatch)
 
 `android-publish.yml` also has a `workflow_dispatch` trigger with a `track`
-input (`internal` | `beta` | `production`). To promote a build:
+input (`validate` | `internal` | `alpha` | `beta` | `production`) for ad-hoc
+builds. To publish a fresh build to a specific track:
 
-1. Go to **Repository → Actions → Android Publish**.
-2. Click **Run workflow**.
-3. Select the desired track and click **Run workflow**.
+1. Go to **Repository → Actions → Android Publish → Run workflow**.
+2. Select the desired track and click **Run workflow**.
 
 > **Note:** The `workflow_dispatch` path does not bump the version — it uses the
 > `versionName` and `versionCode` from `android/app/build.gradle.kts`. For a
 > manual dispatch to have the correct version, ensure `build.gradle.kts` matches
 > the version you intend to publish, or use the tag-triggered path instead.
+>
+> For production, prefer **Android Promote** over a fresh `production` dispatch
+> so the artifact users get is the one that was actually tested.
 
 ---
 


### PR DESCRIPTION
Tag-triggered publishes previously always went to the internal track. Read
the ANDROID_AUTO_TRACK repo variable so releases reach the app's current
track (now: closed "extend testing") with no per-release manual step, and
advance the ladder by flipping the variable. Add an Android Promote workflow
and Fastfile lane to promote the tested versionCode to production without
rebuilding. Document the ladder, the dial, and Google's closed-test gate.

https://claude.ai/code/session_01DHGGAnkaCtCnqD9Lj2bnek