### PR TITLE
fix(backend): enforce consistent language responses across all prompts

### DIFF
--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -328,6 +328,19 @@ def get_opening_phrase(language_code: str = "en") -> str:
     return BIBLE_OPENING_PHRASES.get(language_code, BIBLE_OPENING_PHRASES["en"])
 
 
+def _build_language_instruction(language_code: str) -> tuple[str, str]:
+    """Return (language_name, language_instruction) for the given locale code."""
+    language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
+    instruction = (
+        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
+        f"Every single word of your response must be in {language_name}. "
+        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
+        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
+        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
+    )
+    return language_name, instruction
+
+
 def get_system_prompt(language_code: str = "en") -> str:
     """
     Get the system prompt with language-specific instructions.
@@ -338,15 +351,7 @@ def get_system_prompt(language_code: str = "en") -> str:
     Returns:
         System prompt with appropriate language instruction
     """
-    language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
-
-    language_instruction = (
-        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
-        f"Every single word of your response must be in {language_name}. "
-        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
-        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
-        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
-    )
+    language_name, language_instruction = _build_language_instruction(language_code)
 
     biblical_ex, non_biblical_ex = SOURCE_ATTRIBUTION_EXAMPLES.get(
         language_code, SOURCE_ATTRIBUTION_EXAMPLES["en"]
@@ -377,15 +382,7 @@ def get_verse_lookup_prompt(language_code: str = "en") -> str:
     Returns:
         System prompt for verse explanation with appropriate language instruction
     """
-    language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
-
-    language_instruction = (
-        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
-        f"Every single word of your response must be in {language_name}. "
-        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
-        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
-        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
-    )
+    language_name, language_instruction = _build_language_instruction(language_code)
 
     return (
         VERSE_LOOKUP_SYSTEM_PROMPT.format(
@@ -406,15 +403,7 @@ def get_prayer_lookup_prompt(language_code: str = "en") -> str:
     Returns:
         System prompt for prayer explanation with appropriate language instruction
     """
-    language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
-
-    language_instruction = (
-        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
-        f"Every single word of your response must be in {language_name}. "
-        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
-        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
-        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
-    )
+    language_name, language_instruction = _build_language_instruction(language_code)
 
     return (
         PRAYER_LOOKUP_SYSTEM_PROMPT.format(

--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -8,7 +8,6 @@ and provides spiritually meaningful guidance.
 SYSTEM_PROMPT_TEMPLATE = """You are a compassionate spiritual companion who helps people find encouragement, guidance, and understanding of faith.
 
 ## LANGUAGE RULE - VERY IMPORTANT
-**ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
 ## Weaving Scripture In — Naturally and Warmly
@@ -77,7 +76,6 @@ When discussing prayers that are NOT from the Bible (e.g., Hail Mary, Serenity P
 VERSE_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful Bible study companion who helps people understand scripture and spiritual content.
 
 ## LANGUAGE RULE - VERY IMPORTANT
-**ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
 ## Grounding Your Answer in Scripture
@@ -142,7 +140,6 @@ Use semicolons to separate multiple references. Use English book names regardles
 PRAYER_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful spiritual companion who helps people understand prayers and passages from all Christian traditions.
 
 ## LANGUAGE RULE - VERY IMPORTANT
-**ALWAYS respond in the same language the user is writing in.**
 {language_instruction}
 
 ## Be Clear About the Source — Woven In, Not a Header
@@ -343,16 +340,13 @@ def get_system_prompt(language_code: str = "en") -> str:
     """
     language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
 
-    if language_code == "en":
-        language_instruction = "The user is writing in English. Respond in English."
-    else:
-        language_instruction = (
-            f"**CRITICAL LANGUAGE RULE**: The user is writing in {language_name}. "
-            f"You MUST respond entirely in {language_name} from start to finish. "
-            f"Every single word of your response must be in {language_name}. "
-            f"Do NOT switch languages at any point in your response. "
-            f"Do NOT mix {language_name} with English or any other language."
-        )
+    language_instruction = (
+        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
+        f"Every single word of your response must be in {language_name}. "
+        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
+        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
+        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
+    )
 
     biblical_ex, non_biblical_ex = SOURCE_ATTRIBUTION_EXAMPLES.get(
         language_code, SOURCE_ATTRIBUTION_EXAMPLES["en"]
@@ -385,16 +379,13 @@ def get_verse_lookup_prompt(language_code: str = "en") -> str:
     """
     language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
 
-    if language_code == "en":
-        language_instruction = "The user is writing in English. Respond in English."
-    else:
-        language_instruction = (
-            f"**CRITICAL LANGUAGE RULE**: The user is writing in {language_name}. "
-            f"You MUST respond entirely in {language_name} from start to finish. "
-            f"Every single word of your response must be in {language_name}. "
-            f"Do NOT switch languages at any point in your response. "
-            f"Do NOT mix {language_name} with English or any other language."
-        )
+    language_instruction = (
+        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
+        f"Every single word of your response must be in {language_name}. "
+        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
+        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
+        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
+    )
 
     return (
         VERSE_LOOKUP_SYSTEM_PROMPT.format(
@@ -417,16 +408,13 @@ def get_prayer_lookup_prompt(language_code: str = "en") -> str:
     """
     language_name = LANGUAGE_NAMES.get(language_code, LANGUAGE_NAMES.get("en"))
 
-    if language_code == "en":
-        language_instruction = "The user is writing in English. Respond in English."
-    else:
-        language_instruction = (
-            f"**CRITICAL LANGUAGE RULE**: The user is writing in {language_name}. "
-            f"You MUST respond entirely in {language_name} from start to finish. "
-            f"Every single word of your response must be in {language_name}. "
-            f"Do NOT switch languages at any point in your response. "
-            f"Do NOT mix {language_name} with English or any other language."
-        )
+    language_instruction = (
+        f"**CRITICAL LANGUAGE RULE**: You MUST respond entirely in {language_name} from start to finish. "
+        f"Every single word of your response must be in {language_name}. "
+        f"Do NOT switch languages at any point in your response, even if the user explicitly asks you to write in a different language. "
+        f"If the user asks to switch languages, kindly let them know they can change the app language using the language switcher, and continue responding in {language_name}. "
+        f"Even if earlier messages in this conversation were in a different language, always respond in {language_name} now."
+    )
 
     return (
         PRAYER_LOOKUP_SYSTEM_PROMPT.format(

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -57,6 +57,19 @@ class TestGetSystemPrompt:
         assert "You MUST respond entirely in" in result
         assert "Do NOT switch languages" in result  # Updated for stronger instruction
 
+    def test_new_language_clauses_present(self):
+        """The three PR#640 clauses must appear (regression guard for the
+        German-then-Italian inconsistency bug)."""
+        result = get_system_prompt("de")
+        assert "even if the user explicitly asks" in result
+        assert "language switcher" in result
+        assert "earlier messages in this conversation were in a different language" in result
+
+    def test_old_english_special_case_removed(self):
+        """The pre-PR#640 soft English instruction must be gone."""
+        result = get_system_prompt("en")
+        assert "The user is writing in English. Respond in English." not in result
+
     def test_german(self):
         result = get_system_prompt("de")
         assert "German" in result
@@ -158,6 +171,12 @@ class TestGetVerseLookupPrompt:
         assert "Italian" in result
         assert "You MUST respond entirely in" in result
 
+    def test_new_language_clauses_present(self):
+        result = get_verse_lookup_prompt("de")
+        assert "even if the user explicitly asks" in result
+        assert "language switcher" in result
+        assert "earlier messages in this conversation were in a different language" in result
+
     def test_contains_verse_content(self):
         result = get_verse_lookup_prompt("en")
         assert "Bible study companion" in result or "Bible verse" in result.lower()
@@ -181,6 +200,12 @@ class TestGetPrayerLookupPrompt:
         assert "German" in result
         assert "You MUST respond entirely in" in result
 
+    def test_new_language_clauses_present(self):
+        result = get_prayer_lookup_prompt("it")
+        assert "even if the user explicitly asks" in result
+        assert "language switcher" in result
+        assert "earlier messages in this conversation were in a different language" in result
+
     def test_contains_prayer_content(self):
         result = get_prayer_lookup_prompt("en")
         assert "prayer" in result.lower()
@@ -195,6 +220,41 @@ class TestGetPrayerLookupPrompt:
         result = get_prayer_lookup_prompt("en")
         assert "Do NOT suggest" not in result
         assert "don't recommend them for use" not in result
+
+
+class TestBuildLanguageInstruction:
+    """Tests for the shared _build_language_instruction helper (PR#640 dedup)."""
+
+    def test_returns_name_and_instruction_tuple(self):
+        from chat.prompts import _build_language_instruction
+
+        name, instruction = _build_language_instruction("it")
+        assert name == LANGUAGE_NAMES["it"]
+        assert "CRITICAL LANGUAGE RULE" in instruction
+
+    def test_unknown_locale_falls_back_to_english_name(self):
+        from chat.prompts import _build_language_instruction
+
+        name, instruction = _build_language_instruction("xx")
+        assert name == LANGUAGE_NAMES["en"]
+        assert LANGUAGE_NAMES["en"] in instruction
+
+    def test_contains_all_new_clauses(self):
+        from chat.prompts import _build_language_instruction
+
+        _, instruction = _build_language_instruction("de")
+        assert "even if the user explicitly asks" in instruction
+        assert "language switcher" in instruction
+        assert "earlier messages in this conversation were in a different language" in instruction
+
+    def test_instruction_identical_across_all_builders(self):
+        """All three builders must embed the exact same instruction for a locale."""
+        from chat.prompts import _build_language_instruction
+
+        _, instruction = _build_language_instruction("it")
+        assert instruction in get_system_prompt("it")
+        assert instruction in get_verse_lookup_prompt("it")
+        assert instruction in get_prayer_lookup_prompt("it")
 
 
 class TestBuildSearchContextPrompt:
@@ -1177,3 +1237,101 @@ class TestChatStreamLanguageSuggestion:
         meta = chunks[0]
         assert meta["type"] == "metadata"
         assert meta["language_suggestion"] is None
+
+
+class TestChatLanguageSuggestion:
+    """Tests for language_suggestion in the non-stream chat() ChatResponse."""
+
+    @pytest.mark.asyncio
+    @patch("chat.service.settings")
+    @patch("chat.service.detect_language_confident", return_value="it")
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="web")
+    @patch("chat.service.get_translation_info", return_value=None)
+    @patch("chat.service.get_model_override_for_language", return_value=None)
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_mismatch_sets_suggestion(
+        self,
+        mock_extract,
+        mock_is_verse,
+        mock_override,
+        mock_trans_info,
+        mock_resolve,
+        mock_detect,
+        mock_confident,
+        mock_settings,
+    ):
+        """chat() should set language_suggestion when the typed language differs
+        from the explicit UI language."""
+        mock_settings.content_filter_intent_detection = False
+        mock_settings.max_message_length = 2000
+        mock_settings.max_conversation_history = 10
+        mock_settings.llm_temperature = 0.7
+        mock_settings.llm_max_tokens = 1024
+        mock_settings.llm_provider = "test"
+        mock_settings.llm_model = "test-model"
+        mock_settings.hybrid_search_enabled = False
+        mock_settings.topic_boosting_enabled = False
+        mock_settings.query_expansion_enabled = False
+        mock_settings.max_context_verses = 10
+
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="x", verses=[], passages=[])
+        )
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="Ciao", provider="test", model="test-model")
+        )
+
+        request = ChatRequest(message="Ciao, come stai oggi?", language="en")
+        response = await service.chat(request)
+        assert response.language_suggestion == "it"
+
+    @pytest.mark.asyncio
+    @patch("chat.service.settings")
+    @patch("chat.service.detect_language_confident", return_value="en")
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="web")
+    @patch("chat.service.get_translation_info", return_value=None)
+    @patch("chat.service.get_model_override_for_language", return_value=None)
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_match_leaves_suggestion_none(
+        self,
+        mock_extract,
+        mock_is_verse,
+        mock_override,
+        mock_trans_info,
+        mock_resolve,
+        mock_detect,
+        mock_confident,
+        mock_settings,
+    ):
+        """chat() should leave language_suggestion None when typed language
+        matches the UI language."""
+        mock_settings.content_filter_intent_detection = False
+        mock_settings.max_message_length = 2000
+        mock_settings.max_conversation_history = 10
+        mock_settings.llm_temperature = 0.7
+        mock_settings.llm_max_tokens = 1024
+        mock_settings.llm_provider = "test"
+        mock_settings.llm_model = "test-model"
+        mock_settings.hybrid_search_enabled = False
+        mock_settings.topic_boosting_enabled = False
+        mock_settings.query_expansion_enabled = False
+        mock_settings.max_context_verses = 10
+
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="x", verses=[], passages=[])
+        )
+        llm.chat = AsyncMock(
+            return_value=LLMResponse(content="Hello", provider="test", model="test-model")
+        )
+
+        request = ChatRequest(message="Hello, how are you?", language="en")
+        response = await service.chat(request)
+        assert response.language_suggestion is None

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -43,11 +43,13 @@ class TestGetSystemPrompt:
 
     def test_english_default(self):
         result = get_system_prompt()
