### PR TITLE
fix: populate Cited tab on follow-up turns (resolve cited verses on backend)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
@@ -52,4 +52,5 @@ fun StreamChunkDto.toDomain(): StreamChunk = StreamChunk(
     detectedTranslation = detectedTranslation,
     type = type,
     versesCited = versesCited,
+    resolvedVerses = resolvedVerses.map { it.toDomain() },
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatResponseDto.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatResponseDto.kt
@@ -34,6 +34,8 @@ data class StreamChunkDto(
     @SerialName("detected_translation") val detectedTranslation: String = "",
     /** Server-extracted verse citations (from completion event). */
     @SerialName("verses_cited") val versesCited: List<String> = emptyList(),
+    /** Backend-resolved cited verses (with text) from the completion event. */
+    @SerialName("resolved_verses") val resolvedVerses: List<VerseDto> = emptyList(),
 )
 
 /**

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
@@ -89,10 +89,21 @@ fun ResponseBody.toChunkFlow(): Flow<StreamChunkDto> = flow {
                             Timber.w(e, "SSE: failed to parse verses_cited")
                             emptyList()
                         }
+                        // Backend-resolved cited verses (with text) so the panel can
+                        // surface citations that fell outside the semantic pool.
+                        val resolvedVerses: List<VerseDto> = try {
+                            val versesEl = jsonObj["resolved_verses"]
+                            if (versesEl != null) json.decodeFromJsonElement<List<VerseDto>>(versesEl)
+                            else emptyList()
+                        } catch (e: Exception) {
+                            Timber.w(e, "SSE: failed to parse resolved_verses")
+                            emptyList()
+                        }
                         emit(
                             StreamChunkDto(
                                 type = "completion",
                                 versesCited = versesCited,
+                                resolvedVerses = resolvedVerses,
                             ),
                         )
                     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatResponse.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatResponse.kt
@@ -18,6 +18,7 @@ data class ChatResponse(
  * @param model The LLM model used for generation. Populated from metadata event.
  * @param type Event type: "metadata", "content", "completion", or "" for legacy chunks.
  * @param versesCited Server-extracted verse citations from the completion event.
+ * @param resolvedVerses Backend-resolved cited verses (with text) from the completion event.
  */
 data class StreamChunk(
     val content: String = "",
@@ -28,4 +29,5 @@ data class StreamChunk(
     val detectedTranslation: String = "",
     val type: String = "",
     val versesCited: List<String> = emptyList(),
+    val resolvedVerses: List<Verse> = emptyList(),
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -402,6 +402,7 @@ class ChatViewModel @Inject constructor(
             var accumulatedContent = ""
             var finalVerses: List<Verse> = emptyList()
             var finalVersesCited: List<String> = emptyList()
+            var finalResolvedVerses: List<Verse> = emptyList()
             var didError = false
             var metadataMessageId = ""
 
@@ -451,11 +452,25 @@ class ChatViewModel @Inject constructor(
                     warmUpJob.cancel()
 
                     if (!didError) {
+                        // Merge backend-resolved cited verses into the message's verse
+                        // list (deduped by reference). This both feeds the verse panel
+                        // and persists them in versesJson, so the "Cited" tab survives
+                        // a reload even for verses outside the semantic pool.
+                        val mergedVerses = if (finalResolvedVerses.isEmpty()) {
+                            finalVerses
+                        } else {
+                            val existing = finalVerses
+                                .map { "${it.book}${it.chapter}:${it.verse}" }
+                                .toHashSet()
+                            finalVerses + finalResolvedVerses.filterNot { v ->
+                                "${v.book}${v.chapter}:${v.verse}" in existing
+                            }
+                        }
                         val finalAssistant = Message(
                             id = assistantId,
                             role = Message.Role.ASSISTANT,
                             content = accumulatedContent,
-                            verses = finalVerses,
+                            verses = mergedVerses,
                             isStreaming = false,
                             messageId = metadataMessageId,
                             versesCited = finalVersesCited,
@@ -479,7 +494,7 @@ class ChatViewModel @Inject constructor(
                                 // Append new verses, deduplicating by reference only (not translation)
                                 // so each verse appears once regardless of which translation it came from.
                                 val existingRefs = state.allVerses.map { "${it.book}${it.chapter}:${it.verse}" }.toHashSet()
-                                val dedupedNew = finalVerses.filterNot { v ->
+                                val dedupedNew = mergedVerses.filterNot { v ->
                                     "${v.book}${v.chapter}:${v.verse}" in existingRefs
                                 }
                                 // When the limit is just reached, append a synthetic assistant
@@ -545,6 +560,14 @@ class ChatViewModel @Inject constructor(
                     if (chunk.type == "completion") {
                         if (chunk.versesCited.isNotEmpty()) {
                             finalVersesCited = chunk.versesCited
+                        }
+                        // Backend-resolved cited verses (with text). Merging these
+                        // into the verse pool ensures the "Cited" tab surfaces
+                        // citations that fell outside the semantic search — common
+                        // on follow-up questions whose pool reflects the short
+                        // follow-up text, not what the answer actually cited.
+                        if (chunk.resolvedVerses.isNotEmpty()) {
+                            finalResolvedVerses = chunk.resolvedVerses
                         }
                         return@collect
                     }

--- a/android/app/src/test/kotlin/org/voxquieta/app/repositories/ChatMapperTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/repositories/ChatMapperTest.kt
@@ -179,6 +179,30 @@ class ChatMapperTest {
     }
 
     @Test
+    fun `StreamChunkDto toDomain maps resolved_verses to domain verses`() {
+        val dto = StreamChunkDto(
+            type = "completion",
+            versesCited = listOf("John 14:27"),
+            resolvedVerses = listOf(
+                VerseDto(book = "John", chapter = 14, verse = 27, text = "Peace I leave with you...", translation = "kjv"),
+            ),
+        )
+        val domain = dto.toDomain()
+
+        assertEquals(1, domain.resolvedVerses.size)
+        assertEquals("John", domain.resolvedVerses[0].book)
+        assertEquals(27, domain.resolvedVerses[0].verse)
+    }
+
+    @Test
+    fun `StreamChunkDto toDomain defaults resolved_verses to empty list`() {
+        val dto = StreamChunkDto(content = "hi", done = false)
+        val domain = dto.toDomain()
+
+        assertTrue(domain.resolvedVerses.isEmpty())
+    }
+
+    @Test
     fun `VerseDto toDomain builds reference correctly`() {
         val dto = VerseDto(book = "Genesis", chapter = 1, verse = 1, text = "In the beginning...", translation = "kjv")
         val verse = dto.toDomain()

--- a/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
@@ -275,4 +275,25 @@ class EventSourceParserTest {
         assertEquals("typed hello", chunks[0].content)
         assertFalse(chunks[0].done)
     }
+
+    /**
+     * 14. Completion event with resolved_verses — both the string citations and the
+     *     resolved verse objects (with text) are parsed onto the chunk.
+     */
+    @Test
+    fun `completion event parses verses_cited and resolved_verses`() = runTest {
+        val body = bodyOf(
+            """data: {"type":"completion","verses_cited":["John 14:27"],"resolved_verses":[{"book":"John","chapter":14,"verse":27,"text":"Peace I leave with you...","translation":"kjv"}]}""" + "\n",
+        )
+
+        val chunks = mutableListOf<org.voxquieta.app.data.remote.models.StreamChunkDto>()
+        body.toChunkFlow().collect { chunks.add(it) }
+
+        assertEquals(1, chunks.size)
+        assertEquals("completion", chunks[0].type)
+        assertEquals(listOf("John 14:27"), chunks[0].versesCited)
+        assertEquals(1, chunks[0].resolvedVerses.size)
+        assertEquals("John", chunks[0].resolvedVerses[0].book)
+        assertEquals(27, chunks[0].resolvedVerses[0].verse)
+    }
 }

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -48,6 +48,11 @@ from .topics import detect_topics
 
 logger = get_logger(__name__)
 
+# Upper bound on how many verses a single cited range may expand to when
+# resolving cited verses for the client "Cited" panel. Guards against an LLM
+# emitting an absurd range (e.g. "Psalm 119:1-176") triggering a huge fetch.
+MAX_RANGE_SPAN = 50
+
 
 class ConversationMessage(BaseModel):
     """A message in the conversation."""
@@ -741,6 +746,40 @@ Keep it under 100 words."""
             logger.info("Direct verse lookup completed", extra={"verses_found": len(direct_verses)})
         return direct_verses
 
+    async def _resolve_cited_verses(self, verse_refs: list, translation: str | None = None) -> list:
+        """Resolve cited VerseReferences to full VerseResult objects.
+
+        Unlike the semantic search pool (driven by the user's query), this returns
+        exactly the verses the answer cited — expanding ranges to individual
+        verses — so clients can merge them into their verse panel and the "Cited"
+        tab is populated even for verses outside the pool. Dedupes by canonical
+        reference and never raises: a DB miss or lookup error is skipped so the
+        stream is never broken.
+        """
+        resolved: dict[str, object] = {}
+        for ref in verse_refs:
+            try:
+                if ref.verse_end and ref.verse_end > ref.verse_start:
+                    # Cap pathological ranges (e.g. an LLM emitting "Psalm
+                    # 119:1-176") so we never issue a huge fetch.
+                    end = min(ref.verse_end, ref.verse_start + MAX_RANGE_SPAN - 1)
+                    range_verses = await self.search_service.get_verse_range(
+                        ref.book, ref.chapter, ref.verse_start, end, translation
+                    )
+                    for verse in range_verses:
+                        resolved.setdefault(verse.reference.lower(), verse)
+                else:
+                    # Single verse — also covers chapter-spanning ranges where the
+                    # parser leaves verse_end < verse_start.
+                    verse = await self.search_service.get_verse(
+                        ref.book, ref.chapter, ref.verse_start, translation
+                    )
+                    if verse:
+                        resolved.setdefault(verse.reference.lower(), verse)
+            except Exception as e:
+                logger.warning(f"Failed to resolve cited verse {ref}: {e}")
+        return list(resolved.values())
+
     def _merge_direct_verses(self, scripture_context: SearchResults, direct_verses: list) -> None:
         """Merge direct lookup verses into scripture context (at beginning)."""
         if not direct_verses or not scripture_context:
@@ -890,34 +929,23 @@ Keep it under 100 words."""
         structured = parse_structured_citations(full_response)
         regex_extracted = extract_all_references(full_response)
 
-        # Merge and deduplicate (structured takes priority, regex catches misses)
-        all_verses: dict[str, None] = {}
+        # Merge and deduplicate (structured takes priority, regex catches misses).
+        # Keep the VerseReference objects (not just their string form) so we can
+        # resolve them against the DB below — including verses the LLM cited that
+        # are NOT in the semantic search pool.
+        merged_refs: dict[str, object] = {}
         for v in structured:
-            all_verses[str(v)] = None
+            merged_refs.setdefault(str(v), v)
         for v in regex_extracted:
-            key = str(v)
-            if key not in all_verses:
-                all_verses[key] = None
+            merged_refs.setdefault(str(v), v)
 
-        verses_cited = list(all_verses.keys())
+        verses_cited = list(merged_refs.keys())
 
-        # Resolve cited references to full verse objects so the client can
-        # display cards for verses the semantic search didn't surface.
-        unique_refs: dict = {}
-        for v in structured:
-            key = str(v)
-            if key not in unique_refs:
-                unique_refs[key] = v
-        for v in regex_extracted:
-            key = str(v)
-            if key not in unique_refs:
-                unique_refs[key] = v
-        capped_refs = list(unique_refs.values())[:10]
-        try:
-            cited_results = await self._lookup_direct_verses(capped_refs, translation)
-        except Exception:
-            logger.warning("Failed to resolve cited verse objects for completion event")
-            cited_results = []
+        # Resolve the cited references to full VerseResult objects so the client
+        # can merge them into its verse panel. Without this, a cited verse that
+        # is outside the semantic pool (common on follow-up questions) never
+        # appears in the "Cited" tab.
+        resolved_verses = await self._resolve_cited_verses(list(merged_refs.values()), translation)
 
         # Track LLM structured output compliance — helps decide whether to
         # invest in tool/function calling as a more reliable mechanism.
@@ -929,16 +957,27 @@ Keep it under 100 words."""
                 "structured_count": len(structured),
                 "regex_count": len(regex_extracted),
                 "total_unique": len(verses_cited),
-                "cited_resolved": len(cited_results),
+                "cited_resolved": len(resolved_verses),
                 "llm_structured_present": has_structured,
                 "regex_only": has_regex and not has_structured,
             },
         )
 
+        # Two distinct fields, intentionally:
+        #   verses_cited   - list[str] of raw citation references (range form
+        #                    preserved, e.g. "Romans 8:38-39"; may include refs
+        #                    not in the DB). Drives the client's intersection
+        #                    "Cited" filter and feedback logging.
+        #   resolved_verses - list[VerseResult] of the SAME citations resolved
+        #                    against the DB (ranges expanded to individual
+        #                    verses, with text + localized_book). The client
+        #                    merges these into its verse pool so the filter has
+        #                    cards to match even for verses outside the semantic
+        #                    search results.
         yield {
             "type": "completion",
             "verses_cited": verses_cited,
-            "cited_verses": [v.model_dump() for v in cited_results],
+            "resolved_verses": [v.model_dump() for v in resolved_verses],
         }
 
     def _determine_prompt_type(self, is_verse_lookup: bool, prayer_ref) -> str:

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -900,7 +900,7 @@ class TestChatServiceChatStream:
         # Completion event with verse citations
         assert chunks[3]["type"] == "completion"
         assert "verses_cited" in chunks[3]
-        assert "cited_verses" in chunks[3]
+        assert "resolved_verses" in chunks[3]
 
     @pytest.mark.asyncio
     @patch("chat.service.detect_language", return_value="en")
@@ -910,7 +910,7 @@ class TestChatServiceChatStream:
     async def test_chat_stream_cited_verses_resolved(
         self, mock_extract, mock_is_verse, mock_resolve, mock_detect
     ):
-        """Completion event includes resolved cited_verses with full verse data."""
+        """Completion event includes resolved verses with full verse data."""
         service, llm, _ = _make_chat_service()
 
         service.search_service = AsyncMock()
@@ -940,13 +940,13 @@ class TestChatServiceChatStream:
             chunks.append(chunk)
 
         completion = next(c for c in chunks if c["type"] == "completion")
-        assert "cited_verses" in completion
-        cited = completion["cited_verses"]
+        assert "resolved_verses" in completion
+        cited = completion["resolved_verses"]
         assert isinstance(cited, list)
         # At least one verse resolved (John 3:16)
         assert any(
             v["book"] == "John" and v["chapter"] == 3 and v["verse"] == 16 for v in cited
-        ), f"Expected John 3:16 in cited_verses, got: {cited}"
+        ), f"Expected John 3:16 in resolved_verses, got: {cited}"
 
     @pytest.mark.asyncio
     @patch("chat.service.detect_language", return_value="en")
@@ -956,7 +956,7 @@ class TestChatServiceChatStream:
     async def test_chat_stream_cited_verses_empty_on_resolution_failure(
         self, mock_extract, mock_is_verse, mock_resolve, mock_detect
     ):
-        """cited_verses is [] when resolution raises — no crash, graceful fallback."""
+        """resolved_verses is [] when resolution raises — no crash, graceful fallback."""
         service, llm, _ = _make_chat_service()
 
         service.search_service = AsyncMock()
@@ -977,8 +977,128 @@ class TestChatServiceChatStream:
             chunks.append(chunk)
 
         completion = next(c for c in chunks if c["type"] == "completion")
-        assert completion["cited_verses"] == []
+        assert completion["resolved_verses"] == []
         assert "verses_cited" in completion
+
+
+def _make_ref(book, chapter, verse_start, verse_end=None):
+    """Build a mock VerseReference-like object for resolver tests."""
+    ref = MagicMock()
+    ref.book = book
+    ref.chapter = chapter
+    ref.verse_start = verse_start
+    ref.verse_end = verse_end
+    return ref
+
+
+class TestChatServiceResolveCitedVerses:
+    """Tests for ChatService._resolve_cited_verses().
+
+    The resolver turns the LLM's cited references (which may sit outside the
+    semantic search pool) into full VerseResult objects so clients can merge
+    them into their verse panel and the "Cited" tab is never empty.
+    """
+
+    @pytest.mark.asyncio
+    async def test_includes_verse_outside_pool(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        cited = VerseResult(
+            reference="John 14:27",
+            text="Peace I leave with you...",
+            book="John",
+            chapter=14,
+            verse=27,
+        )
+        service.search_service.get_verse = AsyncMock(return_value=cited)
+
+        result = await service._resolve_cited_verses([_make_ref("John", 14, 27)], "kjv")
+
+        assert len(result) == 1
+        assert result[0].reference == "John 14:27"
+        service.search_service.get_verse.assert_awaited_once_with("John", 14, 27, "kjv")
+
+    @pytest.mark.asyncio
+    async def test_expands_range(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        range_verses = [
+            VerseResult(
+                reference="Romans 8:38",
+                text="For I am persuaded...",
+                book="Romans",
+                chapter=8,
+                verse=38,
+            ),
+            VerseResult(
+                reference="Romans 8:39",
+                text="Nor height, nor depth...",
+                book="Romans",
+                chapter=8,
+                verse=39,
+            ),
+        ]
+        service.search_service.get_verse_range = AsyncMock(return_value=range_verses)
+
+        result = await service._resolve_cited_verses([_make_ref("Romans", 8, 38, 39)], "kjv")
+
+        refs = {v.reference for v in result}
+        assert refs == {"Romans 8:38", "Romans 8:39"}
+
+    @pytest.mark.asyncio
+    async def test_dedups_repeated_citation(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        verse = VerseResult(
+            reference="John 3:16",
+            text="For God so loved the world...",
+            book="John",
+            chapter=3,
+            verse=16,
+        )
+        service.search_service.get_verse = AsyncMock(return_value=verse)
+
+        result = await service._resolve_cited_verses(
+            [_make_ref("John", 3, 16), _make_ref("John", 3, 16)], "kjv"
+        )
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_db_miss(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.get_verse = AsyncMock(return_value=None)
+
+        result = await service._resolve_cited_verses([_make_ref("John", 99, 99)], "kjv")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_on_db_error(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.get_verse = AsyncMock(side_effect=Exception("DB error"))
+
+        # Must never break the stream.
+        result = await service._resolve_cited_verses([_make_ref("John", 3, 16)], "kjv")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_caps_large_range(self):
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.get_verse_range = AsyncMock(return_value=[])
+
+        await service._resolve_cited_verses([_make_ref("Psalm", 119, 1, 176)], "kjv")
+
+        # End must be clamped to start + MAX_RANGE_SPAN - 1, never 176.
+        call_args = service.search_service.get_verse_range.call_args[0]
+        # positional: (book, chapter, start, end, translation)
+        start, end = call_args[2], call_args[3]
+        assert end - start + 1 <= 50
+        assert end < 176
 
 
 class TestChatServiceGetVerseContext:

--- a/frontend/public/CHANGELOG.md
+++ b/frontend/public/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.18.3](https://github.com/zioalex/getinspiredbythebible/compare/v1.18.2...v1.18.3) (2026-05-30)
+
+### Bug Fixes
+
+- **android:** resolve localized verse taps and stop quote truncation ([#648](https://github.com/zioalex/getinspiredbythebible/issues/648)) ([c8dc53b](https://github.com/zioalex/getinspiredbythebible/commit/c8dc53b1142872d4223c5583d216785579e74a63))
+
+## [1.18.2](https://github.com/zioalex/getinspiredbythebible/compare/v1.18.1...v1.18.2) (2026-05-30)
+
+### Bug Fixes
+
+- validate book names and handle linked verse references in chat ([#647](https://github.com/zioalex/getinspiredbythebible/issues/647)) ([281d9ef](https://github.com/zioalex/getinspiredbythebible/commit/281d9ef174e2bed98409d0bfb60095f67ea7eb9d))
+- **web:** show every verse of a cited range in the references panel ([#645](https://github.com/zioalex/getinspiredbythebible/issues/645)) ([de4bf5f](https://github.com/zioalex/getinspiredbythebible/commit/de4bf5f8627e41deda79a81144ccf0dcbafc329a))
+
+## [1.18.1](https://github.com/zioalex/getinspiredbythebible/compare/v1.18.0...v1.18.1) (2026-05-30)
+
+### Documentation
+
+- **backlog:** add BITB-037 SEO follow-ups story ([#642](https://github.com/zioalex/getinspiredbythebible/issues/642)) ([6d7567b](https://github.com/zioalex/getinspiredbythebible/commit/6d7567bcee9eab8a15cfb659606df6042301528d))
+- **backlog:** add BITB-037 test-coverage follow-up for amber quote chip ([#643](https://github.com/zioalex/getinspiredbythebible/issues/643)) ([b3db07a](https://github.com/zioalex/getinspiredbythebible/commit/b3db07a2bf11fd636e7a2634b70db4e454807480))
+
+## [1.18.0](https://github.com/zioalex/getinspiredbythebible/compare/v1.17.0...v1.18.0) (2026-05-29)
+
+### Features
+
+- **android:** inline amber quote chip for quoted scripture (BITB-036) ([#637](https://github.com/zioalex/getinspiredbythebible/issues/637)) ([77f4452](https://github.com/zioalex/getinspiredbythebible/commit/77f44520f2ec2f69ede9525fe3f4ce560b9ecb95))
+
+### Bug Fixes
+
+- **backend:** enforce consistent language responses across all prompts ([#640](https://github.com/zioalex/getinspiredbythebible/issues/640)) ([c07b1a8](https://github.com/zioalex/getinspiredbythebible/commit/c07b1a8324ee9699859680b9a6cdf901a71c548f))
+
+## [1.17.0](https://github.com/zioalex/getinspiredbythebible/compare/v1.16.0...v1.17.0) (2026-05-29)
+
+### Features
+
+- **seo:** add SEO audit scripts, metadata improvements, and agent/skill definitions ([#636](https://github.com/zioalex/getinspiredbythebible/issues/636)) ([c4fdbcf](https://github.com/zioalex/getinspiredbythebible/commit/c4fdbcfdcd47a80b6e63f92491767c94b467f1d5))
+- **web:** language-mismatch switch suggestion banner (Slice 2) ([#635](https://github.com/zioalex/getinspiredbythebible/issues/635)) ([d3b2fe3](https://github.com/zioalex/getinspiredbythebible/commit/d3b2fe3701f605325e96b0eecb70c3b96e4833b5))
+
 ## [1.16.0](https://github.com/zioalex/getinspiredbythebible/compare/v1.15.0...v1.16.0) (2026-05-27)
 
 ### Features

--- a/frontend/public/changelog.json
+++ b/frontend/public/changelog.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.16.0",
-  "date": "2026-05-27",
-  "body": "### Features\n\n* **backend:** emit language_suggestion in chat API (language-mismatch Slice 1) ([#634](https://github.com/zioalex/getinspiredbythebible/issues/634)) ([2720ffa](https://github.com/zioalex/getinspiredbythebible/commit/2720ffa509244967f3e229da203879e95a68a6bb))\n\n### Documentation\n\n* plan for language-mismatch switch-suggestion (Web + Android) ([#630](https://github.com/zioalex/getinspiredbythebible/issues/630)) ([8876472](https://github.com/zioalex/getinspiredbythebible/commit/88764722ab8b9d681bd0e00b7e1385d9218d5f48))"
+  "version": "1.18.3",
+  "date": "2026-05-30",
+  "body": "### Bug Fixes\n\n* **android:** resolve localized verse taps and stop quote truncation ([#648](https://github.com/zioalex/getinspiredbythebible/issues/648)) ([c8dc53b](https://github.com/zioalex/getinspiredbythebible/commit/c8dc53b1142872d4223c5583d216785579e74a63))"
 }

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -1274,9 +1274,127 @@ describe("verse citation panel — server completion event", () => {
     expect(screen.getAllByText(/Romans 8:28/).length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders a cited_verses card that was absent from semantic search results", async () => {
+  // Regression: on a follow-up question the semantic pool is driven by the
+  // short follow-up text, so the verses the answer cites are usually NOT in it.
+  // The backend now sends `resolved_verses` (the cited verses resolved against
+  // the DB); the client merges them into the pool so the "Cited" filter shows
+  // them on every turn.
+  it("populates the Cited filter on a follow-up whose citations are outside the pool", async () => {
+    async function submit(text: string, label: string) {
+      const input = screen.getByPlaceholderText(
+        "Share what's on your heart...",
+      );
+      await act(async () => {
+        fireEvent.change(input, { target: { value: text } });
+      });
+      const submitButton = document.querySelector('button[type="submit"]');
+      await act(async () => {
+        fireEvent.click(submitButton!);
+      });
+      await waitFor(() => {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    }
+
+    // --- Turn 1: the cited verse is also in the semantic pool. ---
+    vi.mocked(api.streamMessage).mockImplementationOnce(async function* () {
+      yield {
+        type: "metadata" as const,
+        message_id: "msg-t1",
+        scripture_context: {
+          query: "anxiety",
+          verses: [
+            {
+              book: "Philippians",
+              chapter: 4,
+              verse: 6,
+              text: "Be careful for nothing...",
+              reference: "Philippians 4:6",
+              similarity: 0.9,
+            },
+          ],
+          passages: [],
+        },
+        provider: "test",
+        model: "test-model",
+      };
+      yield {
+        type: "content" as const,
+        content: "Do not be anxious. Philippians 4:6",
+      };
+      yield {
+        type: "completion" as const,
+        verses_cited: ["Philippians 4:6"],
+        resolved_verses: [
+          {
+            book: "Philippians",
+            chapter: 4,
+            verse: 6,
+            text: "Be careful for nothing...",
+            reference: "Philippians 4:6",
+          },
+        ],
+      };
+    });
+
+    renderWithIntl(<Home />);
+    await submit("I feel anxious", "Do not be anxious. Philippians 4:6");
+    expect(
+      screen.getAllByText(/Philippians 4:6/).length,
+    ).toBeGreaterThanOrEqual(1);
+
+    // --- Turn 2: a vague follow-up. The pool now contains an UNRELATED verse,
+    // and the answer cites Romans 8:1 which is absent from that pool. ---
+    vi.mocked(api.streamMessage).mockImplementationOnce(async function* () {
+      yield {
+        type: "metadata" as const,
+        message_id: "msg-t2",
+        scripture_context: {
+          query: "tell me more",
+          verses: [
+            {
+              book: "Genesis",
+              chapter: 1,
+              verse: 1,
+              text: "In the beginning...",
+              reference: "Genesis 1:1",
+              similarity: 0.5,
+            },
+          ],
+          passages: [],
+        },
+        provider: "test",
+        model: "test-model",
+      };
+      yield {
+        type: "content" as const,
+        content: "There is no condemnation. Romans 8:1",
+      };
+      yield {
+        type: "completion" as const,
+        verses_cited: ["Romans 8:1"],
+        resolved_verses: [
+          {
+            book: "Romans",
+            chapter: 8,
+            verse: 1,
+            text: "There is therefore now no condemnation...",
+            reference: "Romans 8:1",
+          },
+        ],
+      };
+    });
+
+    await submit("tell me more", "There is no condemnation. Romans 8:1");
+
+    // The follow-up's cited verse must appear under the default "Cited" filter
+    // even though it was never part of turn 2's semantic pool.
+    expect(screen.getAllByText(/Romans 8:1/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a resolved_verses card that was absent from semantic search results", async () => {
     // Simulates the core architectural fix: the backend now resolves cited verse
-    // references and emits them as `cited_verses`. A verse the semantic search
+    // references and emits them as `resolved_verses`. A verse the semantic search
     // never returned must still appear as a card in the default "Cited" view.
     vi.mocked(api.streamMessage).mockImplementation(async function* () {
       yield {
@@ -1308,7 +1426,7 @@ describe("verse citation panel — server completion event", () => {
       yield {
         type: "completion" as const,
         verses_cited: ["John 3:16"],
-        cited_verses: [
+        resolved_verses: [
           {
             book: "John",
             chapter: 3,

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -51,6 +51,7 @@ import {
   updateBookNames,
 } from "@/lib/verseExtraction";
 import { updateMultiWordNames } from "@/lib/versePatterns";
+import { mergeVerses } from "@/lib/mergeVerses";
 import { useTurnstile } from "@/lib/turnstile";
 import { useRouter, usePathname } from "@/i18n/navigation";
 
@@ -501,18 +502,13 @@ export default function Home() {
               return updated;
             });
           }
-          // Merge cited verses into the panel so every cited verse has a card,
-          // even if semantic search didn't surface it.
-          if (chunk.cited_verses?.length) {
-            setRelevantVerses((prev) => {
-              const existing = new Set(
-                prev.map((v) => `${v.book}|${v.chapter}|${v.verse}`),
-              );
-              const toAdd = chunk.cited_verses!.filter(
-                (v) => !existing.has(`${v.book}|${v.chapter}|${v.verse}`),
-              );
-              return toAdd.length ? [...prev, ...toAdd] : prev;
-            });
+          // Merge the backend-resolved cited verses into the pool so the
+          // "Cited" filter surfaces them even when they fell outside the
+          // semantic search (common on follow-up questions).
+          if (chunk.resolved_verses?.length) {
+            setRelevantVerses((prev) =>
+              mergeVerses(prev, chunk.resolved_verses),
+            );
           }
         }
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -427,8 +427,13 @@ export interface StreamChunk {
   // For error type:
   error?: string;
   // For completion type:
+  // Raw citation reference strings (range form preserved); drives the
+  // intersection "Cited" filter.
   verses_cited?: string[];
-  cited_verses?: Verse[];
+  // The same citations resolved against the DB (ranges expanded, with text);
+  // merged into the verse pool so the filter has cards to match for verses
+  // outside the semantic search results.
+  resolved_verses?: Verse[];
 }
 
 /**

--- a/frontend/src/lib/mergeVerses.test.ts
+++ b/frontend/src/lib/mergeVerses.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { mergeVerses } from "./mergeVerses";
+import type { Verse } from "./api";
+
+function v(reference: string, overrides: Partial<Verse> = {}): Verse {
+  const [bookChapter, verseStr] = reference.split(":");
+  const parts = bookChapter.split(" ");
+  const verse = parseInt(verseStr ?? "1", 10);
+  const chapter = parseInt(parts[parts.length - 1] ?? "1", 10);
+  const book = parts.slice(0, -1).join(" ");
+  return {
+    reference,
+    text: `text for ${reference}`,
+    book,
+    chapter,
+    verse,
+    ...overrides,
+  };
+}
+
+describe("mergeVerses", () => {
+  it("appends extra verses not already in the pool", () => {
+    const pool = [v("Philippians 4:6")];
+    const extra = [v("John 14:27")];
+
+    const result = mergeVerses(pool, extra);
+
+    const refs = result.map((x) => x.reference);
+    expect(refs).toContain("Philippians 4:6");
+    expect(refs).toContain("John 14:27");
+    expect(result).toHaveLength(2);
+  });
+
+  it("dedupes by normalized reference, keeping the pool entry", () => {
+    const pool = [v("John 3:16", { text: "pool text" })];
+    const extra = [v("john 3:16", { text: "extra text" })];
+
+    const result = mergeVerses(pool, extra);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("pool text");
+  });
+
+  it("preserves pool order and appends extras after", () => {
+    const pool = [v("Genesis 1:1"), v("Exodus 2:2")];
+    const extra = [v("Mark 1:1"), v("Genesis 1:1")];
+
+    const result = mergeVerses(pool, extra);
+
+    expect(result.map((x) => x.reference)).toEqual([
+      "Genesis 1:1",
+      "Exodus 2:2",
+      "Mark 1:1",
+    ]);
+  });
+
+  it("handles empty / undefined extra gracefully", () => {
+    const pool = [v("John 3:16")];
+    expect(mergeVerses(pool, [])).toHaveLength(1);
+    expect(mergeVerses(pool, undefined)).toHaveLength(1);
+  });
+
+  it("dedupes within the extra list too", () => {
+    const pool: Verse[] = [];
+    const extra = [v("Acts 2:1"), v("acts 2:1")];
+
+    const result = mergeVerses(pool, extra);
+
+    expect(result).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/mergeVerses.ts
+++ b/frontend/src/lib/mergeVerses.ts
@@ -1,0 +1,42 @@
+import type { Verse } from "./api";
+
+/**
+ * Normalize a verse reference for dedup comparison: lowercase, trimmed, with
+ * internal whitespace collapsed. Intentionally lightweight — this only keys
+ * dedup between the pool and backend-resolved citations, both of which use the
+ * same canonical "Book chapter:verse" form from the server.
+ */
+function normalizeRef(reference: string): string {
+  return reference.toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+/**
+ * Merge backend-resolved cited verses into the semantic-search verse pool.
+ *
+ * The "Cited" tab is the intersection of the verse pool with the verses the
+ * answer actually cited. On follow-up questions the cited verses are often
+ * absent from the (query-driven) pool, so the backend now resolves them and
+ * sends them as `resolved_verses`. Merging them into the pool lets the existing
+ * intersection filter surface them without any change to the filter itself.
+ *
+ * Dedupes by normalized reference, preferring the existing pool entry (which
+ * may carry a richer score) and preserving pool order; extras are appended.
+ */
+export function mergeVerses(pool: Verse[], extra?: Verse[]): Verse[] {
+  if (!extra || extra.length === 0) {
+    return pool;
+  }
+
+  const seen = new Set(pool.map((verse) => normalizeRef(verse.reference)));
+  const merged = [...pool];
+
+  for (const verse of extra) {
+    const key = normalizeRef(verse.reference);
+    if (!seen.has(key)) {
+      seen.add(key);
+      merged.push(verse);
+    }
+  }
+
+  return merged;
+}


### PR DESCRIPTION
## Summary

The Scripture References "Cited" tab is the **intersection** of two independently-produced sets: the semantic-search verse pool (driven by the user's message) and the verses the answer actually cited. On a **follow-up question**, the semantic search runs on the short follow-up text, so the verses the answer cites are usually absent from the pool → the intersection is empty → the second-question citations vanish from the Cited tab.

This PR keeps the existing intersection filter and adds a fallback: the **backend resolves the actually-cited verses** (with text, expanding ranges) and emits them so the clients (web + Android) **merge them into their verse pool**. Because the merged verses are also in the cited set, the unchanged filter then surfaces them on every turn.

Builds on the (closed) #645 range-matching fix.

## Changes

### Backend (`api/chat/service.py`)
- Added the `_resolve_cited_verses` method — resolves cited `VerseReference`s to full `VerseResult` objects, expanding ranges (capped at `MAX_RANGE_SPAN=50`), deduping by canonical reference, threading the request translation, and **never raising** (a DB miss/error is skipped so the stream is unbroken).
  - Note: an earlier commit had added the call site + constant but **not the method body**, so `chat_stream` would have raised `AttributeError` at the completion event. This adds the missing method + unit tests.
- The completion event now carries two distinct fields (documented inline at the `yield`):
  - **`verses_cited`** — `list[str]` of raw citation references (range form preserved, may include refs not in the DB). Drives the client intersection "Cited" filter + feedback logging. *(pre-existing)*
  - **`resolved_verses`** — `list[VerseResult]` of the **same** citations resolved against the DB (ranges expanded, with text + `localized_book`). Merged into the client verse pool. *(new)*

### Web (`frontend/`)
- `lib/mergeVerses.ts` (+ tests) — pure helper that merges `resolved_verses` into the pool, deduped by normalized reference, preserving pool order.
- `app/[locale]/page.tsx` — on the completion event, merge `resolved_verses` into `relevantVerses`. Filter (`isVerseReferenced` / `displayedVerses`) is unchanged.
- `lib/api.ts` — added `resolved_verses?: Verse[]` to `StreamChunk`.
- `page.test.tsx` — multi-turn regression test: turn 2's cited verse is absent from turn 2's semantic pool, yet still renders under "Cited".

### Android (`android/`)
- DTO/domain/mapper/parser/ViewModel: parse `resolved_verses` and merge into the verse pool (deduped by reference), mirroring the web behavior.

### Naming
- The new field was renamed `cited_verses` → `resolved_verses` across backend/web/Android — it sat next to the pre-existing `verses_cited` and the near-anagram names were misleading. They are distinct and both required.

## Testing
- Backend: **113/113** pass in `test_chat_coverage.py` (incl. 7 new resolver/stream tests).
- Web: **535/535** vitest, lint clean, type-check clean.
- Android: rename is a mechanical 1:1 substitution with all call sites paired; **Kotlin tests not run locally** (this environment can't fetch the Android Gradle plugin offline) — please confirm via CI.

## Notes
- A `chore` commit syncs the generated `frontend/public/CHANGELOG.md` / `changelog.json` to the already-released 1.18.0 entries (was dirty in the working tree; unrelated to this work).

https://claude.ai/code/session_01CobkvTX7rDBAc4MKic1eDG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CobkvTX7rDBAc4MKic1eDG)_