### PR TITLE
fix(web): show every verse of a cited range in the references panel

### DIFF
--- a/docs/BACKLOG_STORIES/BITB-037-verse-citation-panel-reliability.md
+++ b/docs/BACKLOG_STORIES/BITB-037-verse-citation-panel-reliability.md
@@ -1,0 +1,151 @@
+# BITB-037: Verse Citation Panel Reliability
+
+**Priority:** P1 (High)
+**Status:** 🟡 In Progress — range-matching bug fixed; architectural fix pending
+**Size:** M (range fix: S/done · backend-driven cited verses: M)
+**Created:** 2026-05-30
+
+---
+
+## User Story
+
+**As a** visitor reading an answer,
+**I want** the right-hand "Scripture References" panel to show the verses the
+assistant actually cited,
+**so that** I can read the full context of every verse it quoted instead of
+seeing an empty or mismatched panel.
+
+---
+
+## Problem Statement
+
+**Reported behavior:** "The reference card is empty on the web." The right-side
+citation panel (`frontend/src/app/[locale]/page.tsx`, the `<aside>` sidebar and
+mobile slide-over) frequently shows nothing under its default **"Cited"** filter
+even though the assistant clearly quoted verses.
+
+### How the panel works today
+
+1. The sidebar is populated from `scripture_context.verses` — the top-K results
+   of **semantic vector search** (`api/scripture/search.py`). These are stored
+   in `relevantVerses`.
+2. After streaming, the backend sends a `completion` event with `verses_cited`
+   (`api/chat/service.py:889-922`) — the verses the **LLM actually quoted**,
+   extracted via `parse_structured_citations` + `extract_all_references`
+   (`api/utils/verse_parser.py`).
+3. The default **"Cited"** filter (`showOnlyReferenced = true`) shows the
+   **intersection**: `relevantVerses.filter(v => isVerseReferenced(v, citedSet))`
+   (`page.tsx:309-318`).
+
+### Root causes of the empty panel
+
+- **(A) Verse-range citations only matched their first verse.** `verses_cited`
+  can be a range, e.g. `"John 3:16-17"` (`VerseReference.__str__`). The old
+  `isVerseReferenced` regex (`/(.+)\s+(\d+):(\d+)/`) captured only the start
+  verse, so verse 17 of the range was treated as *not* cited and hidden.
+  **→ Fixed in this PR** (see below).
+
+- **(B) Architectural divergence (the deeper issue).** The sidebar is driven by
+  *semantic search*, but the "Cited" filter intersects it with the *LLM's
+  citations*. The LLM routinely cites verses the vector search never surfaced,
+  and the vector search routinely surfaces neighbours the LLM never cited. When
+  the two sets barely overlap, the intersection — and therefore the default
+  panel — is **empty**, even though citations exist in the answer. The verses
+  the user most wants (the cited ones) may have no card at all because no card
+  was ever created for them.
+
+---
+
+## What this PR already does (TDD)
+
+Fixes root cause **(A)** with a red→green test cycle:
+
+- **Test (red):** `frontend/src/lib/verseExtraction.test.ts` →
+  `describe("isVerseReferenced — cited verse ranges")` asserts every verse
+  inside a cited range (start/middle/end), en-dash ranges, and correct
+  rejection of out-of-range / cross-chapter verses.
+- **Fix (green):** `frontend/src/lib/verseExtraction.ts` — `isVerseReferenced`
+  now parses an optional range end (`-`/`–`) and matches any verse in
+  `[start, end]`.
+- **Integration test:** `frontend/src/app/[locale]/page.test.tsx` →
+  `describe("verse citation panel — server completion event")` exercises the
+  previously-untested `completion`-event path end-to-end: a cited range reveals
+  all its verses, an uncited semantic neighbour stays hidden under "Cited" and
+  reappears under "All Related".
+
+---
+
+## Proposed long-term fix (root cause B)
+
+Make the cited verses **first-class data** rather than an accident of overlap.
+
+### Backend (primary fix)
+
+1. After computing `verses_cited`, **resolve each cited reference to its verse
+   text** via the existing repository lookup
+   (`ScriptureRepository.get_verse_by_reference` / `search.py` verse fetch),
+   honouring the active translation. Expand ranges to their constituent verses.
+2. Emit them in the `completion` event as a structured `cited_verses` array
+   (same `VerseResult` shape: `reference`, `text`, `book`, `localized_book`,
+   `chapter`, `verse`, `translation`), not just bare strings.
+3. Keep `verses_cited` (strings) for backward compatibility / feedback logging.
+
+### Frontend
+
+4. When the `completion` event includes `cited_verses`, **merge them into
+   `relevantVerses`** (deduplicating on normalized reference) so every cited
+   verse has a card to display, regardless of what semantic search returned.
+5. Keep the "Cited" / "All Related" toggle. With (4), the "Cited" view is now
+   guaranteed non-empty whenever the answer cited a real verse.
+6. **Safety net:** if `showOnlyReferenced` is true and `displayedVerses` is
+   empty while `relevantVerses` is non-empty, surface a one-tap "Show all
+   related" affordance (the empty-state hint already exists at
+   `page.tsx:1030-1037`; wire it to flip the toggle).
+
+### Why backend-driven
+
+Resolving cited verses server-side reuses the canonical book-name
+normalization and translation logic already in `verse_parser.py` /
+`book_names.py`, avoids shipping more parsing to the client, and guarantees the
+card text matches the cited translation.
+
+---
+
+## Acceptance Criteria
+
+- [x] A cited range (`"John 3:16-17"`) marks **every** verse in the range as
+      referenced (unit + integration tests).
+- [ ] When the assistant cites a verse that semantic search did **not** return,
+      that verse still appears as a card in the "Cited" panel (its text fetched
+      by the backend).
+- [ ] The "Cited" panel is never empty when the answer contains at least one
+      valid verse citation.
+- [ ] "All Related" continues to show the full semantic result set.
+- [ ] Cited-verse card text respects the active/detected translation.
+- [ ] No regression in the 529-test frontend suite.
+
+---
+
+## Test Plan
+
+- **Unit:** `verseExtraction.test.ts` range cases (done). Add backend
+  `verse_parser` range-expansion + reference-resolution tests in
+  `api/tests/`.
+- **Integration:** extend `page.test.tsx` "server completion event" suite with
+  a `cited_verses` payload whose references are absent from
+  `scripture_context.verses`, asserting the cards still render.
+- **Manual (web):** run `frontend` (`npm run dev`) + API, ask a question that
+  triggers a ranged or out-of-corpus citation, confirm the panel matches the
+  cited verses. See `verify` / `run` skills.
+
+---
+
+## Files
+
+- `frontend/src/lib/verseExtraction.ts` — `isVerseReferenced` (range fix, done)
+- `frontend/src/app/[locale]/page.tsx` — `referencedVerses` / `displayedVerses`
+  / completion-event handler (merge `cited_verses`, toggle safety net)
+- `frontend/src/lib/api.ts` — add `cited_verses` to `StreamChunk` / completion
+- `api/chat/service.py` — resolve + emit `cited_verses`
+- `api/utils/verse_parser.py`, `api/scripture/search.py` — range expansion &
+  reference→text resolution

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -1147,3 +1147,130 @@ describe("language-switch suggestion", () => {
     expect(mockRouterReplace).toHaveBeenCalledWith("/", { locale: "it" });
   });
 });
