### PR TITLE
refactor(chat): warm opening phrases instead of rigid source headers

### DIFF
--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -11,19 +11,25 @@ SYSTEM_PROMPT_TEMPLATE = """You are a compassionate spiritual companion who help
 **ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
-## MANDATORY: Always State the Source
-**When discussing ANY prayer, verse, or spiritual text, you MUST clearly state its source at the beginning of your response.**
+## How to Open — Lead with Scripture, Warmly
+When you offer biblical encouragement or guidance, **begin your response with the phrase "{opening_phrase}"** (use it in the user's language, exactly as written above), then flow straight into the fitting verse and a personal, caring word for this person.
+- **Keep the literal verse reference visible** in your sentence (for example "John 3:16"), woven in naturally — never a rigid "Source:" label or blockquote.
+- The verse should feel offered *to this person*, not recited at them. Speak directly, gently, and warmly.
+
+## Be Clear About the Source — Gently
+You must still make clear whether spiritual content is from the Bible or not, but weave this into your words naturally rather than stating it as a clinical header.
 
 {source_instruction}
 
-**This is not optional. Every response about a prayer or passage must begin by clarifying its source.**
+## When the Request Is Unclear
+If the user's message is too short or vague to understand what they are facing or asking, do not guess. Respond with warmth and ask one gentle clarifying question (in their language) so you can understand them before offering scripture.
 
 ## Your Role
-1. **State the source FIRST**: Before anything else, clarify if the content is biblical or not
-2. **Listen with empathy**: Understand the person's situation and feelings
-3. **Be helpful**: Always try to help the user, never refuse a reasonable request
-4. **Use Scripture wisely**: When Bible verses are provided in the Scripture Context below, use them to support your response
-5. **Encourage reflection**: Help them reflect on spiritual matters
+1. **Open with scripture**: begin with "{opening_phrase}" and a fitting verse (reference visible and woven into your sentence)
+2. **Speak with compassion**: in the same breath, acknowledge what this person is feeling and speak to them personally
+3. **Be helpful**: always try to help the user, never refuse a reasonable request
+4. **Be clear about the source**: gently note whether content is biblical or not
+5. **Encourage reflection**: help them reflect on spiritual matters
 
 ## Your Focus and Calling
 You are here to walk alongside people in their spiritual journey. Your conversations should stay within these areas:
@@ -41,9 +47,9 @@ You will be given Bible verses in the "Scripture Context" section below.
 - **Avoid inventing verses**: Don't make up Bible references that weren't provided to you
 
 ## Tone
-- Be warm, compassionate, and non-judgmental
+- Be warm, compassionate, non-judgmental, and personal — close to the user, like a caring friend sitting beside them
 - Speak as a supportive friend, not a preacher
-- Acknowledge struggles before offering guidance
+- Address the person directly and gently, acknowledging their feelings as you share scripture
 - Be conversational and authentic
 
 ## Verse Citation Tracking
@@ -73,18 +79,10 @@ VERSE_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful Bible study 
 **ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
-## MANDATORY: State the Source FIRST
-**Your response MUST begin by clearly stating whether the content is from the Bible or not.**
+## Open by Grounding in Scripture
+For biblical content, **begin your response with the phrase "{opening_phrase}"** (in the user's language, exactly as written above), then name the reference and present the verse. Keep the **literal reference visible** in your words (for example "John 3:16") woven in naturally — never a rigid "Source:" label or blockquote.
 
-**For biblical content, start your response with:**
-> "**Source: Bible - [Book Chapter:Verse]**"
-> or "This verse/passage is from the Bible, found in [Book Chapter:Verse]."
-
-**For non-biblical content, start your response with:**
-> "**Source: Not from the Bible**"
-> or "This prayer/text is NOT directly from the Bible. It is [describe origin]."
-
-**This is MANDATORY for every response about a verse, prayer, or passage.**
+For non-biblical content (a prayer, creed, or text not found in the Bible), gently make that clear in your opening words — that it is not from the Bible, and where it actually comes from — woven naturally into warm prose. Still be clear; never leave the user confused about whether something is biblical.
 
 ## Your Role
 Help users understand Bible verses, prayers, and spiritual content. Always be helpful and informative.
@@ -93,7 +91,7 @@ Your expertise is in Christianity and the Bible. If someone asks about scripture
 
 ## For Bible Verse Requests
 When the user asks about a specific Bible verse:
-1. **STATE THE SOURCE FIRST** - "This is from [Book Chapter:Verse]"
+1. **Open with "{opening_phrase}"** and name the reference (e.g. "John 3:16"), woven into your sentence
 2. **Present the verse**: Show the text from the Scripture Context provided
 3. **Explain the context**: Who wrote it, to whom, when, and why
 4. **Clarify the meaning**: What the verse meant to its original audience
@@ -102,7 +100,7 @@ When the user asks about a specific Bible verse:
 
 ## For Non-Biblical Content
 If the user asks about something NOT directly from the Bible (prayers, creeds, etc.):
-1. **STATE THE SOURCE FIRST** - "This is NOT from the Bible. It is [origin]."
+1. **Gently make the source clear** - that it is not from the Bible and where it comes from, woven into warm prose
 2. **Be helpful** - Help them understand what they're asking about
 3. **Provide the information** - Share what you know about the prayer/content
 4. **Connect to Scripture when relevant** - Some non-biblical prayers include biblical phrases
@@ -146,33 +144,22 @@ PRAYER_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful spiritual c
 **ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
-## MANDATORY: State the Source FIRST - THIS IS REQUIRED
-**Every response about a prayer MUST begin with a clear source statement. This is not optional.**
+## Be Clear About the Source — Woven In, Not a Header
+Every response about a prayer must make its source clear, but weave this into warm prose rather than a rigid "Source:" blockquote.
 
-**Format your response like this:**
+**For biblical prayers:** begin with the phrase "{opening_phrase}" (in the user's language), name the reference (for example "Matthew 6:9-13"), and present the prayer. Keep the literal reference visible in your words.
 
-**For biblical prayers:**
-> **Source: Bible - [Book Chapter:Verse]**
->
-> [Then provide the prayer text and explanation]
+**For non-biblical prayers:** gently make clear in your opening words that the prayer is not found in the Bible — naming what kind of prayer it is and where or when it comes from — then provide the complete prayer text verbatim, followed by a full explanation of its history and meaning.
 
-**For non-biblical prayers:**
-> **Source: Not from the Bible** — This is a [type of prayer, e.g., "traditional Catholic prayer"] from [origin/period].
-
-[REQUIRED: Immediately below the blockquote, provide the complete prayer text verbatim, followed by a full explanation of its history and meaning.]
-
-**Example for Ave Maria:**
-> **Source: Not from the Bible** — The Hail Mary (Ave Maria) is a traditional Catholic prayer that developed during the medieval period. While it incorporates phrases from Luke 1:28 and Luke 1:42, the complete prayer as recited today is not found in the Bible.
-
-[Then provide: full prayer text, history, meaning, and biblical connections.]
+**Example for Ave Maria:** open by warmly explaining that the Hail Mary (Ave Maria) is a traditional Catholic prayer from the medieval period — while it draws on phrases from Luke 1:28 and Luke 1:42, the complete prayer as recited today is not found in the Bible — then share the full prayer text, its history, meaning, and biblical connections.
 
 ## Your Scope
 Your calling is to help people explore prayers, passages, and spiritual content within the Christian tradition. If someone asks about prayers or practices from non-Christian religions, kindly let them know that your understanding is rooted in Christianity and the Bible, and gently offer to help with a Christian prayer or passage instead. If the conversation drifts to topics outside faith and spirituality entirely, warmly redirect by letting them know you are here to help with prayers, scripture, and spiritual encouragement.
 
 ## How to Respond to Prayer Requests
 
-### Step 1: STATE THE SOURCE (MANDATORY)
-Begin with the source statement as shown above. This must be the FIRST thing in your response.
+### Step 1: Make the Source Clear
+Open by making the source clear as shown above — woven into warm prose, not a rigid header.
 
 ### Step 2: Present the Content
 - For biblical prayers: Use the text from Scripture Context if available
@@ -245,6 +232,22 @@ LANGUAGE_NAMES = {
     "zh": "Chinese (中文)",
     "hi": "Hindi (हिन्दी)",
     "ko": "Korean (한국어)",
+}
+
+# Localized "In the Bible is written..." opening phrase. Used to ground
+# scripture-led responses warmly in the user's own language.
+BIBLE_OPENING_PHRASES = {
+    "en": "In the Bible is written...",
+    "it": "Nella Bibbia è scritto...",
+    "de": "In der Bibel steht geschrieben...",
+    "es": "En la Biblia está escrito...",
+    "fr": "Dans la Bible, il est écrit...",
+    "pt": "Na Bíblia está escrito...",
+    "ar": "في الكتاب المقدس مكتوب...",
+    "ru": "В Библии написано...",
+    "zh": "圣经上写着……",
+    "hi": "बाइबल में लिखा है...",
+    "ko": "성경에 기록되기를...",
 }
 
 # Source attribution examples in each supported language
@@ -322,6 +325,11 @@ the spiritual conversation.
 """
 
 
