### PR TITLE
fix(android): render changelog body as markdown so links are tappable

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChangelogScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChangelogScreen.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -111,9 +113,12 @@ fun ChangelogScreen(onNavigateBack: () -> Unit) {
                         )
                     }
                     Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = entry.body,
+                    val uriHandler = LocalUriHandler.current
+                    MarkdownText(
+                        markdown = entry.body,
                         style = MaterialTheme.typography.bodyMedium,
+                        linkColor = MaterialTheme.colorScheme.primary,
+                        onLinkClicked = { url -> uriHandler.openUri(url) },
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     HorizontalDivider()

--- a/android/app/src/test/kotlin/org/voxquieta/app/screens/ChangelogEntryTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/screens/ChangelogEntryTest.kt
@@ -1,0 +1,37 @@
+package org.voxquieta.app.screens
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.voxquieta.app.presentation.screens.ChangelogEntry
+
+class ChangelogEntryTest {
+
+    @Test
+    fun `ChangelogEntry stores body with markdown links unchanged`() {
+        val body = "* Fix crash ([#123](https://github.com/org/repo/pull/123))"
+        val entry = ChangelogEntry(version = "1.0.0", date = "2024-01-01", body = body)
+        assertEquals(body, entry.body)
+    }
+
+    @Test
+    fun `ChangelogEntry body preserves raw markdown syntax`() {
+        val body = "### Fixed\n\n* Update deps ([#456](https://github.com/org/repo/pull/456))"
+        val entry = ChangelogEntry(version = "2.0.0", date = "2024-06-01", body = body)
+        assertTrue(entry.body.contains("[#456](https://github.com/org/repo/pull/456)"))
+    }
+
+    @Test
+    fun `ChangelogEntry with blank date is valid`() {
+        val entry = ChangelogEntry(version = "0.1.0", date = "", body = "Initial release")
+        assertTrue(entry.date.isBlank())
+        assertEquals("Initial release", entry.body)
+    }
+
+    @Test
+    fun `ChangelogEntry data class equality holds`() {
+        val a = ChangelogEntry("1.0.0", "2024-01-01", "body")
+        val b = ChangelogEntry("1.0.0", "2024-01-01", "body")
+        assertEquals(a, b)
+    }
+}


### PR DESCRIPTION
Replace plain Text() with MarkdownText() in ChangelogScreen so that
markdown links in release notes (e.g. PR references) appear as tappable
hyperlinks matching the web changelog, instead of raw [text](url) syntax.

Adds ChangelogEntryTest to lock in the body field contract.

https://claude.ai/code/session_01MDxyG4o63igk8rJ4qppFh2