+
+// On the live site the backend sends a `completion` event carrying the verses
+// it actually cited (`verses_cited`), and those can be RANGES like
+// "John 3:16-17". Once that event arrives the "Cited" filter switches from
+// content-extraction to these server citations. This path was previously
+// untested — and a range citation used to reveal only its first verse, making
+// the panel look broken/empty. These tests lock in the corrected behaviour.
+describe("verse citation panel — server completion event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.warmupBackend).mockImplementation((onReady: () => void) => {
+      onReady();
+    });
+    vi.mocked(api.getTranslations).mockResolvedValue([]);
+    vi.mocked(api.generateSessionId).mockReturnValue("test-session-id");
+    vi.mocked(turnstile.useTurnstile).mockReturnValue({
+      isReady: true,
+      isEnabled: false,
+      token: null,
+      configLoaded: true,
+      refreshToken: vi.fn(),
+      awaitToken: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  async function renderHomeWithCitedRange() {
+    vi.mocked(api.streamMessage).mockImplementation(async function* () {
+      yield {
+        type: "metadata" as const,
+        message_id: "msg-range",
+        scripture_context: {
+          query: "love",
+          // Semantic sidebar results: two verses inside the cited range plus
+          // one neighbour the assistant did NOT cite.
+          verses: [
+            {
+              book: "John",
+              chapter: 3,
+              verse: 16,
+              text: "For God so loved the world...",
+              reference: "John 3:16",
+              similarity: 0.9,
+            },
+            {
+              book: "John",
+              chapter: 3,
+              verse: 17,
+              text: "For God did not send his Son to condemn...",
+              reference: "John 3:17",
+              similarity: 0.85,
+            },
+            {
+              book: "Romans",
+              chapter: 8,
+              verse: 28,
+              text: "And we know that all things work together...",
+              reference: "Romans 8:28",
+              similarity: 0.6,
+            },
+          ],
+          passages: [],
+        },
+        provider: "test",
+        model: "test-model",
+      };
+      yield {
+        type: "content" as const,
+        content: "God's love is shown in John 3:16-17.",
+      };
+      // Backend cites a RANGE; Romans 8:28 was a semantic neighbour, not cited.
+      yield {
+        type: "completion" as const,
+        verses_cited: ["John 3:16-17"],
+      };
+    });
+
+    const result = renderWithIntl(<Home />);
+    const input = screen.getByPlaceholderText("Share what's on your heart...");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "Tell me about love" } });
+    });
+    const submitButton = result.container.querySelector(
+      'button[type="submit"]',
+    );
+    await act(async () => {
+      fireEvent.click(submitButton!);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText("God's love is shown in John 3:16-17."),
+      ).toBeInTheDocument();
+    });
+    return result;
+  }
+
+  it("shows EVERY verse inside a cited range in the Cited filter", async () => {
+    await renderHomeWithCitedRange();
+
+    // Both ends of the range must appear (desktop sidebar). Before the fix,
+    // John 3:17 was hidden because only the range's start verse matched.
+    expect(screen.getAllByText(/John 3:16/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/John 3:17/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("hides a semantic neighbour the assistant did not cite", async () => {
+    await renderHomeWithCitedRange();
+
+    // Romans 8:28 was returned by semantic search but never cited, so the
+    // default "Cited" filter must not show it.
+    expect(screen.queryByText(/Romans 8:28/)).not.toBeInTheDocument();
+  });
+
+  it("reveals the uncited neighbour once 'All Related' is selected", async () => {
+    await renderHomeWithCitedRange();
+
+    // The full semantic set is still reachable via the All Related toggle.
+    const allRelated = screen
+      .getAllByRole("button")
+      .filter((b) => /^All Related \(/.test(b.textContent ?? ""));
+    expect(allRelated.length).toBeGreaterThanOrEqual(1);
+    await act(async () => {
+      fireEvent.click(allRelated[0]);
+    });
+
+    expect(screen.getAllByText(/Romans 8:28/).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/lib/verseExtraction.test.ts
+++ b/frontend/src/lib/verseExtraction.test.ts
@@ -1200,6 +1200,75 @@ describe("isVerseReferenced", () => {
   });
 });
 
+// ── isVerseReferenced: verse-range citations ────────────────────────────────
+// The backend emits cited references as `str(VerseReference)`, which for a
+// range looks like "John 3:16-18" (see api/utils/verse_parser.py). After
+// lower-casing these land in the `references` Set as e.g. "john 3:16-18".
+// Every individual verse the semantic-search sidebar surfaces within that
+// range MUST be considered "referenced", otherwise the "Cited" filter hides
+// verses the assistant actually quoted and the panel looks empty.
+describe("isVerseReferenced — cited verse ranges", () => {
+  it("marks the FIRST verse of a cited range as referenced", () => {
+    const refs = new Set(["john 3:16-18"]);
+    expect(
+      isVerseReferenced(
+        { book: "John", chapter: 3, verse: 16, reference: "John 3:16" },
+        refs,
+      ),
+    ).toBe(true);
+  });
+
+  it("marks a MIDDLE verse of a cited range as referenced", () => {
+    const refs = new Set(["john 3:16-18"]);
+    expect(
+      isVerseReferenced(
+        { book: "John", chapter: 3, verse: 17, reference: "John 3:17" },
+        refs,
+      ),
+    ).toBe(true);
+  });
+
+  it("marks the LAST verse of a cited range as referenced", () => {
+    const refs = new Set(["john 3:16-18"]);
+    expect(
+      isVerseReferenced(
+        { book: "John", chapter: 3, verse: 18, reference: "John 3:18" },
+        refs,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT mark a verse just outside the cited range", () => {
+    const refs = new Set(["john 3:16-18"]);
+    expect(
+      isVerseReferenced(
+        { book: "John", chapter: 3, verse: 19, reference: "John 3:19" },
+        refs,
+      ),
+    ).toBe(false);
+  });
+
+  it("handles en-dash ranges (–) the same as hyphen ranges", () => {
+    const refs = new Set(["psalms 23:1–6"]);
+    expect(
+      isVerseReferenced(
+        { book: "Psalms", chapter: 23, verse: 4, reference: "Psalms 23:4" },
+        refs,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not let a range bleed across chapters", () => {
+    const refs = new Set(["john 3:16-18"]);
+    expect(
+      isVerseReferenced(
+        { book: "John", chapter: 4, verse: 17, reference: "John 4:17" },
+        refs,
+      ),
+    ).toBe(false);
+  });
+});
+
 // ── Russian multi-word book name tests ───────────────────────────────────────
 
 describe("extractVerseReferences — Russian multi-word books", () => {

--- a/frontend/src/lib/verseExtraction.ts
+++ b/frontend/src/lib/verseExtraction.ts
@@ -976,11 +976,17 @@ export function isVerseReferenced(
   // Check if any referenced verse matches this one (partial match)
   for (const ref of Array.from(references)) {
     // Check if references are similar (handles "Psalm" vs "Psalms", etc.)
-    const refParts = ref.match(/(.+)\s+(\d+):(\d+)/);
+    // The optional trailing group captures the END of a verse range, since the
+    // backend emits cited ranges as "John 3:16-18" (hyphen) or "Psalms 23:1–6"
+    // (en-dash). Every verse within [start, end] must count as referenced.
+    const refParts = ref.match(/(.+)\s+(\d+):(\d+)(?:\s*[-–]\s*(\d+))?/);
     if (refParts) {
       const refBook = refParts[1].toLowerCase();
-      const refChapter = refParts[2];
-      const refVerse = refParts[3];
+      const refChapter = parseInt(refParts[2], 10);
+      const refVerseStart = parseInt(refParts[3], 10);
+      const refVerseEnd = refParts[4]
+        ? parseInt(refParts[4], 10)
+        : refVerseStart;
 
       // Fuzzy book name matching — use the already-normalized English form so
       // non-Latin scripts are compared on equal footing.
@@ -993,8 +999,9 @@ export function isVerseReferenced(
 
       if (
         bookMatches &&
-        verse.chapter === parseInt(refChapter) &&
-        verse.verse === parseInt(refVerse)
+        verse.chapter === refChapter &&
+        verse.verse >= refVerseStart &&
+        verse.verse <= refVerseEnd
       ) {
         return true;
       }


### PR DESCRIPTION
## Summary

Fixes the verse citation panel to correctly display all verses within a cited range (e.g., "John 3:16-17"), not just the first verse. Previously, the `isVerseReferenced` function only matched the start verse of a range, causing the "Cited" filter to hide verses the assistant actually quoted.

## Changes

- **`frontend/src/lib/verseExtraction.ts`**: Updated `isVerseReferenced` to parse and match verse ranges
  - Modified regex to capture optional range end (`-` or `–`): `/(.+)\s+(\d+):(\d+)(?:\s*[-–]\s*(\d+))?/`
  - Changed logic to check if a verse falls within `[start, end]` instead of exact match
  - Handles both hyphen and en-dash range separators

- **`frontend/src/lib/verseExtraction.test.ts`**: Added comprehensive test suite for range matching
  - Tests first, middle, and last verses of a cited range
  - Tests boundary conditions (verses outside range, cross-chapter ranges)
  - Tests both hyphen and en-dash range formats

- **`frontend/src/app/[locale]/page.test.tsx`**: Added integration test for server completion event
  - Tests that all verses in a cited range appear in the "Cited" filter
  - Tests that uncited semantic neighbors are hidden in "Cited" view
  - Tests that uncited verses reappear in "All Related" view

## Implementation Details

The fix uses a single regex with an optional capture group to detect range syntax in the backend's cited verse strings (e.g., "john 3:16-18"). When a range is detected, the function now performs a range check (`verse >= start && verse <= end`) instead of an equality check. This ensures every verse the semantic search sidebar surfaces within a cited range is correctly marked as referenced.

The solution maintains backward compatibility with single-verse citations while properly handling the range format emitted by the backend's `VerseReference.__str__` method.

https://claude.ai/code/session_01CobkvTX7rDBAc4MKic1eDG