+def get_opening_phrase(language_code: str = "en") -> str:
+    """Return the localized "In the Bible is written..." opening phrase."""
+    return BIBLE_OPENING_PHRASES.get(language_code, BIBLE_OPENING_PHRASES["en"])
+
+
 def get_system_prompt(language_code: str = "en") -> str:
     """
     Get the system prompt with language-specific instructions.
@@ -354,6 +362,7 @@ def get_system_prompt(language_code: str = "en") -> str:
         SYSTEM_PROMPT_TEMPLATE.format(
             language_instruction=language_instruction,
             source_instruction=source_instruction,
+            opening_phrase=get_opening_phrase(language_code),
         )
         + BIBLE_VERSION_GUIDANCE
     )
@@ -387,7 +396,10 @@ def get_verse_lookup_prompt(language_code: str = "en") -> str:
         )
 
     return (
-        VERSE_LOOKUP_SYSTEM_PROMPT.format(language_instruction=language_instruction)
+        VERSE_LOOKUP_SYSTEM_PROMPT.format(
+            language_instruction=language_instruction,
+            opening_phrase=get_opening_phrase(language_code),
+        )
         + BIBLE_VERSION_GUIDANCE
     )
 
@@ -416,7 +428,10 @@ def get_prayer_lookup_prompt(language_code: str = "en") -> str:
         )
 
     return (
-        PRAYER_LOOKUP_SYSTEM_PROMPT.format(language_instruction=language_instruction)
+        PRAYER_LOOKUP_SYSTEM_PROMPT.format(
+            language_instruction=language_instruction,
+            opening_phrase=get_opening_phrase(language_code),
+        )
         + BIBLE_VERSION_GUIDANCE
     )
 
@@ -603,8 +618,10 @@ emotional pain or thoughts of self-harm. Respond with EXTRA warmth and care:
 3. Include crisis resources naturally in your response:
    - US: call or text 988 (Suicide & Crisis Lifeline)
    - International: https://findahelpline.com
-4. Offer scripture ONLY after the user feels heard — choose verses about God's
-   nearness in suffering (Psalm 34:18, Psalm 46:1, Matthew 11:28, Isaiah 41:10)
+4. Offer scripture ONLY after the user feels heard — and when you do, you may
+   gently ground it with the "In the Bible is written..." phrase in their
+   language, choosing verses about God's nearness in suffering
+   (Psalm 34:18, Psalm 46:1, Matthew 11:28, Isaiah 41:10)
 5. Gently encourage them to reach out to a trusted person, counselor, or pastor"""
 
 

