### PR TITLE
fix: validate book names and handle linked verse references in chat

### DIFF
--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -9,8 +9,19 @@ import ShareMenu from "./ShareMenu";
 import {
   createVersePattern,
   createVersePatternGlobal,
-  CONJUNCTIONS,
 } from "@/lib/versePatterns";
+import { isKnownBook } from "@/lib/verseExtraction";
+
+/** Recursively extract the plain-text content of a React node (e.g. link children). */
+function getNodeText(node: React.ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(getNodeText).join("");
+  if (React.isValidElement(node)) {
+    return getNodeText((node.props as { children?: React.ReactNode }).children);
+  }
+  return "";
+}
 
 interface ChatMessageProps {
   message: Message;
@@ -48,8 +59,9 @@ export default function ChatMessage({
     if (match) {
       const book = match[1].trim();
 
-      // Skip if the book name is a conjunction (e.g., "e 51:17", "and 8:28")
-      if (CONJUNCTIONS.has(book.toLowerCase())) {
+      // Only act on real Bible books — ignore prose/times/conjunctions that
+      // happen to match the "Word digit:digit" shape (e.g. "um 14:30").
+      if (!isKnownBook(book)) {
         return;
       }
 
@@ -73,8 +85,13 @@ export default function ChatMessage({
     while ((match = verseRefPattern.exec(text)) !== null) {
       const book = match[1].trim();
 
-      // Skip if the book name is a conjunction (e.g., "e 51:17", "and 8:28")
-      if (CONJUNCTIONS.has(book.toLowerCase())) {
+      // Only mark real Bible books.  The verse regex intentionally accepts any
+      // "Word digit:digit" shape, so without this check prose like
+      // "Trost der Hoffnung 5:5", clock times ("um 14:30") and greedy
+      // over-matches would be swallowed into clickable spans.  Leaving
+      // lastIndex unchanged is correct: the skipped span is folded into the
+      // next plain/quote segment, so no text is lost.
+      if (!isKnownBook(book)) {
         continue;
       }
 
@@ -214,6 +231,35 @@ export default function ChatMessage({
                       {children}
                     </code>
                   ),
+                  // Verse references the model emits as markdown links
+                  // (e.g. "[Hiob 7:3](url)") should behave like every other
+                  // inline verse marking — amber, clickable, opening the
+                  // in-app verse view — not a default blue external link.
+                  a: ({ href, children }) => {
+                    const linkText = getNodeText(children);
+                    const match = linkText.match(createVersePattern());
+                    if (match && isKnownBook(match[1].trim())) {
+                      return (
+                        <span
+                          className="text-amber-800 font-semibold cursor-pointer hover:underline"
+                          onClick={handleTextClick}
+                        >
+                          {linkText}
+                        </span>
+                      );
+                    }
+                    // Non-verse links render as normal styled links.
+                    return (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary-600 hover:underline"
+                      >
+                        {children}
+                      </a>
+                    );
+                  },
                   // Ensure lists look good
                   ul: ({ children }) => (
                     <ul className="list-disc pl-5 space-y-1">{children}</ul>

--- a/frontend/src/components/ChatMessage.verseMarking.test.tsx
+++ b/frontend/src/components/ChatMessage.verseMarking.test.tsx
@@ -1,0 +1,101 @@
+import { screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ChatMessage from "./ChatMessage";
+import { renderWithIntl } from "@/test/i18n-helpers";
+import type { Message } from "@/lib/api";
+
+// NOTE: unlike ChatMessage.test.tsx, this suite uses the REAL react-markdown so
+// the custom `p` / `a` renderers (which produce the inline verse marking) run.
+
+function renderAssistant(content: string, onVerseClick = vi.fn()) {
+  const message: Message = { role: "assistant", content };
+  const utils = renderWithIntl(
+    <ChatMessage message={message} onVerseClick={onVerseClick} />,
+  );
+  return { ...utils, onVerseClick };
+}
+
+describe("ChatMessage inline verse marking — real references", () => {
+  it("marks a plain-text reference as an amber clickable span", () => {
+    renderAssistant("Wie es in Hiob 7:3 heißt, finden wir Trost.");
+    const span = screen.getByText("Hiob 7:3");
+    expect(span.tagName).toBe("SPAN");
+    expect(span.className).toContain("text-amber-800");
+    expect(span.className).toContain("cursor-pointer");
+  });
+
+  it("calls onVerseClick with the parsed book/chapter/verse", () => {
+    const { onVerseClick } = renderAssistant("Lies Hiob 7:3 heute.");
+    fireEvent.click(screen.getByText("Hiob 7:3"));
+    expect(onVerseClick).toHaveBeenCalledWith("Hiob", 7, 3);
+  });
+
+  it("marks multiple references in the same paragraph", () => {
+    renderAssistant("Siehe Hiob 7:3 und auch Psalm 70:3 heute.");
+    expect(screen.getByText("Hiob 7:3").className).toContain("text-amber-800");
+    expect(screen.getByText("Psalm 70:3").className).toContain(
+      "text-amber-800",
+    );
+  });
+});
+
+describe("ChatMessage inline verse marking — no longer cuts text", () => {
+  it("does not mark German prose that merely contains numbers", () => {
+    const text = "Gott schenkt uns Trost der Hoffnung 5:5 jeden Tag.";
+    const { container } = renderAssistant(text);
+    // The full sentence is preserved …
+    expect(container.textContent).toContain(text);
+    // … and nothing inside it became an amber verse span.
+    expect(container.querySelectorAll("span.text-amber-800").length).toBe(0);
+  });
+
+  it("does not mark a clock time as a verse", () => {
+    const text = "Wir treffen uns um 14:30 Uhr.";
+    const { container } = renderAssistant(text);
+    expect(container.textContent).toContain(text);
+    expect(container.querySelectorAll("span.text-amber-800").length).toBe(0);
+  });
+
+  it("does not swallow a whole clause via greedy over-match", () => {
+    const text = "In 1. Mose lesen wir dass Gott alles 1:1 erschuf.";
+    const { container } = renderAssistant(text);
+    expect(container.textContent).toContain(text);
+    expect(container.querySelectorAll("span.text-amber-800").length).toBe(0);
+  });
+});
+
+describe("ChatMessage inline verse marking — markdown links", () => {
+  it("renders a verse-reference link as an amber clickable span (not a blue <a>)", () => {
+    const { container, onVerseClick } = renderAssistant(
+      "Wie es in [Hiob 7:3](https://example.com/hiob-7-3) heißt.",
+    );
+    const span = screen.getByText("Hiob 7:3");
+    expect(span.tagName).toBe("SPAN");
+    expect(span.className).toContain("text-amber-800");
+    // It must NOT be rendered as an anchor element.
+    expect(container.querySelector('a[href*="hiob-7-3"]')).toBeNull();
+    // Clicking opens the in-app verse view.
+    fireEvent.click(span);
+    expect(onVerseClick).toHaveBeenCalledWith("Hiob", 7, 3);
+  });
+
+  it("works for a localized (Korean) reference link", () => {
+    const { onVerseClick } = renderAssistant(
+      "[요한복음 3:16](https://example.com/jn) 말씀입니다.",
+    );
+    const span = screen.getByText("요한복음 3:16");
+    expect(span.className).toContain("text-amber-800");
+    fireEvent.click(span);
+    expect(onVerseClick).toHaveBeenCalledWith("요한복음", 3, 16);
+  });
+
+  it("keeps a non-verse link as a real anchor", () => {
+    const { container } = renderAssistant(
+      "See [Bible Gateway](https://www.biblegateway.com) for more.",
+    );
+    const anchor = container.querySelector("a");
+    expect(anchor).not.toBeNull();
+    expect(anchor!.getAttribute("href")).toBe("https://www.biblegateway.com");
+    expect(anchor!.textContent).toBe("Bible Gateway");
+  });
+});

--- a/frontend/src/lib/verseExtraction.ts
+++ b/frontend/src/lib/verseExtraction.ts
@@ -841,6 +841,57 @@ export function updateBookNames(apiData: Record<string, string>): void {
       LOCALIZED_BOOK_TO_ENGLISH[key] = english.toLowerCase();
     }
   }
+  // The set of valid book names changed — drop the cache so isKnownBook()
+  // rebuilds it (including any newly added API-provided aliases).
+  _cachedKnownBooks = null;
+}
+
+// ---------------------------------------------------------------------------
+// Known-book allowlist
+// ---------------------------------------------------------------------------
+
+// Lazily-built set of every recognised book name (lowercased).  Populated on
+// first call to isKnownBook() and invalidated by updateBookNames().
+let _cachedKnownBooks: Set<string> | null = null;
+
+/**
+ * Returns the set of all recognised book names (lowercased).
+ *
+ * The set is the union of:
+ *   - every KEY of LOCALIZED_BOOK_TO_ENGLISH   (all localized names, e.g.
+ *     "hiob", "5. mose", "약한복음", "1 царств"), and
+ *   - every VALUE of LOCALIZED_BOOK_TO_ENGLISH (the 66 English canonical
+ *     names, e.g. "job", "genesis", "1 samuel", "song of solomon").
+ *
+ * Including the English values means plain English references ("John 3:16")
+ * are recognised even though English book names are not stored as keys.
+ */
+function getKnownBooks(): Set<string> {
+  if (_cachedKnownBooks !== null) {
+    return _cachedKnownBooks;
+  }
+  const known = new Set<string>();
+  for (const [localized, english] of Object.entries(
+    LOCALIZED_BOOK_TO_ENGLISH,
+  )) {
+    known.add(localized.toLowerCase());
+    known.add(english.toLowerCase());
+  }
+  _cachedKnownBooks = known;
+  return known;
+}
+
+/**
+ * Returns true when `book` is a real Bible book name in any supported language.
+ *
+ * Used to validate the book portion of a regex match before treating it as a
+ * verse reference.  The verse regex deliberately accepts any "Word digit:digit"
+ * shape (to stay language-agnostic), so this allowlist is what prevents prose
+ * like "Trost der Hoffnung 5:5", clock times like "um 14:30", and greedy
+ * over-matches from being marked as verses.
+ */
+export function isKnownBook(book: string): boolean {
+  return getKnownBooks().has(book.trim().toLowerCase());
 }
 
 /**
@@ -909,10 +960,6 @@ function normalizeArabicText(text: string): string {
 }
 
 export function extractVerseReferences(text: string): Set<string> {
-  // Conjunctions that should not be treated as book names
-  // English: "and", German: "und", Italian: "e", Spanish: "y", French: "et", etc.
-  const CONJUNCTIONS = new Set(["e", "and", "und", "y", "et", "o", "a"]);
-
   // Preprocess: strip Arabic tashkeel/tatweel and normalize guillemets.
   text = normalizeArabicText(text);
 
@@ -931,8 +978,11 @@ export function extractVerseReferences(text: string): Set<string> {
     const chapter = normalizeDigits(match[2]);
     const verse = normalizeDigits(match[3]);
 
-    // Skip if the book name is a conjunction (e.g., "e 51:17", "and 8:28")
-    if (CONJUNCTIONS.has(book.toLowerCase())) {
+    // Skip anything whose "book" is not a real Bible book in any supported
+    // language.  This rejects conjunctions ("e 51:17", "und 3:16"), prose that
+    // happens to contain numbers ("Trost der Hoffnung 5:5"), clock times
+    // ("um 14:30") and greedy over-matches — none of which are verses.
+    if (!isKnownBook(book)) {
       continue;
     }
 

--- a/frontend/src/lib/verseMarking.multilang.test.ts
+++ b/frontend/src/lib/verseMarking.multilang.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { extractVerseReferences, isKnownBook } from "./verseExtraction";
+
+/**
+ * Cross-language regression tests for the inline verse-marking fix.
+ *
+ * Two guarantees are verified for every supported locale
+ * (en, it, de, es, fr, pt, ar, ru, zh, hi, ko):
+ *
+ *   1. A real verse reference in that language is recognised
+ *      (isKnownBook + extractVerseReferences).
+ *   2. Prose / clock times / scores / conjunctions that merely contain a
+ *      "word digit:digit" shape are NOT treated as verses — this is what
+ *      previously caused text to be swallowed into clickable spans.
+ */
+
+// One representative "John 3:16" per supported language → normalizes to "john 3:16".
+const JOHN_3_16: Array<{ locale: string; book: string; text: string }> = [
+  { locale: "en", book: "John", text: "John 3:16" },
+  { locale: "it", book: "Giovanni", text: "Giovanni 3:16" },
+  { locale: "de", book: "Johannes", text: "Johannes 3:16" },
+  { locale: "es", book: "Juan", text: "Juan 3:16" },
+  { locale: "fr", book: "Jean", text: "Jean 3:16" },
+  { locale: "pt", book: "João", text: "João 3:16" },
+  { locale: "ar", book: "يوحنا", text: "يوحنا 3:16" },
+  { locale: "hi", book: "यूहन्ना", text: "यूहन्ना 3:16" },
+  { locale: "ru", book: "Иоанна", text: "Иоанна 3:16" },
+  { locale: "zh", book: "约翰福音", text: "约翰福音 3:16" },
+  { locale: "ko", book: "요한복음", text: "요한복음 3:16" },
+];
+
+describe("isKnownBook — accepts real books in every language", () => {
+  for (const { locale, book } of JOHN_3_16) {
+    it(`accepts ${locale} book name "${book}"`, () => {
+      expect(isKnownBook(book)).toBe(true);
+    });
+  }
+
+  it("accepts English canonical names (stored as map values, not keys)", () => {
+    for (const b of [
+      "Genesis",
+      "Job",
+      "Psalms",
+      "Matthew",
+      "Romans",
+      "1 Samuel",
+      "Song of Solomon",
+      "Revelation",
+      "Acts",
+      "Jude",
+    ]) {
+      expect(isKnownBook(b)).toBe(true);
+    }
+  });
+
+  it("accepts numbered / multi-word localized books", () => {
+    expect(isKnownBook("1. Mose")).toBe(true); // German Genesis
+    expect(isKnownBook("Hiob")).toBe(true); // German Job
+    expect(isKnownBook("Psalm")).toBe(true); // German/English alias
+    expect(isKnownBook("Cantico dei Cantici")).toBe(true); // Italian Song of Solomon
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(isKnownBook("  hIoB  ")).toBe(true);
+    expect(isKnownBook("JOHANNES")).toBe(true);
+  });
+});
+
+describe("isKnownBook — rejects non-books (the false positives that cut text)", () => {
+  const NON_BOOKS = [
+    "Trost der Hoffnung", // German prose ("der" connector)
+    "treu", // ordinary German word
+    "um", // German "at" (clock times: "um 14:30")
+    "Ergebnis", // "score" prose
+    "vers",
+    "kapitel",
+    "und", // German conjunction
+    "and",
+    "e", // Italian conjunction
+    "et", // French conjunction
+    "y", // Spanish conjunction
+    "Trost der Hoffnung", // greedy multi-word over-match
+    "1. Mose lesen wir dass Gott alles", // greedy numbered over-match
+  ];
+  for (const word of NON_BOOKS) {
+    it(`rejects "${word}"`, () => {
+      expect(isKnownBook(word)).toBe(false);
+    });
+  }
+});
+
+describe("extractVerseReferences — real references in every language", () => {
+  for (const { locale, text } of JOHN_3_16) {
+    it(`extracts "${text}" (${locale}) → john 3:16`, () => {
+      const refs = extractVerseReferences(text);
+      expect(refs.has("john 3:16")).toBe(true);
+      expect(refs.size).toBe(1);
+    });
+  }
+
+  it("extracts a real reference embedded in a localized sentence", () => {
+    // German, Italian, Spanish, French, Portuguese sentences.
+    expect(
+      extractVerseReferences("Wie es in Johannes 3:16 heißt, ...").has(
+        "john 3:16",
+      ),
+    ).toBe(true);
+    expect(
+      extractVerseReferences("Come dice Giovanni 3:16, ...").has("john 3:16"),
+    ).toBe(true);
+    expect(
+      extractVerseReferences("Como dice Juan 3:16, ...").has("john 3:16"),
+    ).toBe(true);
+    expect(
+      extractVerseReferences("Comme le dit Jean 3:16, ...").has("john 3:16"),
+    ).toBe(true);
+    expect(
+      extractVerseReferences("Como diz João 3:16, ...").has("john 3:16"),
+    ).toBe(true);
+  });
+});
+
+describe("extractVerseReferences — German screenshot scenario", () => {
+  it("marks Hiob 7:3 and Psalm 70:3 but nothing else", () => {
+    const text =
+      'Wie es in Hiob 7:3 heißt, wurden ihm "Monate der Enttäuschung" zuteil. ' +
+      "In Psalm 70:3 steht, dass diejenigen, die uns nach dem Leben trachten, " +
+      "beschämt und zuschanden werden.";
+    const refs = extractVerseReferences(text);
+    expect(refs.has("job 7:3")).toBe(true);
+    expect(refs.has("psalms 70:3")).toBe(true);
+    expect(refs.size).toBe(2);
+  });
+});
+
+describe("extractVerseReferences — rejects non-verse 'word digit:digit'", () => {
+  const NON_VERSES = [
+    "Gott schenkt uns Trost der Hoffnung 5:5 jeden Tag.", // connector over-match
+    "Wir treffen uns um 14:30 Uhr.", // clock time
+    "Das Spiel endete 2:1 für uns.", // score
+    "Gott ist treu 3:4 immer.", // arbitrary word + numbers
+    "In 1. Mose lesen wir dass Gott alles 1:1 erschuf.", // greedy numbered over-match
+    "Il rapporto è 3:2 e 51:17 punti.", // conjunctions + ratios
+  ];
+  for (const text of NON_VERSES) {
+    it(`extracts nothing from: "${text}"`, () => {
+      expect(extractVerseReferences(text).size).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Inline verse marking in the chat misbehaved (visible in German answers):

1. **It cut/swallowed text.** `highlightText()` marked *any* `Word digit:digit` substring as a clickable verse, validating only against a 7-word conjunction blocklist. German prose (`Trost der Hoffnung 5:5`), clock times (`um 14:30`), scores, and greedy regex over-matches were turned into amber spans, mangling the sentence.
2. **Some references didn't get marked.** The model sometimes emits references as markdown links `[Hiob 7:3](url)`. `ChatMessage.tsx` had no `a` renderer, so these rendered as default blue `<a>` links and bypassed the verse marking entirely.

## Changes

- **`verseExtraction.ts`** — add `isKnownBook()`, an allowlist built from `LOCALIZED_BOOK_TO_ENGLISH` (all localized keys + the 66 English canonical values, 781 names). It accepts every real book in all 11 supported languages and rejects the false positives above. Wired into `updateBookNames()` cache invalidation and applied in `extractVerseReferences`.
- **`ChatMessage.tsx`** — replace the conjunction-only checks in `highlightText` / `handleTextClick` with `isKnownBook()`, and add a custom react-markdown `a` renderer so verse-reference links render as the same amber clickable span and open the in-app verse view; non-verse links stay normal anchors.

## Tests

Added cross-language coverage as requested:

- `verseMarking.multilang.test.ts` (46 tests) — real references across **en, it, de, es, fr, pt, ar, ru, zh, hi, ko**, the German screenshot scenario, and false-positive rejection.
- `ChatMessage.verseMarking.test.tsx` (9 tests) — rendering with the real markdown: verses marked, prose/times no longer cut, linked references open the verse view, non-verse links preserved.

Full suite: **575 passed (55 new)**; `tsc --noEmit` and ESLint clean.

https://claude.ai/code/session_01WDjAfRgaUff3GUa3K5F6CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDjAfRgaUff3GUa3K5F6CJ)_