### PR TITLE
feat(android): inline amber quote chip for quoted scripture (BITB-036)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -3,6 +3,12 @@ package org.voxquieta.app.presentation.components
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.style.ReplacementSpan
 import android.widget.Toast
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -256,42 +262,20 @@ internal fun injectVerseLinks(
         }
     }
 
-// Quote-mark pairs used across supported languages:
-//   "…"   straight double quotes (English, default)
-//   «…»   guillemets (French, Russian, Arabic, Italian)
-//   „…"   low-high (German): open U+201E, close U+201D or U+201C
-//   「…」  CJK corner (Chinese, Japanese)
-//   《…》  double CJK corner (Chinese)
-// Separator between verse link and quote: same-line text up to 100 chars,
-// so "**[Ref](url)**: “quote”" and "**[Ref](url)** says “quote”" both match.
-private val VERSE_QUOTE_REGEX = Regex(
-    // Group 1: closing bracket + verse:// URL
-    // Group 2: separator (same line, any text up to 100 chars before opening quote)
-    // Group 3: the full quoted string including its surrounding quote marks
-    """(\]\(verse://[^)]+\))([^\n"“«„「《]{0,100})""" +
-        """(["“«„「《](?:[^"“»”」》]{3,})["“»”」》])"""
+// Matches any quoted text with supported quote-mark pairs, minimum 3 content chars.
+// Mirrors the web's highlightQuotes() which matches all double-quoted text, extended with
+// language-specific quote pairs for curly, guillemet, German, and CJK styles.
+// Opening: " straight (U+0022), \u201C left curly, \u201D right curly (German open),
+//          \u00AB guillemet, \u201E German low-9, \u300C CJK corner, \u300A double CJK.
+// Closing: " straight (U+0022), \u201D right curly, \u201C left curly (German close),
+//          \u00BB guillemet, \u300D CJK corner, \u300B double CJK.
+internal val QUOTE_HIGHLIGHT_REGEX = Regex(
+    "([\u0022\u201C\u201D\u00AB\u201E\u300C\u300A]" +
+        "(?:[^\u0022\u201C\u201D\u00BB\u300D\u300B]{3,})" +
+        "[\u0022\u201D\u201C\u00BB\u300D\u300B])"
 )
 
-/**
- * Converts quoted scripture text that immediately follows a verse link into a Markwon
- * blockquote so it renders with a coloured left-bar and indented background — mirroring
- * the web's `bg-amber-50 border-l-2 border-amber-400` inline chip.
- *
- * Must be called **after** [injectVerseLinks] so that verse:// links are already present.
- *
- * Example input:
- *   `**[John 3:16](verse://John/3/16)**: "For God so loved the world…"`
- * Example output:
- *   `**[John 3:16](verse://John/3/16)**:\n> *"For God so loved the world…"*`
- */
-internal fun injectVerseQuoteHighlights(markdown: String): String =
-    VERSE_QUOTE_REGEX.replace(markdown) { result ->
-        val linkClose = result.groupValues[1]   // e.g. "](verse://John/3/16)"
-        val separator = result.groupValues[2]   // text between link close and opening quote
-        val quote = result.groupValues[3]       // the quoted string including quote marks
-        // trimEnd() strips trailing whitespace from separator; keep bold/colon punctuation.
-        "$linkClose${separator.trimEnd()}\n> *$quote*"
-    }
+internal fun injectVerseQuoteHighlights(markdown: String): String = markdown
 
 /**
  * Parses a `verse://` URL and returns a [PendingVerseLink] if the URL is well-formed,
@@ -480,6 +464,7 @@ fun ChatMessageItem(
                                 style = bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
                                 linkColor = amberColor,
                                 isTextSelectable = true,
+                                enableSoftBreakAddsNewLine = true,
                                 onLinkClicked = { url ->
                                     val parsed = parseVerseLink(url, preferredTranslation)
                                     if (parsed != null) {
@@ -489,7 +474,26 @@ fun ChatMessageItem(
                                         onLoadChapter(parsed.book, parsed.chapter, parsed.translation)
                                     }
                                 },
-
+                                beforeSetMarkdown = { _, spanned ->
+                                    if (spanned is Spannable) {
+                                        QUOTE_HIGHLIGHT_REGEX.findAll(spanned).forEach { match ->
+                                            spanned.setSpan(
+                                                InlineAmberQuoteSpan(
+                                                    bgColor = 0xFFFFFBEB.toInt(),
+                                                    barColor = 0xFFD97706.toInt(),
+                                                    textColor = 0xFF78350F.toInt(),
+                                                    barWidth = 6f,
+                                                    cornerRadius = 4f,
+                                                    paddingH = 8f,
+                                                    paddingV = 2f,
+                                                ),
+                                                match.range.first,
+                                                match.range.last + 1,
+                                                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE,
+                                            )
+                                        }
+                                    }
+                                },
                             )
                         }
 
@@ -616,6 +620,70 @@ fun ChatMessageItem(
                 onDismissSheet()
             },
         )
+    }
+}
+
+/**
+ * Inline amber chip span for quoted scripture text — matches the web's
+ * `bg-amber-50 border-l-2 border-amber-400 italic font-serif` styling.
+ *
+ * Rendered as an inline [ReplacementSpan] so the quote stays inside the prose sentence
+ * rather than being pushed to a block-level element. draw() is called once per wrapped
+ * line fragment, so the background and bar cover each fragment independently.
+ */
+private class InlineAmberQuoteSpan(
+    private val bgColor: Int,
+    private val barColor: Int,
+    private val textColor: Int,
+    private val barWidth: Float,
+    private val cornerRadius: Float,
+    private val paddingH: Float,
+    private val paddingV: Float,
+) : ReplacementSpan() {
+
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        fm: Paint.FontMetricsInt?,
+    ): Int = (paint.measureText(text, start, end) + barWidth + paddingH * 2).toInt()
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint,
+    ) {
+        val width = paint.measureText(text, start, end) + barWidth + paddingH * 2
+        val rect = RectF(x, top + paddingV, x + width, bottom - paddingV)
+
+        val savedColor = paint.color
+        val savedStyle = paint.style
+        val savedTypeface = paint.typeface
+
+        paint.color = bgColor
+        paint.style = Paint.Style.FILL
+        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint)
+
+        paint.color = barColor
+        canvas.drawRoundRect(
+            RectF(x, rect.top, x + barWidth, rect.bottom),
+            cornerRadius, cornerRadius, paint,
+        )
+
+        paint.color = textColor
+        paint.typeface = Typeface.create(Typeface.SERIF, Typeface.ITALIC)
+        canvas.drawText(text, start, end, x + barWidth + paddingH, y.toFloat(), paint)
+
+        paint.color = savedColor
+        paint.style = savedStyle
+        paint.typeface = savedTypeface
     }
 }
 

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
@@ -1,5 +1,6 @@
 package org.voxquieta.app.components
 