-        assert "respond in English" in result.lower() or "writing in English" in result
+        assert "English" in result
+        assert "CRITICAL LANGUAGE RULE" in result
 
     def test_english_explicit(self):
         result = get_system_prompt("en")
-        assert "The user is writing in English" in result
+        assert "English" in result
+        assert "CRITICAL LANGUAGE RULE" in result
 
     def test_italian(self):
         result = get_system_prompt("it")
@@ -143,11 +145,13 @@ class TestGetVerseLookupPrompt:
 
     def test_english_default(self):
         result = get_verse_lookup_prompt()
-        assert "writing in English" in result
+        assert "English" in result
+        assert "CRITICAL LANGUAGE RULE" in result
 
     def test_english_explicit(self):
         result = get_verse_lookup_prompt("en")
-        assert "writing in English" in result
+        assert "English" in result
+        assert "CRITICAL LANGUAGE RULE" in result
 
     def test_non_english(self):
         result = get_verse_lookup_prompt("it")
@@ -164,11 +168,13 @@ class TestGetPrayerLookupPrompt:
 
     def test_english_default(self):
         result = get_prayer_lookup_prompt()
-        assert "writing in English" in result
+        assert "English" in result
+        assert "CRITICAL LANGUAGE RULE" in result
 
     def test_english_explicit(self):
         result = get_prayer_lookup_prompt("en")
