### PR TITLE
feat(backend): emit language_suggestion in chat API (language-mismatch Slice 1)

### DIFF
--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -21,6 +21,7 @@ from scripture import ScriptureSearchService, SearchResults
 from utils.content_safety import get_content_safety_service
 from utils.language import (
     detect_language,
+    detect_language_confident,
     get_model_override_for_language,
     get_translation_info,
     resolve_translation,
@@ -91,6 +92,7 @@ class ChatResponse(BaseModel):
     model: str
     detected_translation: str | None = None
     translation_info: dict | None = None
+    language_suggestion: str | None = None  # Detected language differs from selected UI language
 
 
 @dataclass
@@ -322,6 +324,15 @@ Keep it under 100 words."""
         translation = resolve_translation(request.preferred_translation, effective_language)
         translation_info = get_translation_info(translation)
         model_override = get_model_override_for_language(effective_language)
+        # Suggest a language switch only when the user explicitly set a UI language,
+        # we're confident the message is in a *different* language, and confidence
+        # is high enough to avoid false positives on short/ambiguous text.
+        _confident_lang = detect_language_confident(request.message)
+        language_suggestion = (
+            _confident_lang
+            if (request.language and _confident_lang and _confident_lang != request.language)
+            else None
+        )
         logger.info(
             "Language detection and translation resolution",
             extra={
@@ -448,6 +459,7 @@ Keep it under 100 words."""
             model=response.model,
             detected_translation=translation,
             translation_info=translation_info,
+            language_suggestion=language_suggestion,
         )
 
     async def _handle_off_topic(
@@ -759,6 +771,12 @@ Keep it under 100 words."""
         translation = resolve_translation(request.preferred_translation, effective_language)
         translation_info = get_translation_info(translation)
         model_override = get_model_override_for_language(effective_language)
+        _confident_lang = detect_language_confident(request.message)
+        language_suggestion = (
+            _confident_lang
+            if (request.language and _confident_lang and _confident_lang != request.language)
+            else None
+        )
         logger.info(
             "Language detection and translation resolution (stream)",
             extra={
@@ -798,6 +816,7 @@ Keep it under 100 words."""
                     "model": settings.llm_model,
                     "detected_translation": translation,
                     "translation_info": translation_info,
+                    "language_suggestion": language_suggestion,
                 }
 
                 messages = self._build_messages(
@@ -841,6 +860,7 @@ Keep it under 100 words."""
             "model": settings.llm_model,
             "detected_translation": translation,
             "translation_info": translation_info,
+            "language_suggestion": language_suggestion,
         }
 
         # Step 3: Build messages with appropriate prompt type

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -1071,3 +1071,102 @@ class TestChatServiceModelOverride:
         # auto-detected "it", not any client-supplied locale.
         mock_resolve.assert_called_once_with(None, "it")
         mock_override.assert_called_once_with("it")
+
+
+class TestChatStreamLanguageSuggestion:
+    """Tests for language_suggestion in chat_stream() metadata."""
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.detect_language_confident", return_value="it")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_mismatch_emits_suggestion(
+        self, mock_extract, mock_is_verse, mock_resolve, mock_confident, mock_detect
+    ):
+        """When UI language differs from typed language, metadata should carry the suggestion."""
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+        llm.chat = AsyncMock(return_value=LLMResponse(content="GENERAL", provider="t", model="m"))
+
+        async def mock_stream(*args, **kwargs):
+            yield "ciao"
+
+        llm.chat_stream = mock_stream
+
+        request = ChatRequest(message="Cosa dice la Bibbia", language="en")
+        chunks = []
+        async for chunk in service.chat_stream(request):
+            chunks.append(chunk)
+
+        meta = chunks[0]
+        assert meta["type"] == "metadata"
+        assert meta["language_suggestion"] == "it"
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.detect_language_confident", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_matching_language_no_suggestion(
+        self, mock_extract, mock_is_verse, mock_resolve, mock_confident, mock_detect
+    ):
+        """When UI language matches typed language, suggestion should be None."""
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+        llm.chat = AsyncMock(return_value=LLMResponse(content="GENERAL", provider="t", model="m"))
+
+        async def mock_stream(*args, **kwargs):
+            yield "God loves you"
+
+        llm.chat_stream = mock_stream
+
+        request = ChatRequest(message="What does the Bible say?", language="en")
+        chunks = []
+        async for chunk in service.chat_stream(request):
+            chunks.append(chunk)
+
+        meta = chunks[0]
+        assert meta["type"] == "metadata"
+        assert meta["language_suggestion"] is None
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="it")
+    @patch("chat.service.detect_language_confident", return_value="it")
+    @patch("chat.service.resolve_translation", return_value="ita1927")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_no_explicit_language_no_suggestion(
+        self, mock_extract, mock_is_verse, mock_resolve, mock_confident, mock_detect
+    ):
+        """When no explicit UI language is set, suggestion should be None."""
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+        llm.chat = AsyncMock(return_value=LLMResponse(content="GENERAL", provider="t", model="m"))
+
+        async def mock_stream(*args, **kwargs):
+            yield "Dio ti ama"
+
+        llm.chat_stream = mock_stream
+
+        # No language field — auto-detect only, no suggestion should fire
+        request = ChatRequest(message="Cosa dice la Bibbia sull amore")
+        assert request.language is None
+        chunks = []
+        async for chunk in service.chat_stream(request):
+            chunks.append(chunk)
+
+        meta = chunks[0]
+        assert meta["type"] == "metadata"
+        assert meta["language_suggestion"] is None

--- a/api/tests/test_language_detection.py
+++ b/api/tests/test_language_detection.py
@@ -14,6 +14,7 @@ from utils.language import (
     LANGUAGE_TRANSLATIONS,
     TRANSLATION_INFO,
     detect_language,
+    detect_language_confident,
     detect_translation,
     get_all_translations,
     get_localized_book_name,
@@ -494,3 +495,30 @@ class TestResolveTranslation:
     def test_empty_string_preference_falls_back(self):
         """Test empty string preference falls back."""
         assert resolve_translation("", "it") == "ita1927"
+
+
+class TestDetectLanguageConfident:
+    """Tests for detect_language_confident — high-confidence detection only."""
+
+    def test_long_italian_returns_it(self):
+        """Long Italian text should be detected with high confidence."""
+        result = detect_language_confident("Cosa dice la Bibbia sull'amore e la speranza in Dio?")
+        assert result == "it"
+
+    def test_short_text_returns_none(self):
+        """Text shorter than min_text_length should return None."""
+        assert detect_language_confident("Ciao") is None
+
+    def test_empty_returns_none(self):
+        """Empty string should return None."""
+        assert detect_language_confident("") is None
+
+    def test_long_english_returns_en(self):
+        """Long English text should be detected with high confidence."""
+        result = detect_language_confident("What does the Bible say about love and hope in God?")
+        assert result == "en"
+
+    def test_long_german_returns_de(self):
+        """Long German text should be detected with high confidence."""
+        result = detect_language_confident("Was sagt die Bibel über Liebe und Hoffnung in Gott?")
+        assert result == "de"

--- a/api/utils/language.py
+++ b/api/utils/language.py
@@ -152,16 +152,18 @@ class LanguageDetector(ABC):
         """
         pass
 
-    @abstractmethod
     def detect_confident(self, text: str) -> str | None:
         """
         Detect language only when confident; otherwise return None.
+
+        Default implementation always returns None (conservative — no suggestion).
+        Override in concrete classes that support confidence scoring.
 
         Returns:
             ISO 639-1 code when text is long enough AND confidence is high,
             else None.
         """
-        pass
+        return None
 
     @property
     @abstractmethod

--- a/api/utils/language.py
+++ b/api/utils/language.py
@@ -152,6 +152,17 @@ class LanguageDetector(ABC):
         """
         pass
 
+    @abstractmethod
+    def detect_confident(self, text: str) -> str | None:
+        """
+        Detect language only when confident; otherwise return None.
+
+        Returns:
+            ISO 639-1 code when text is long enough AND confidence is high,
+            else None.
+        """
+        pass
+
     @property
     @abstractmethod
     def name(self) -> str:
@@ -240,6 +251,23 @@ class LinguaLanguageDetector(LanguageDetector):
         except Exception:
             return DEFAULT_LANGUAGE
 
+    def detect_confident(self, text: str) -> str | None:
+        """Detect language only when text is long enough and confidence is high."""
+        if not text or len(text.strip()) < self._min_text_length:
+            return None
+        try:
+            confidence_values = self._detector.compute_language_confidence_values(text)
+            if not confidence_values:
+                return None
+            top = confidence_values[0]
+            top_lang = top.language.iso_code_639_1.name.lower()
+            top_conf = top.value
+            if top_conf >= self._confidence_threshold:
+                return str(top_lang)
+            return None
+        except Exception:
+            return None
+
 
 # =============================================================================
 # Detector Factory and Global Instance
@@ -325,6 +353,23 @@ def detect_language(text: str) -> str:
         Returns 'en' if detection fails, text is too short, or confidence is low
     """
     return get_detector().detect(text)
+
+
+def detect_language_confident(text: str) -> str | None:
+    """
+    Detect the language only when confident enough to suggest a UI switch.
+
+    Unlike detect_language(), returns None when text is too short or detection
+    confidence is below threshold, so callers can distinguish "probably X" from
+    "confidently X". Use this to gate language-switch suggestions.
+
+    Args:
+        text: Text to analyze
+
+    Returns:
+        ISO 639-1 code when confident, or None when uncertain / text too short
+    """
+    return get_detector().detect_confident(text)
 
 
 def get_translation_for_language(language_code: str) -> str:


### PR DESCRIPTION
## Summary

Implements **Slice 1 (Backend)** of the language-mismatch switch suggestion feature (see `docs/BACKLOG_STORIES/language-mismatch-switch-suggestion.md`).

When a user has **explicitly selected** a UI language (e.g. English) but types a message in a **different language** (e.g. Italian) with high confidence, the backend now returns a `language_suggestion` field in the API response. Clients (Slice 2 — web, Slice 3 — Android) will use this to render a dismissible one-tap switch banner.

**Response language behavior is byte-for-byte unchanged.** The suggestion is purely additive metadata.

### Changes

- **`api/utils/language.py`**: Add `detect_language_confident(text) -> str | None` — returns the detected language code only when text length ≥ `min_text_length` AND confidence ≥ `confidence_threshold`; returns `None` for short or ambiguous text. Prevents false positives on greetings like "Ciao".
- **`api/chat/service.py`**: Add `language_suggestion: str | None = None` to `ChatResponse`. Compute and include the suggestion in both `chat()` (response body) and `chat_stream()` (metadata chunk — main path and off-topic; blocked path skipped per spec).
- **`api/tests/test_language_detection.py`**: Unit tests for `detect_language_confident` (Italian → "it", "Ciao" → None, English → "en", German → "de").
- **`api/tests/test_chat_coverage.py`**: Three streaming service tests — mismatch emits suggestion, matching language returns None, no explicit language returns None.

### When is the suggestion emitted?

```python
language_suggestion = (
    confident_lang
    if (request.language and confident_lang and confident_lang != request.language)
    else None
)
```

Only when:
1. `request.language` is explicitly set (user chose a UI language)
2. Detection is confident (long enough text, high confidence score)
3. The two differ

### Slices roadmap

- **Slice 1 (this PR)**: Backend — additive metadata, safe alone
- **Slice 2**: Web — `LanguageSwitchSuggestion` banner + sessionStorage conversation persistence
- **Slice 3**: Android — `LanguageSwitchBanner` following `ChurchFinderBanner` pattern

## Test plan

- [x] Syntax check passes on all modified files
- [x] `detect_language_confident` unit tests added
- [x] Service streaming tests cover mismatch / match / no-explicit-language cases
- [ ] CI pipeline green (Backend API Tests, Pre-Commit Hooks)
- [ ] Manual: send Italian message with `language: "en"` → verify `language_suggestion: "it"` in response metadata

https://claude.ai/code/session_01CChUfVf7f3Hf4naqigxkzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CChUfVf7f3Hf4naqigxkzq)_