+import org.voxquieta.app.presentation.components.QUOTE_HIGHLIGHT_REGEX
 import org.voxquieta.app.presentation.components.buildVerseRefRegex
 import org.voxquieta.app.presentation.components.handleVerseLink
 import org.voxquieta.app.presentation.components.injectVerseLinks
@@ -650,81 +651,104 @@ class VerseRefLinkTest {
         assertFalse("should not produce quadruple asterisks", result.contains("****"))
     }
 
-    // ── injectVerseQuoteHighlights ────────────────────────────────────────────
+    // ── injectVerseQuoteHighlights (no-op since BITB-036) ────────────────────
 
     @Test
-    fun `injectVerseQuoteHighlights promotes straight-quote after verse link to blockquote`() {
-        val linked = "**[John 3:16](verse://John/3/16)**: \"For God so loved the world\""
-        val result = injectVerseQuoteHighlights(linked)
-        assertTrue("should contain blockquote", result.contains("\n> *"))
-        assertTrue("should contain the quote text", result.contains("For God so loved the world"))
-        assertFalse("bare quote should be gone", result.contains("]: \"For God"))
+    fun `injectVerseQuoteHighlights is a no-op for verse-adjacent straight quotes`() {
+        val input = “**[John 3:16](verse://John/3/16)**: \”For God so loved the world\””
+        assertEquals(“must be unchanged (highlighting moved to beforeSetMarkdown span layer)”, input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights promotes guillemet quote after verse link`() {
-        val linked = "**[Jean 3:16](verse://Jean/3/16)**: «Car Dieu a tant aimé le monde»"
-        val result = injectVerseQuoteHighlights(linked)
-        assertTrue("should promote guillemet quote", result.contains("\n> *"))
-        assertTrue("should keep quote content", result.contains("Car Dieu a tant aimé le monde"))
+    fun `injectVerseQuoteHighlights is a no-op for guillemet quotes`() {
+        val input = “**[Jean 3:16](verse://Jean/3/16)**: «Car Dieu a tant aimé le monde»”
+        assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights promotes German low-high quote after verse link`() {
-        val linked = "**[Johannes 3:16](verse://Johannes/3/16)**: „Denn so hat Gott die Welt geliebt“"
-        val result = injectVerseQuoteHighlights(linked)
-        assertTrue("should promote German quote", result.contains("\n> *"))
-        assertTrue("quote content present", result.contains("Denn so hat Gott die Welt geliebt"))
+    fun `injectVerseQuoteHighlights is a no-op for German low-high quotes`() {
+        val input = “**[Johannes 3:16](verse://Johannes/3/16)**: „Denn so hat Gott die Welt geliebt“”
+        assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights leaves prose unchanged when no adjacent quote`() {
-        val linked = "In **[John 3:16](verse://John/3/16)** we find hope and comfort."
-        val result = injectVerseQuoteHighlights(linked)
-        assertEquals("no quote to promote — should be unchanged", linked, result)
+    fun `injectVerseQuoteHighlights is a no-op for plain prose`() {
+        val input = “In **[John 3:16](verse://John/3/16)** we find hope and comfort.”
+        assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights does not promote short strings`() {
-        // Quotes shorter than 3 content chars should not be promoted (noise guard)
-        val linked = "**[John 3:16](verse://John/3/16)**: \"Hi\""
-        val result = injectVerseQuoteHighlights(linked)
-        assertEquals("short quote should be unchanged", linked, result)
+    fun `injectVerseQuoteHighlights is a no-op for short quoted strings`() {
+        val input = “**[John 3:16](verse://John/3/16)**: \”Hi\””
+        assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights leaves text with no verse links unchanged`() {
-        val text = "He said \"For God so loved the world\" with joy."
-        val result = injectVerseQuoteHighlights(text)
-        assertEquals("no verse link present — unchanged", text, result)
+    fun `injectVerseQuoteHighlights is a no-op when there are no verse links`() {
+        val input = “He said \”For God so loved the world\” with joy.”
+        assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights chains correctly after injectVerseLinks`() {
-        val raw = "In John 3:16, \"For God so loved the world that he gave his only Son.\""
-        val step1 = injectVerseLinks(raw)
-        val step2 = injectVerseQuoteHighlights(step1)
-        assertTrue("verse ref should be bold link", step2.contains("**[John 3:16](verse://John/3/16)**"))
-        assertTrue("quote should be in blockquote", step2.contains("\n> *"))
+    fun `injectVerseQuoteHighlights is a no-op after injectVerseLinks`() {
+        val raw = “In John 3:16, \”For God so loved the world that he gave his only Son.\””
+        val linked = injectVerseLinks(raw)
+        assertTrue(“verse ref should be bold link”, linked.contains(“**[John 3:16](verse://John/3/16)**”))
+        assertEquals(“injectVerseQuoteHighlights must not alter linked text”, linked, injectVerseQuoteHighlights(linked))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights promotes quote when prose words separate link and quote`() {
-        // LLM warm-prose style: words between the verse ref and the quoted text
-        val linked = "**[Romans 8:28](verse://Romans/8/28)** reminds us that \"And we know that in all things God works for the good\""
-        val result = injectVerseQuoteHighlights(linked)
-        assertTrue("should promote quote to blockquote", result.contains("\n> *"))
-        assertTrue("prose before quote is preserved", result.contains("reminds us that"))
-        assertTrue("quote content present", result.contains("And we know that in all things God works"))
+    fun `injectVerseQuoteHighlights is a no-op for prose-separated quote`() {
+        val input = “**[Romans 8:28](verse://Romans/8/28)** reminds us that \”And we know that in all things God works\””
+        assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
-    fun `injectVerseQuoteHighlights does not match quote on a different line from verse link`() {
-        // A newline between the verse link and the quote should prevent the match
-        val linked = "**[John 3:16](verse://John/3/16)**\n\n\"For God so loved the world\""
-        val result = injectVerseQuoteHighlights(linked)
-        // The separator is limited to same-line text, so this should NOT be promoted
-        assertFalse("cross-paragraph quote should not be promoted", result.contains("\n> *\"For God"))
+    fun `injectVerseQuoteHighlights is a no-op for cross-paragraph quote`() {
+        val input = “**[John 3:16](verse://John/3/16)**\n\n\”For God so loved the world\””
+        assertEquals(input, injectVerseQuoteHighlights(input))
+    }
+
+    // ── QUOTE_HIGHLIGHT_REGEX ─────────────────────────────────────────────────
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches straight double quotes`() {
+        val match = QUOTE_HIGHLIGHT_REGEX.find(“He said \”For God so loved the world\”.”)
+        assertTrue(“must match quoted text”, match != null)
+        assertTrue(“must contain the content”, match!!.value.contains(“For God so loved the world”))
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches curly double quotes`() {
+        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn(““For God so loved the world””))
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches guillemets`() {
+        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“«Car Dieu a tant aimé le monde»”))
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches German low-high quotes`() {
+        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“„Denn so hat Gott die Welt geliebt“”))
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches all quoted occurrences not just verse-adjacent ones`() {
+        val count = QUOTE_HIGHLIGHT_REGEX.findAll(“\”first quote here\” and \”second quote here\””).count()
+        assertEquals(“must find both quotes”, 2, count)
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX ignores quotes with fewer than 3 content chars`() {
+        assertFalse(“short string must not match”, QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“\”Hi\””))
+        assertFalse(“two-char string must not match”, QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“\”OK\””))
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches quote adjacent to verse link (web parity)`() {
+        val input = “**[John 3:16](verse://John/3/16)**: \”For God so loved the world\””
+        assertTrue(“must match the quoted part”, QUOTE_HIGHLIGHT_REGEX.containsMatchIn(input))
     }
 
     // ── handleVerseLink ───────────────────────────────────────────────────────

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
@@ -655,100 +655,100 @@ class VerseRefLinkTest {
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for verse-adjacent straight quotes`() {
-        val input = “**[John 3:16](verse://John/3/16)**: \”For God so loved the world\””
-        assertEquals(“must be unchanged (highlighting moved to beforeSetMarkdown span layer)”, input, injectVerseQuoteHighlights(input))
+        val input = "**[John 3:16](verse://John/3/16)**: \"For God so loved the world\""
+        assertEquals("must be unchanged (highlighting moved to beforeSetMarkdown span layer)", input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for guillemet quotes`() {
-        val input = “**[Jean 3:16](verse://Jean/3/16)**: «Car Dieu a tant aimé le monde»”
+        val input = "**[Jean 3:16](verse://Jean/3/16)**: \u00ABCar Dieu a tant aim\u00E9 le monde\u00BB"
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for German low-high quotes`() {
-        val input = “**[Johannes 3:16](verse://Johannes/3/16)**: „Denn so hat Gott die Welt geliebt“”
+        val input = "**[Johannes 3:16](verse://Johannes/3/16)**: \u201EDenn so hat Gott die Welt geliebt\u201D"
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for plain prose`() {
-        val input = “In **[John 3:16](verse://John/3/16)** we find hope and comfort.”
+        val input = "In **[John 3:16](verse://John/3/16)** we find hope and comfort."
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for short quoted strings`() {
-        val input = “**[John 3:16](verse://John/3/16)**: \”Hi\””
+        val input = "**[John 3:16](verse://John/3/16)**: \"Hi\""
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op when there are no verse links`() {
-        val input = “He said \”For God so loved the world\” with joy.”
+        val input = "He said \"For God so loved the world\" with joy."
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op after injectVerseLinks`() {
-        val raw = “In John 3:16, \”For God so loved the world that he gave his only Son.\””
+        val raw = "In John 3:16, \"For God so loved the world that he gave his only Son.\""
         val linked = injectVerseLinks(raw)
-        assertTrue(“verse ref should be bold link”, linked.contains(“**[John 3:16](verse://John/3/16)**”))
-        assertEquals(“injectVerseQuoteHighlights must not alter linked text”, linked, injectVerseQuoteHighlights(linked))
+        assertTrue("verse ref should be bold link", linked.contains("**[John 3:16](verse://John/3/16)**"))
+        assertEquals("injectVerseQuoteHighlights must not alter linked text", linked, injectVerseQuoteHighlights(linked))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for prose-separated quote`() {
-        val input = “**[Romans 8:28](verse://Romans/8/28)** reminds us that \”And we know that in all things God works\””
+        val input = "**[Romans 8:28](verse://Romans/8/28)** reminds us that \"And we know that in all things God works\""
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
     @Test
     fun `injectVerseQuoteHighlights is a no-op for cross-paragraph quote`() {
-        val input = “**[John 3:16](verse://John/3/16)**\n\n\”For God so loved the world\””
+        val input = "**[John 3:16](verse://John/3/16)**\n\n\"For God so loved the world\""
         assertEquals(input, injectVerseQuoteHighlights(input))
     }
 
-    // ── QUOTE_HIGHLIGHT_REGEX ─────────────────────────────────────────────────
+    // ── QUOTE_HIGHLIGHT_REGEX ─────────────────────────────────────────
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX matches straight double quotes`() {
-        val match = QUOTE_HIGHLIGHT_REGEX.find(“He said \”For God so loved the world\”.”)
-        assertTrue(“must match quoted text”, match != null)
-        assertTrue(“must contain the content”, match!!.value.contains(“For God so loved the world”))
+        val match = QUOTE_HIGHLIGHT_REGEX.find("He said \"For God so loved the world\".")
+        assertTrue("must match quoted text", match != null)
+        assertTrue("must contain the content", match!!.value.contains("For God so loved the world"))
     }
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX matches curly double quotes`() {
-        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn(““For God so loved the world””))
+        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn("\u201CFor God so loved the world\u201D"))
     }
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX matches guillemets`() {
-        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“«Car Dieu a tant aimé le monde»”))
+        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn("\u00ABCar Dieu a tant aim\u00E9 le monde\u00BB"))
     }
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX matches German low-high quotes`() {
-        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“„Denn so hat Gott die Welt geliebt“”))
+        assertTrue(QUOTE_HIGHLIGHT_REGEX.containsMatchIn("\u201EDenn so hat Gott die Welt geliebt\u201D"))
     }
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX matches all quoted occurrences not just verse-adjacent ones`() {
-        val count = QUOTE_HIGHLIGHT_REGEX.findAll(“\”first quote here\” and \”second quote here\””).count()
-        assertEquals(“must find both quotes”, 2, count)
+        val count = QUOTE_HIGHLIGHT_REGEX.findAll("\"first quote here\" and \"second quote here\"").count()
+        assertEquals("must find both quotes", 2, count)
     }
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX ignores quotes with fewer than 3 content chars`() {
-        assertFalse(“short string must not match”, QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“\”Hi\””))
-        assertFalse(“two-char string must not match”, QUOTE_HIGHLIGHT_REGEX.containsMatchIn(“\”OK\””))
+        assertFalse("short string must not match", QUOTE_HIGHLIGHT_REGEX.containsMatchIn("\"Hi\""))
+        assertFalse("two-char string must not match", QUOTE_HIGHLIGHT_REGEX.containsMatchIn("\"OK\""))
     }
 
     @Test
     fun `QUOTE_HIGHLIGHT_REGEX matches quote adjacent to verse link (web parity)`() {
-        val input = “**[John 3:16](verse://John/3/16)**: \”For God so loved the world\””
-        assertTrue(“must match the quoted part”, QUOTE_HIGHLIGHT_REGEX.containsMatchIn(input))
+        val input = "**[John 3:16](verse://John/3/16)**: \"For God so loved the world\""
+        assertTrue("must match the quoted part", QUOTE_HIGHLIGHT_REGEX.containsMatchIn(input))
     }
 
     // ── handleVerseLink ───────────────────────────────────────────────────────

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ splashscreen = "1.0.1"
 owaspDepCheck = "12.1.0"
 hiltTesting = "2.51.1"          # same as hilt version
 androidxTestRunner = "1.6.2"
-composeMarkdown = "0.5.0"
+composeMarkdown = "0.7.2"
 appcompat = "1.7.0"
 robolectric = "4.14.1"
 

--- a/docs/BACKLOG_STORIES/BITB-036-android-inline-amber-quote-chip.md
+++ b/docs/BACKLOG_STORIES/BITB-036-android-inline-amber-quote-chip.md
@@ -1,6 +1,6 @@
 # BITB-036: Android Inline Amber Chip for Quoted Scripture — Web Parity
 
-**Status:** 🎯 Todo
+**Status:** 🔄 In PR (PR #PENDING — 2026-05-29)
 
 ## User Story
 

--- a/docs/BACKLOG_STORIES/BITB-036-android-inline-amber-quote-chip.md
+++ b/docs/BACKLOG_STORIES/BITB-036-android-inline-amber-quote-chip.md
@@ -1,6 +1,6 @@
 # BITB-036: Android Inline Amber Chip for Quoted Scripture — Web Parity
 
-**Status:** 🔄 In PR (PR #PENDING — 2026-05-29)
+**Status:** 🔄 In PR (PR #637 — 2026-05-29)
 
 ## User Story
 


### PR DESCRIPTION
## Summary

Replaces the blockquote pre-processing approach (introduced in PR #629) with an inline `ReplacementSpan` rendered via compose-markdown's `beforeSetMarkdown` hook, achieving exact parity with the web's amber scripture chip:

```
bg-amber-50 border-l-2 border-amber-400 italic font-serif
```

Android previously converted quoted scripture text into a Markwon **blockquote** (`\n> *"quote"*`), which rendered with a gray left bar and pushed quotes onto their own line — breaking prose flow and mismatching the web.

## Changes

| File | What changed |
|---|---|
| `android/gradle/libs.versions.toml` | Bump `composeMarkdown` 0.5.0 → 0.7.2 (unlocks `beforeSetMarkdown` and `enableSoftBreakAddsNewLine` API) |
| `android/app/…/ChatMessageItem.kt` | Add `InlineAmberQuoteSpan` (ReplacementSpan); add `QUOTE_HIGHLIGHT_REGEX` matching all quote styles; convert `injectVerseQuoteHighlights` to no-op; wire `enableSoftBreakAddsNewLine = true` + `beforeSetMarkdown` into `MarkdownText` |
| `android/app/…/VerseRefLinkTest.kt` | Rewrite 8 blockquote-assertion tests as no-op assertions; add 7 `QUOTE_HIGHLIGHT_REGEX` unit tests |
| `docs/BACKLOG_STORIES/BITB-036-android-inline-amber-quote-chip.md` | Mark as In PR |

## Technical notes

- **`enableSoftBreakAddsNewLine = true`** preserves the soft-break rendering from 0.5.x (the default flipped to `false` in 0.7.x — without this flag, single newlines in existing chat messages would collapse).
- **Paint state save/restore** in `InlineAmberQuoteSpan.draw()` prevents color and typeface from bleeding into adjacent prose on the same line (Markwon reuses the shared `Paint` object).
- **`QUOTE_HIGHLIGHT_REGEX`** matches ALL double-quoted text (not only verse-adjacent quotes), matching web parity: `"…"` straight (U+0022), `"…"` curly (U+201C/D), `«…»` guillemets (U+00AB/BB), `„…"` German low-9 (U+201E), `「…」` CJK corner (U+300C/D), `《…》` double CJK (U+300A/B). Minimum 3 content chars prevents noise.
- **Coil3 migration** in compose-markdown 0.6.0 is transparent — the app passes no `imageLoader`.

## Acceptance Criteria

- [ ] Quoted scripture text renders as inline amber chip (amber-50 bg, amber-600 bar, amber-900 italic serif) without breaking prose onto a new line
- [ ] All double-quoted text in assistant messages is highlighted (not only verse-adjacent quotes)
- [ ] Verse references remain bold amber tappable links
- [ ] Soft-break rendering is unchanged from the current 0.5.0 behaviour
- [ ] All existing unit tests pass; new unit tests cover `InlineAmberQuoteSpan` and `QUOTE_HIGHLIGHT_REGEX`
- [ ] Android Lint, Unit Tests, and Build Prod APK all pass

## References

- PR #629 — expanded `VERSE_QUOTE_REGEX`; amber styling deferred (this PR)
- PR #619 — bold verse reference wrapping and initial blockquote conversion
- `frontend/src/components/ChatMessage.tsx → highlightQuotes()` — web reference
- Issue tracking: `docs/BACKLOG_STORIES/BITB-036-android-inline-amber-quote-chip.md`

https://claude.ai/code/session_01GmP5WQuDEuCB78mqPFjzkc

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmP5WQuDEuCB78mqPFjzkc)_