### PR TITLE
feat(android): add New Chat top-bar shortcut and resume navigation tests (BITB-027)

### DIFF
--- a/android/app/src/androidTest/kotlin/org/voxquieta/app/MainActivityTest.kt
+++ b/android/app/src/androidTest/kotlin/org/voxquieta/app/MainActivityTest.kt
@@ -40,7 +40,7 @@ class MainActivityTest {
      * replaced with a non-Activity context.
      */
     @Test
-    fun appLaunchesWithoutCrash_andConversationsScreenIsDisplayed() {
+    fun appLaunchesWithoutCrash_andChatScreenIsDisplayed() {
         assertEquals(
             "MainActivity should be in RESUMED state (no crash during startup)",
             Lifecycle.State.RESUMED,
@@ -53,7 +53,7 @@ class MainActivityTest {
      * Guards against the BUG C fix regression (onOpenSettings wired correctly).
      */
     @Test
-    fun settingsScreenIsReachableFromConversationsScreen() {
+    fun settingsScreenIsReachableFromChatScreen() {
         assertEquals(
             "MainActivity should be in RESUMED state",
             Lifecycle.State.RESUMED,

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -332,6 +332,13 @@ fun ChatScreen(
                             }
                         }
                     }
+                    // ── New chat ───────────────────────────────────────────────
+                    IconButton(onClick = onNewConversation) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = stringResource(R.string.action_new_chat),
+                        )
+                    }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.surface,

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatTopBarPolicy.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatTopBarPolicy.kt
@@ -4,11 +4,10 @@ package org.voxquieta.app.presentation.screens
  * Pure (Compose-free) policy describing which actions/entries are visible in the
  * Chat screen's top app bar and navigation drawer.
  *
- * The Chat screen's top-right `actions` row is intentionally minimal. Only the
- * Bible version chip, the language picker, and (when there are related verses)
- * the verses panel are exposed there. All other actions — clearing the current
- * conversation, starting a new one, opening Settings — live behind the
- * hamburger menu on the left.
+ * The Chat screen's top-right `actions` row exposes the Bible version chip, the
+ * language picker, the "+ New chat" shortcut, and (when there are related verses)
+ * the verses panel. All other actions — clearing the current conversation and
+ * opening Settings — live behind the hamburger menu on the left.
  *
  * Keeping this policy in a small, pure data class makes the visibility rules
  * trivially unit-testable on the JVM (no Compose / instrumented test harness
@@ -27,15 +26,14 @@ internal data class ChatTopBarPolicy(
  * Build the [ChatTopBarPolicy] for the current chat state.
  *
  * Rules (must stay in sync with [ChatScreen]):
- *  - The Bible version chip and the language picker are *always* in the top
- *    app bar — they are not state-dependent and therefore not represented in
- *    this policy object.
+ *  - The Bible version chip, the language picker, and the "+ New chat" button
+ *    are *always* in the top app bar — they are not state-dependent and
+ *    therefore not represented in this policy object.
  *  - The verses panel icon is shown in the top bar only when at least one
  *    related verse has been collected for the current conversation.
  *  - The "Clear conversation" drawer entry is shown only when the current
  *    conversation has at least one message.
- *  - "New chat" and Settings are always present in the drawer and are not
- *    represented here.
+ *  - "New chat" is also available in the drawer; Settings is drawer-only.
  */
 internal fun chatTopBarPolicy(
     versesCount: Int,

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -1705,4 +1705,36 @@ class ChatViewModelTest {
 
         assertEquals("it", requestSlot.captured.language)
     }
+
+    // ── resolveResumeConversationId ─────────────────────────────────────────
+
+    @Test
+    fun `resolveResumeConversationId returns persisted id when conversation still exists`() = runTest {
+        coEvery { lastConversationPreferences.getLastConversationId() } returns stubConversation.id
+        every { repository.observeConversations() } returns flowOf(listOf(stubConversation))
+
+        val result = viewModel.resolveResumeConversationId()
+
+        assertEquals(stubConversation.id, result)
+    }
+
+    @Test
+    fun `resolveResumeConversationId returns null when no id is persisted`() = runTest {
+        coEvery { lastConversationPreferences.getLastConversationId() } returns null
+
+        val result = viewModel.resolveResumeConversationId()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveResumeConversationId clears stale id and returns null when conversation no longer exists`() = runTest {
+        coEvery { lastConversationPreferences.getLastConversationId() } returns "stale-conv-id"
+        every { repository.observeConversations() } returns flowOf(emptyList())
+
+        val result = viewModel.resolveResumeConversationId()
+
+        assertNull(result)
+        coVerify { lastConversationPreferences.setLastConversationId(null) }
+    }
 }

--- a/docs/BACKLOG_STORIES/BITB-027-android-chat-first-navigation.md
+++ b/docs/BACKLOG_STORIES/BITB-027-android-chat-first-navigation.md
@@ -1,5 +1,7 @@
 # BITB-027: Android Chat-First Navigation with History Drawer
 
+**Status:** ✅ Done (chat-first NavHost, DataStore-backed resume, ModalNavigationDrawer with conversation list + Settings link, + New chat top-right icon added 2026-05-25; resolveResumeConversationId unit tests added)
+
 ## User Story
 
 As an Android user, I want the app to open directly into the chat experience (resuming my last conversation) so that I can start interacting immediately, with my chat history one tap away behind a clearly labelled button.

--- a/docs/BACKLOG_STORIES/BITB-028-church-finder-bottom-sheet-cleanup.md
+++ b/docs/BACKLOG_STORIES/BITB-028-church-finder-bottom-sheet-cleanup.md
@@ -1,5 +1,7 @@
 # BITB-028: Simplify Church Finder Headers (Banner + Bottom Sheet)
 
+**Status:** ✅ Done (all acceptance criteria checked; ChurchFinderBottomSheet.kt has X close button, ChurchFinderBanner.kt uses Icons.Default.Close; verified 2026-05-25)
+
 ## User Story
 
 As an Android user, I want the church-finder UI surfaces (the in-chat suggestion banner *and* the bottom sheet that opens from it) to have an obvious, single-tap way to dismiss them, so that I'm not distracted by unclear secondary text or low-contrast labels.

--- a/docs/BACKLOG_STORIES/BITB-035-chat-interrupt-and-multiline-input.md
+++ b/docs/BACKLOG_STORIES/BITB-035-chat-interrupt-and-multiline-input.md
@@ -1,5 +1,7 @@
 # BITB-035: Interruptible Chat Streaming & Multi-line Input (Web + Android)
 
+**Status:** ✅ Done (AbortSignal in api.ts, AbortController + Stop button + textarea in page.tsx, cancelStream() in ChatViewModel.kt, ImeAction.Default in ChatInputField.kt; all 11 locales have Chat.stopGenerating / chat_stop_button; verified 2026-05-25)
+
 ## User Story
 
 As a user of either the web app or the Android app, I want to:


### PR DESCRIPTION
## Summary

- Add `+` (New Chat) `IconButton` to the top-right of `ChatScreen`'s `TopAppBar`, satisfying the explicit BITB-027 acceptance criterion: a visible shortcut matching the muscle memory of ChatGPT/Gemini
- Update `ChatTopBarPolicy` KDoc to document that New Chat is now exposed in both the top bar and the hamburger drawer
- Add 3 JVM unit tests for `ChatViewModel.resolveResumeConversationId()` (returns id when conversation exists; returns null when nothing stored; clears stale id and returns null when conversation deleted)
- Rename `MainActivityTest` methods to reflect chat-first navigation (old names referenced `ConversationsScreen`, which is no longer the start destination)
- Mark BITB-027 (chat-first nav), BITB-028 (church finder cleanup), and BITB-035 (chat interrupt + multiline) as ✅ Done in backlog — all three were verified already-implemented on `main`

## Context

BITB-027's navigation architecture (chat-first `NavHost`, DataStore-backed resume, `ModalNavigationDrawer` with history, `popUpTo` back-stack replacement) was already fully implemented on `main`. This PR closes the two genuine gaps:
1. The story's AC explicitly required a top-right `+` icon — the existing implementation put New Chat in the drawer only
2. `resolveResumeConversationId()` had no dedicated unit test coverage

## Test plan

- [ ] Android Lint passes (no new warnings from added `IconButton`)
- [ ] Kotlin Compile Check passes
- [ ] Unit Tests pass — 3 new `resolveResumeConversationId` tests green
- [ ] Instrumented UI Tests pass — `MainActivityTest` renamed methods still exercise the same lifecycle assertions
- [ ] Compose UI Tests (Robolectric) pass
- [ ] Manual: tap `+` in top-right → new conversation opens; back exits app

https://claude.ai/code/session_01Dqowu2ZwB3CYGp33puve2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dqowu2ZwB3CYGp33puve2U)_