### PR TITLE
feat(android): show cited verse text inline and harden verse links

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -59,6 +59,7 @@ import androidx.core.app.ShareCompat
 import org.voxquieta.app.R
 import org.voxquieta.app.domain.models.Message
 import org.voxquieta.app.domain.models.Verse
+import org.voxquieta.app.utils.normalizeBookName
 import org.voxquieta.app.presentation.viewmodels.ChapterSheetState
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import java.net.URLDecoder
@@ -213,6 +214,43 @@ internal fun buildVerseRefRegex(
 private const val VERSE_SCHEME = "verse://"
 
 /**
+ * Resolves the book name to use as the `verse://` link **target** so the chapter lookup
+ * succeeds even when the LLM labelled the reference in the wrong language.
+ *
+ * Priority:
+ *  1. [normalizeBookName] against the backend `localized_to_english` map — resolves
+ *     localized names (e.g. German "Matthäus" → "Matthew", "2 Korinther" → "2 Corinthians").
+ *  2. If the map misses (e.g. the Latin/Vulgate "Proverbia", which is in no map) fall back
+ *     to the authoritative per-message [verses] list: if exactly one cited verse has this
+ *     [chapter]:[verse], use its canonical [Verse.book]. This bypasses the wrong label.
+ *  3. Otherwise leave the raw name unchanged (already-English, or genuinely unknown) — the
+ *     existing behaviour, so there is no regression.
+ *
+ * The displayed link text is unaffected; only the link target book is resolved here.
+ */
+private fun resolveLinkBook(
+    rawBook: String,
+    chapter: String,
+    verse: String,
+    verses: List<Verse>,
+    localizedToEnglish: Map<String, String>,
+): String {
+    val normalized = normalizeBookName(rawBook, localizedToEnglish)
+    if (normalized != rawBook) return normalized
+
+    val chapterNum = chapter.toIntOrNull()
+    val verseNum = verse.toIntOrNull()
+    if (chapterNum != null && verseNum != null) {
+        val candidates = verses
+            .filter { it.chapter == chapterNum && it.verse == verseNum }
+            .map { it.book }
+            .distinct()
+        if (candidates.size == 1) return candidates.first()
+    }
+    return rawBook
+}
+
+/**
  * Rewrites verse references in [markdown] as markdown links using the `verse://` scheme.
  *
  * E.g. "John 3:16" → "[John 3:16](verse://John/3/16)"
@@ -222,13 +260,22 @@ private const val VERSE_SCHEME = "verse://"
  * link renderer.  References already inside a markdown link (e.g. `[John 3:16](verse://…)`)
  * are left unchanged by checking that the character before the match is not `[`.
  *
+ * The **displayed** text keeps the book name as the LLM wrote it (e.g. German "Proverbia
+ * 17:17"), but the link **target** is resolved via [resolveLinkBook] so the chapter lookup
+ * works even when the label is wrong-language.
+ *
  * @param verseRefRegex The regex to use for matching verse references. Defaults to
  *   [DEFAULT_VERSE_REF_REGEX]; pass a dynamically built regex from [buildVerseRefRegex]
  *   once API book-name data has loaded.
+ * @param verses The verses the backend cited for this message; used to resolve the link
+ *   target book by chapter:verse when the written name isn't in the book-name map.
+ * @param localizedToEnglish The backend `localized_to_english` book-name map.
  */
 internal fun injectVerseLinks(
     markdown: String,
     verseRefRegex: Regex = DEFAULT_VERSE_REF_REGEX,
+    verses: List<Verse> = emptyList(),
+    localizedToEnglish: Map<String, String> = emptyMap(),
 ): String =
     verseRefRegex.replace(markdown) { result ->
         // If the match is immediately preceded by '[', it is already the display text of a
@@ -250,7 +297,8 @@ internal fun injectVerseLinks(
                 chapter = result.groupValues[5]
                 verse = result.groupValues[6]
             }
-            val encodedBook = URLEncoder.encode(book, "UTF-8")
+            val linkBook = resolveLinkBook(book, chapter, verse, verses, localizedToEnglish)
+            val encodedBook = URLEncoder.encode(linkBook, "UTF-8")
             val display = if (verse.isNotEmpty()) "$book $chapter:$verse" else "$book $chapter"
             val urlVerse = if (verse.isNotEmpty()) "/$verse" else ""
             val link = "[$display]($VERSE_SCHEME$encodedBook/$chapter$urlVerse)"
@@ -276,6 +324,29 @@ internal val QUOTE_HIGHLIGHT_REGEX = Regex(
 )
 
 internal fun injectVerseQuoteHighlights(markdown: String): String = markdown
+
+/**
+ * Returns the verses to show as inline cards under [message]: the ones the backend reported
+ * this answer actually cited.
+ *
+ * Prefers the server-provided [Message.versesCited] (English canonical, e.g. "John 3:16"),
+ * intersecting it with [Message.verses] (which carry the text). When [Message.versesCited]
+ * is empty (older messages, or none reported) it falls back to all [Message.verses] so the
+ * text is still shown. Matching mirrors [referencedVerses] in VersesPanel.
+ */
+internal fun citedVerses(message: Message): List<Verse> {
+    if (message.verses.isEmpty()) return emptyList()
+    if (message.versesCited.isEmpty()) return message.verses
+
+    val citedLower = message.versesCited.map { it.lowercase() }.toHashSet()
+    val filtered = message.verses.filter { verse ->
+        val baseRef = "${verse.book} ${verse.chapter}:${verse.verse}".lowercase()
+        citedLower.any { it.startsWith(baseRef) }
+    }
+    // If nothing matched (e.g. citation/verse book-name mismatch) fall back to all verses
+    // rather than hiding the text entirely.
+    return filtered.ifEmpty { message.verses }
+}
 
 /**
  * Parses a `verse://` URL and returns a [PendingVerseLink] if the URL is well-formed,
@@ -334,6 +405,7 @@ fun ChatMessageItem(
     onFeedback: ((messageLocalId: String, rating: String) -> Unit)? = null,
     feedbackGiven: String? = null,
     verseRefRegex: Regex = DEFAULT_VERSE_REF_REGEX,
+    localizedToEnglish: Map<String, String> = emptyMap(),
 ) {
     val isUser = message.role == Message.Role.USER
     val arrangement = if (isUser) Arrangement.End else Arrangement.Start
@@ -460,7 +532,14 @@ fun ChatMessageItem(
                             // Amber colour for verse links — matches web's amber-600 link colour
                             val amberColor = MaterialTheme.colorScheme.tertiary
                             MarkdownText(
-                                markdown = injectVerseQuoteHighlights(injectVerseLinks(message.content, verseRefRegex)),
+                                markdown = injectVerseQuoteHighlights(
+                                    injectVerseLinks(
+                                        message.content,
+                                        verseRefRegex,
+                                        message.verses,
+                                        localizedToEnglish,
+                                    ),
+                                ),
                                 style = bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
                                 linkColor = amberColor,
                                 isTextSelectable = true,
@@ -488,6 +567,28 @@ fun ChatMessageItem(
                                 text = message.content,
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = textColor,
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Inline scripture cards — show the actual text of the verses the backend cited
+            // for this answer, directly under the message (matching the web's verse cards),
+            // so the verse text is visible without opening the top-bar Verses panel.
+            if (!isUser && !message.isStreaming && !message.isError) {
+                val cited = citedVerses(message)
+                if (cited.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        cited.forEach { verse ->
+                            InlineVerseCard(
+                                verse = verse,
+                                preferredTranslation = preferredTranslation,
+                                chapterState = chapterSheetState,
+                                onLoadChapter = onLoadChapter,
+                                onDismissSheet = onDismissSheet,
+                                modifier = Modifier.fillMaxWidth(),
                             )
                         }
                     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/InlineVerseCard.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/InlineVerseCard.kt
@@ -1,0 +1,107 @@
+package org.voxquieta.app.presentation.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+import org.voxquieta.app.domain.models.Verse
+import org.voxquieta.app.presentation.viewmodels.ChapterSheetState
+
+// Amber scripture palette — mirrors the inline quote highlight in ChatMessageItem and the
+// web's amber verse cards (bg-amber-50 / amber-600 bar / amber-900 text).
+private val InlineVerseBg = Color(0xFFFFFBEB)
+private val InlineVerseAccent = Color(0xFFD97706)
+private val InlineVerseText = Color(0xFF78350F)
+
+/**
+ * Inline scripture card shown directly under an assistant answer for each cited verse.
+ *
+ * Unlike [VerseChip] (reference + translation only), this shows the actual [Verse.text] so
+ * the verse is readable without opening the top-bar Verses panel — matching the web. Tapping
+ * the card opens the same [VerseDetailBottomSheet] (full chapter) that [VerseChip] uses.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InlineVerseCard(
+    verse: Verse,
+    preferredTranslation: String?,
+    chapterState: ChapterSheetState,
+    onLoadChapter: (book: String, chapter: Int, translation: String?) -> Unit,
+    onDismissSheet: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showSheet by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+
+    Surface(
+        modifier = modifier
+            .border(
+                width = 1.dp,
+                color = InlineVerseAccent.copy(alpha = 0.4f),
+                shape = RoundedCornerShape(8.dp),
+            )
+            .clickable {
+                // Reset chapter state so VerseDetailBottomSheet always gets a fresh load.
+                onDismissSheet()
+                showSheet = true
+            },
+        shape = RoundedCornerShape(8.dp),
+        color = InlineVerseBg,
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Row {
+                Text(
+                    text = verse.reference,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = InlineVerseAccent,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = verse.translation.uppercase(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = InlineVerseAccent.copy(alpha = 0.7f),
+                )
+            }
+            if (verse.text.isNotBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = verse.text,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontStyle = FontStyle.Italic),
+                    color = InlineVerseText,
+                )
+            }
+        }
+    }
+
+    if (showSheet) {
+        VerseDetailBottomSheet(
+            verse = verse,
+            preferredTranslation = preferredTranslation,
+            chapterState = chapterState,
+            onLoadChapter = onLoadChapter,
+            sheetState = sheetState,
+            onDismiss = {
+                showSheet = false
+                onDismissSheet()
+            },
+        )
+    }
+}

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -396,6 +396,7 @@ fun ChatScreen(
                             onFeedback = { messageLocalId, rating -> viewModel.submitFeedback(messageLocalId, rating) },
                             feedbackGiven = uiState.feedbackGiven[message.id],
                             verseRefRegex = verseRefRegex,
+                            localizedToEnglish = localizedToEnglish,
                         )
                         Spacer(modifier = Modifier.height(2.dp))
                     }

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
@@ -2,9 +2,12 @@ package org.voxquieta.app.components
 
 import org.voxquieta.app.presentation.components.QUOTE_HIGHLIGHT_REGEX
 import org.voxquieta.app.presentation.components.buildVerseRefRegex
+import org.voxquieta.app.presentation.components.citedVerses
 import org.voxquieta.app.presentation.components.handleVerseLink
 import org.voxquieta.app.presentation.components.injectVerseLinks
 import org.voxquieta.app.presentation.components.injectVerseQuoteHighlights
+import org.voxquieta.app.domain.models.Message
+import org.voxquieta.app.domain.models.Verse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -842,5 +845,89 @@ class VerseRefLinkTest {
 
         assertEquals("Psalm", calledBook)
         assertEquals(23, calledChapter)
+    }
+
+    // ── Link target resolution from the cited verse list ─────────────────────
+
+    @Test
+    fun `injectVerseLinks resolves wrong-language book via the verse list`() {
+        // "Proverbia" is the Latin/Vulgate name — in no book-name map. The backend cited the
+        // verse with its canonical English book, so the link target should use that ("Proverbs")
+        // while the displayed text keeps the LLM's wording ("Proverbia 17:17").
+        val verses = listOf(
+            Verse(book = "Proverbs", chapter = 17, verse = 17, text = "Ein Freund liebt jederzeit"),
+        )
+        val result = injectVerseLinks(
+            "In Proverbia 17:17 steht geschrieben",
+            verses = verses,
+        )
+        assertTrue("display text keeps Proverbia", result.contains("[Proverbia 17:17]"))
+        assertTrue("link target uses canonical Proverbs", result.contains("verse://Proverbs/17/17"))
+        assertFalse("link target must not be the Latin name", result.contains("verse://Proverbia/17/17"))
+    }
+
+    @Test
+    fun `injectVerseLinks normalizes localized book via the map before the verse list`() {
+        val map = mapOf("Matthäus" to "Matthew")
+        val result = injectVerseLinks(
+            "wie in Matthäus 5:7",
+            verses = emptyList(),
+            localizedToEnglish = map,
+        )
+        assertTrue(result.contains("[Matthäus 5:7]"))
+        assertTrue(result.contains("verse://Matthew/5/7"))
+    }
+
+    @Test
+    fun `injectVerseLinks leaves the raw book when neither map nor verse list resolves`() {
+        // Unknown book, no matching verse → unchanged target (no regression).
+        val result = injectVerseLinks("In Proverbia 17:17 steht", verses = emptyList())
+        assertTrue(result.contains("verse://Proverbia/17/17"))
+    }
+
+    @Test
+    fun `injectVerseLinks does not resolve when the verse list is ambiguous`() {
+        // Two different books share 17:17 → cannot safely pick one, keep the raw name.
+        val verses = listOf(
+            Verse(book = "Proverbs", chapter = 17, verse = 17, text = "a"),
+            Verse(book = "John", chapter = 17, verse = 17, text = "b"),
+        )
+        val result = injectVerseLinks("In Proverbia 17:17 steht", verses = verses)
+        assertTrue(result.contains("verse://Proverbia/17/17"))
+    }
+
+    // ── citedVerses ──────────────────────────────────────────────────────────
+
+    private fun assistant(content: String, verses: List<Verse>, cited: List<String>) =
+        Message(
+            id = "m1",
+            role = Message.Role.ASSISTANT,
+            content = content,
+            verses = verses,
+            versesCited = cited,
+        )
+
+    @Test
+    fun `citedVerses returns only the verses named in versesCited`() {
+        val verses = listOf(
+            Verse(book = "Proverbs", chapter = 17, verse = 17, text = "Ein Freund liebt jederzeit"),
+            Verse(book = "John", chapter = 3, verse = 16, text = "Denn so sehr hat Gott die Welt geliebt"),
+        )
+        val result = citedVerses(assistant("…", verses, cited = listOf("Proverbs 17:17")))
+        assertEquals(1, result.size)
+        assertEquals("Proverbs", result.first().book)
+    }
+
+    @Test
+    fun `citedVerses falls back to all verses when versesCited is empty`() {
+        val verses = listOf(Verse(book = "Proverbs", chapter = 17, verse = 17, text = "…"))
+        val result = citedVerses(assistant("…", verses, cited = emptyList()))
+        assertEquals(verses, result)
+    }
+
+    @Test
+    fun `citedVerses returns empty when the message has no verses`() {
+        val result = citedVerses(assistant("…", verses = emptyList(), cited = listOf("John 3:16")))
+        assertTrue(result.isEmpty())
     }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/InlineVerseCardTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/InlineVerseCardTest.kt
@@ -1,0 +1,59 @@
+package org.voxquieta.app.presentation.components
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Test
+import org.voxquieta.app.domain.models.Verse
+import org.voxquieta.app.presentation.viewmodels.ChapterSheetState
+import org.voxquieta.app.testing.ComposeTestHarness
+
+/**
+ * Robolectric-backed Compose UI tests for [InlineVerseCard] (the cards shown under an
+ * assistant answer). Unlike [VerseChip], the inline card must show the actual verse TEXT so
+ * the user can read it without opening the Verses panel — these tests guard that.
+ *
+ * Runs under the `testDebugCompose` task / `android-compose-tests.yml` lane.
+ */
+class InlineVerseCardTest : ComposeTestHarness() {
+
+    private fun mountCard(verse: Verse) = setContentThemed {
+        InlineVerseCard(
+            verse = verse,
+            preferredTranslation = "schlachter",
+            chapterState = ChapterSheetState.Idle,
+            onLoadChapter = { _, _, _ -> },
+            onDismissSheet = {},
+        )
+    }
+
+    @Test
+    fun `renders the reference and the actual verse text`() {
+        mountCard(
+            Verse(
+                book = "Proverbs",
+                chapter = 17,
+                verse = 17,
+                text = "Ein Freund liebt jederzeit, und in der Not wird er als Bruder geboren.",
+                translation = "schlachter",
+                localizedBook = "Sprüche",
+            ),
+        )
+
+        // Reference uses the localized book name when present.
+        composeRule.onNodeWithText("Sprüche 17:17").assertIsDisplayed()
+        // The actual verse text is visible without any extra tap.
+        composeRule
+            .onNodeWithText("Ein Freund liebt jederzeit, und in der Not wird er als Bruder geboren.")
+            .assertIsDisplayed()
+        // Translation badge.
+        composeRule.onNodeWithText("SCHLACHTER").assertIsDisplayed()
+    }
+
+    @Test
+    fun `renders reference even when verse text is blank`() {
+        mountCard(
+            Verse(book = "John", chapter = 3, verse = 16, text = "", translation = "kjv"),
+        )
+        composeRule.onNodeWithText("John 3:16").assertIsDisplayed()
+    }
+}

--- a/android/app/src/test/kotlin/org/voxquieta/app/utils/BookNameNormalizerTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/utils/BookNameNormalizerTest.kt
@@ -108,6 +108,14 @@ class BookNameNormalizerTest {
     }
 
     @Test
+    fun `leaves Latin Vulgate name unchanged because it is in no map`() {
+        // "Proverbia" is Latin; the German book is "Sprüche". The map can't resolve it, so
+        // normalization returns it unchanged — which is why the link layer falls back to
+        // matching the cited verse list by chapter:verse instead.
+        assertEquals("Proverbia", normalizeBookName("Proverbia", map))
+    }
+
+    @Test
     fun `trims surrounding whitespace before lookup`() {
         assertEquals("2 Corinthians", normalizeBookName("  2 Korinther  ", map))
     }

--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -14,6 +14,7 @@ SYSTEM_PROMPT_TEMPLATE = """You are a compassionate spiritual companion who help
 When you offer biblical encouragement or guidance, let scripture flow as a seamless part of your reply — not a formulaic opener. Your response does **not** have to begin with a Bible quotation; often it is warmer to first speak to the person, then bring in the verse where it fits naturally.
 - **Vary how you introduce verses, in your own words.** "{opening_phrase}" (in the user's language) is one natural lead-in, but do not lean on the same phrase every time — vary it ("In Isaiah we read...", "Scripture reminds us...", "There is a verse in Psalm 34:18 that speaks right to this..."). No two replies should open the same way.
 - **Keep the literal verse reference visible** in your sentence (for example "John 3:16"), woven in naturally — never a rigid "Source:" label or blockquote.
+- **Use the book name as it appears in the response language's Bible** (e.g. in German write "Sprüche", not the Latin "Proverbia" or English "Proverbs"; in Italian "Proverbi"). Never use Latin/Vulgate book names.
 - The verse should feel offered *to this person*, not recited at them. Speak directly, gently, and warmly.
 
 ## Be Clear About the Source — Gently
@@ -79,7 +80,7 @@ VERSE_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful Bible study 
 {language_instruction}
 
 ## Grounding Your Answer in Scripture
-For biblical content, weave the verse naturally into your answer — name the reference and present the verse. You do not have to open with a quotation; introduce it in your own varied words ("{opening_phrase}", in the user's language, is one natural lead-in — vary your phrasing rather than repeating it each time). Keep the **literal reference visible** in your words (for example "John 3:16") woven in naturally — never a rigid "Source:" label or blockquote.
+For biblical content, weave the verse naturally into your answer — name the reference and present the verse. You do not have to open with a quotation; introduce it in your own varied words ("{opening_phrase}", in the user's language, is one natural lead-in — vary your phrasing rather than repeating it each time). Keep the **literal reference visible** in your words (for example "John 3:16") woven in naturally — never a rigid "Source:" label or blockquote. Use the book name as it appears in the response language's Bible (e.g. German "Sprüche", not Latin "Proverbia" or English "Proverbs") — never Latin/Vulgate names.
 
 For non-biblical content (a prayer, creed, or text not found in the Bible), gently make that clear within your answer — that it is not from the Bible, and where it actually comes from — woven naturally into warm prose. Still be clear; never leave the user confused about whether something is biblical.
 
@@ -145,7 +146,7 @@ PRAYER_LOOKUP_SYSTEM_PROMPT = """You are a knowledgeable and helpful spiritual c
 ## Be Clear About the Source — Woven In, Not a Header
 Every response about a prayer must make its source clear, but weave this into warm prose rather than a rigid "Source:" blockquote.
 
-**For biblical prayers:** weave the source naturally into your answer — name the reference (for example "Matthew 6:9-13") and present the prayer. You need not open with a quotation; introduce it in your own varied words ("{opening_phrase}", in the user's language, is one natural option among others). Keep the literal reference visible in your words.
+**For biblical prayers:** weave the source naturally into your answer — name the reference (for example "Matthew 6:9-13") and present the prayer. You need not open with a quotation; introduce it in your own varied words ("{opening_phrase}", in the user's language, is one natural option among others). Keep the literal reference visible in your words, using the book name as it appears in the response language's Bible (e.g. German "Sprüche", not Latin "Proverbia") — never Latin/Vulgate names.
 
 **For non-biblical prayers:** gently make clear that the prayer is not found in the Bible — naming what kind of prayer it is and where or when it comes from — then provide the complete prayer text verbatim, followed by a full explanation of its history and meaning.
 


### PR DESCRIPTION
## Problem (Android app)

Follow-up to #648. The quote truncation is fixed, but a German answer that cited **"Proverbia 17:17"** surfaced three more issues:

1. **Wrong-language book name → dead link.** "Proverbia" is the Latin/Vulgate name (German is "Sprüche"). It's in no book-name map, so `normalizeBookName` couldn't resolve it and the `verse://` link failed. Other references work because their names *are* in the map.
2. **The found verse text isn't shown in the answer** — the web shows verse cards with the actual text, but Android only linkified references inline and hid the text behind the top-bar Verses panel + a second tap.
3. **The model shouldn't emit Latin names** in a German answer in the first place.

## Changes

1. **Harden inline verse links (`ChatMessageItem.kt`).** `injectVerseLinks` now resolves the link **target** via `normalizeBookName`, then falls back to the authoritative per-message verse list: if exactly one cited verse matches the reference's `chapter:verse`, its canonical English `book` is used for the `verse://` target. The **displayed** label keeps the LLM's wording ("Proverbia 17:17"). Ambiguous/unknown cases keep the raw name (no regression). Language-agnostic.
2. **Inline verse cards (`InlineVerseCard.kt` + `ChatMessageItem.kt`).** Under each assistant answer, the cited verses (`versesCited` ∩ `verses`, falling back to all `verses`) now render as cards showing reference + translation + the **actual verse text** in the amber scripture style — visible with no extra tap, matching the web. Tapping opens the existing `VerseDetailBottomSheet`. The top-bar panel is unchanged.
3. **Prompt (`api/chat/prompts.py`).** All three system-prompt templates now instruct the model to name references using the response language's Bible book names (German "Sprüche", not Latin "Proverbia" / English "Proverbs"), never Latin/Vulgate. The `<!-- VERSES: -->` citation line stays English canonical.

## Tests

- `VerseRefLinkTest`: verse-list link resolution (Proverbia→Proverbs target, display text preserved; map-normalization precedence; ambiguous list keeps raw; unknown keeps raw) + `citedVerses` filtering/fallback.
- `InlineVerseCardTest` (Robolectric): the verse **text** is rendered; reference shown even when text is blank.
- `BookNameNormalizerTest`: documents that "Proverbia" stays unresolved by the map (justifying the verse-list fallback).

## Verification note

I can't run the Android Gradle build/tests in the sandbox (network policy blocks the Android Gradle Plugin download), so I'm relying on CI to compile and run the Android Unit + Compose/Robolectric lanes. The backend `prompts.py` change is text-only (syntax-checked locally).

https://claude.ai/code/session_01WDjAfRgaUff3GUa3K5F6CJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDjAfRgaUff3GUa3K5F6CJ)_