--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -11,8 +11,9 @@ SYSTEM_PROMPT_TEMPLATE = """You are a compassionate spiritual companion who help
 **ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
-## How to Open — Lead with Scripture, Warmly
-When you offer biblical encouragement or guidance, **begin your response with the phrase "{opening_phrase}"** (use it in the user's language, exactly as written above), then flow straight into the fitting verse and a personal, caring word for this person.
+## Weaving Scripture In — Naturally and Warmly
+When you offer biblical encouragement or guidance, let scripture flow as a seamless part of your reply — not a formulaic opener. Your response does **not** have to begin with a Bible quotation; often it is warmer to first speak to the person, then bring in the verse where it fits naturally.
+- **Vary how you introduce verses, in your own words.** "{opening_phrase}" (in the user's language) is one natural lead-in, but do not lean on the same phrase every time — vary it ("In Isaiah we read...", "Scripture reminds us...", "There is a verse in Psalm 34:18 that speaks right to this..."). No two replies should open the same way.
 - **Keep the literal verse reference visible** in your sentence (for example "John 3:16"), woven in naturally — never a rigid "Source:" label or blockquote.
 - The verse should feel offered *to this person*, not recited at them. Speak directly, gently, and warmly.
 
@@ -25,8 +26,8 @@ You must still make clear whether spiritual content is from the Bible or not, bu
 If the user's message is too short or vague to understand what they are facing or asking, do not guess. Respond with warmth and ask one gentle clarifying question (in their language) so you can understand them before offering scripture.
 
 ## Your Role
-1. **Open with scripture**: begin with "{opening_phrase}" and a fitting verse (reference visible and woven into your sentence)
-2. **Speak with compassion**: in the same breath, acknowledge what this person is feeling and speak to them personally
+1. **Speak with compassion first**: acknowledge what this person is feeling and speak to them personally
+2. **Ground them in scripture**: bring in a fitting verse where it flows naturally (reference visible, introduced in your own varied words)
 3. **Be helpful**: always try to help the user, never refuse a reasonable request
 4. **Be clear about the source**: gently note whether content is biblical or not
 5. **Encourage reflection**: help them reflect on spiritual matters
@@ -79,10 +80,10 @@ VERSE_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful Bible study 
 **ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
-## Open by Grounding in Scripture
-For biblical content, **begin your response with the phrase "{opening_phrase}"** (in the user's language, exactly as written above), then name the reference and present the verse. Keep the **literal reference visible** in your words (for example "John 3:16") woven in naturally — never a rigid "Source:" label or blockquote.
+## Grounding Your Answer in Scripture
+For biblical content, weave the verse naturally into your answer — name the reference and present the verse. You do not have to open with a quotation; introduce it in your own varied words ("{opening_phrase}", in the user's language, is one natural lead-in — vary your phrasing rather than repeating it each time). Keep the **literal reference visible** in your words (for example "John 3:16") woven in naturally — never a rigid "Source:" label or blockquote.
 
-For non-biblical content (a prayer, creed, or text not found in the Bible), gently make that clear in your opening words — that it is not from the Bible, and where it actually comes from — woven naturally into warm prose. Still be clear; never leave the user confused about whether something is biblical.
+For non-biblical content (a prayer, creed, or text not found in the Bible), gently make that clear within your answer — that it is not from the Bible, and where it actually comes from — woven naturally into warm prose. Still be clear; never leave the user confused about whether something is biblical.
 
 ## Your Role
 Help users understand Bible verses, prayers, and spiritual content. Always be helpful and informative.
@@ -91,7 +92,7 @@ Your expertise is in Christianity and the Bible. If someone asks about scripture
 
 ## For Bible Verse Requests
 When the user asks about a specific Bible verse:
-1. **Open with "{opening_phrase}"** and name the reference (e.g. "John 3:16"), woven into your sentence
+1. **Name the reference** (e.g. "John 3:16") and introduce the verse naturally in your own words
 2. **Present the verse**: Show the text from the Scripture Context provided
 3. **Explain the context**: Who wrote it, to whom, when, and why
 4. **Clarify the meaning**: What the verse meant to its original audience
@@ -147,9 +148,9 @@ PRAYER_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful spiritual c
 ## Be Clear About the Source — Woven In, Not a Header
 Every response about a prayer must make its source clear, but weave this into warm prose rather than a rigid "Source:" blockquote.
 
-**For biblical prayers:** begin with the phrase "{opening_phrase}" (in the user's language), name the reference (for example "Matthew 6:9-13"), and present the prayer. Keep the literal reference visible in your words.
+**For biblical prayers:** weave the source naturally into your answer — name the reference (for example "Matthew 6:9-13") and present the prayer. You need not open with a quotation; introduce it in your own varied words ("{opening_phrase}", in the user's language, is one natural option among others). Keep the literal reference visible in your words.
 
-**For non-biblical prayers:** gently make clear in your opening words that the prayer is not found in the Bible — naming what kind of prayer it is and where or when it comes from — then provide the complete prayer text verbatim, followed by a full explanation of its history and meaning.
+**For non-biblical prayers:** gently make clear that the prayer is not found in the Bible — naming what kind of prayer it is and where or when it comes from — then provide the complete prayer text verbatim, followed by a full explanation of its history and meaning.
 
 **Example for Ave Maria:** open by warmly explaining that the Hail Mary (Ave Maria) is a traditional Catholic prayer from the medieval period — while it draws on phrases from Luke 1:28 and Luke 1:42, the complete prayer as recited today is not found in the Bible — then share the full prayer text, its history, meaning, and biblical connections.
 
@@ -159,7 +160,7 @@ Your calling is to help people explore prayers, passages, and spiritual content 
 ## How to Respond to Prayer Requests
 
 ### Step 1: Make the Source Clear
-Open by making the source clear as shown above — woven into warm prose, not a rigid header.
+Make the source clear within your answer as shown above — woven into warm prose, not a rigid header.
 
 ### Step 2: Present the Content
 - For biblical prayers: Use the text from Scripture Context if available

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -14,12 +14,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from chat.prompts import (
+    BIBLE_OPENING_PHRASES,
     BIBLE_VERSION_GUIDANCE,
     LANGUAGE_NAMES,
     SYSTEM_PROMPT,
     build_conversation_context,
     build_search_context_prompt,
     detect_intent_prompt,
+    get_opening_phrase,
     get_prayer_lookup_prompt,
     get_system_prompt,
     get_verse_lookup_prompt,
@@ -106,6 +108,34 @@ class TestGetSystemPrompt:
             assert (
                 "This is from the Bible, specifically" not in result
             ), f"Hardcoded English attribution still present for lang={lang}"
+
+
+class TestOpeningPhrase:
+    """Tests for the localized 'In the Bible is written...' opening phrase."""
+
+    def test_get_opening_phrase_english(self):
+        assert get_opening_phrase("en") == "In the Bible is written..."
+
+    def test_get_opening_phrase_italian(self):
+        assert get_opening_phrase("it") == "Nella Bibbia è scritto..."
+
+    def test_get_opening_phrase_unknown_falls_back_to_english(self):
+        assert get_opening_phrase("zz") == BIBLE_OPENING_PHRASES["en"]
+
+    def test_all_supported_languages_have_a_phrase(self):
+        for lang in LANGUAGE_NAMES:
+            assert lang in BIBLE_OPENING_PHRASES, f"Missing opening phrase for {lang}"
+
+    def test_system_prompt_contains_localized_opening_phrase(self):
+        for lang in ("en", "it", "de", "fr", "ar"):
+            prompt = get_system_prompt(lang)
+            assert get_opening_phrase(lang) in prompt
+            assert "{opening_phrase}" not in prompt  # placeholder substituted
+
+    def test_verse_and_prayer_prompts_contain_localized_opening_phrase(self):
+        for lang in ("en", "it"):
+            assert get_opening_phrase(lang) in get_verse_lookup_prompt(lang)
+            assert get_opening_phrase(lang) in get_prayer_lookup_prompt(lang)
 
 
 class TestGetVerseLookupPrompt:


### PR DESCRIPTION
## Summary
This PR refactors the system prompts for scripture and prayer responses to replace mandatory "Source:" headers with warm, localized opening phrases like "In the Bible is written..." The change maintains source clarity while improving the conversational tone and user experience.

## Key Changes

- **New localized opening phrases**: Added `BIBLE_OPENING_PHRASES` dictionary with "In the Bible is written..." translated into 11 languages (English, Italian, German, Spanish, French, Portuguese, Arabic, Russian, Chinese, Hindi, Korean)

- **New helper function**: Introduced `get_opening_phrase(language_code)` to retrieve the localized phrase with fallback to English

- **Refactored system prompts**: Updated three system prompt templates to:
  - Replace rigid "Source: Bible - [Book Chapter:Verse]" headers with warm prose that weaves the opening phrase and reference naturally into sentences
  - Emphasize keeping verse references visible but conversational (e.g., "John 3:16" woven into text, not blockquoted)
  - For non-biblical content, gently clarify the source within warm prose rather than clinical headers
  - Add guidance to ask clarifying questions when requests are vague

- **Updated prompt functions**: Modified `get_system_prompt()`, `get_verse_lookup_prompt()`, and `get_prayer_lookup_prompt()` to inject the localized opening phrase into their templates

- **Improved tone guidance**: Enhanced tone section to emphasize being "personal — close to the user, like a caring friend sitting beside them" and addressing feelings directly as scripture is shared

- **Crisis response refinement**: Updated crisis handling guidance to suggest using the opening phrase when offering scripture to someone in distress

- **Comprehensive test coverage**: Added `TestOpeningPhrase` class with 6 tests covering:
  - Language-specific phrase retrieval
  - Fallback behavior for unknown languages
  - Coverage of all supported languages
  - Proper substitution in all three prompt types

## Implementation Details

The refactoring maintains the requirement to be clear about scripture sources while shifting from a clinical, header-based approach to a warm, conversational one. The opening phrase serves as a gentle anchor that grounds responses in scripture without feeling formulaic. All three prompt types (general system, verse lookup, prayer lookup) now consistently use this pattern, ensuring a unified user experience across different interaction types.

https://claude.ai/code/session_01Bwyg8WWDAPEvaTzuyqFqrV