-        assert "writing in English" in result
+        assert "English" in result
+        assert "CRITICAL LANGUAGE RULE" in result
 
     def test_non_english(self):
         result = get_prayer_lookup_prompt("de")

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -364,7 +364,8 @@ class TestSystemPromptConstant:
     """Tests for the SYSTEM_PROMPT constant (backward compat)."""
 
     def test_system_prompt_is_english(self):
-        assert "writing in English" in SYSTEM_PROMPT
+        assert "English" in SYSTEM_PROMPT
+        assert "CRITICAL LANGUAGE RULE" in SYSTEM_PROMPT
 
 
 class TestBibleVersionGuidance:


### PR DESCRIPTION
## Summary
This PR strengthens language consistency enforcement across all system prompts by removing the special case for English and applying uniform, stricter language rules to all languages.

## Key Changes
- **Removed English special case**: Previously, English users received a simple instruction while non-English users received stricter enforcement. Now all languages are treated equally with the same critical language rules.
- **Unified language instruction logic**: Consolidated the language instruction generation across three prompt functions (`get_system_prompt`, `get_verse_lookup_prompt`, `get_prayer_lookup_prompt`) to use identical, consistent rules.
- **Enhanced language enforcement**: Updated the language instruction to explicitly handle edge cases:
  - Prevents language switching even if users explicitly request it
  - Directs users to the app's language switcher for language changes
  - Maintains language consistency even when conversation history contains different languages
- **Simplified prompt templates**: Removed redundant "ALWAYS respond in the same language the user is writing in" statements from template headers, as the logic is now handled entirely by the `{language_instruction}` placeholder.

## Implementation Details
The new unified language instruction applies to all languages and includes:
- Explicit prohibition on language switching mid-response
- User-friendly guidance to use the app's language switcher
- Handling of mixed-language conversation histories
- Consistent enforcement across all three prompt types (main chat, verse lookup, prayer lookup)

https://claude.ai/code/session_012nkMw4JbFPi7C6Vb96EUX9