### PR TITLE
fix(ci): split ANDROID_EXTRA_TRACKS on commas only

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -362,7 +362,8 @@ jobs:
       - name: Also release build to extra closed tracks
         # On tag-triggered releases, additionally release the *same* build to
         # every track listed in the ANDROID_EXTRA_TRACKS repo variable
-        # (comma/space separated) — no rebuild, no new versionCode. This is how
+        # (comma separated; trackIds may contain spaces) — no rebuild, no new
+        # versionCode. This is how
         # one release reaches more than one track at once, e.g. the public
         # Google-Group closed-testing track used to recruit testers, in
         # addition to the primary ANDROID_AUTO_TRACK. Each extra track is
@@ -395,21 +396,38 @@ jobs:
             echo "Primary track is '${PRIMARY_TRACK}' — nothing to promote from. Skipping."
             exit 0
           fi
-          # Split on commas and whitespace; skip blanks and the primary track
-          # (already published above).
-          for TRACK in $(echo "${EXTRA_TRACKS}" | tr ',' ' '); do
+          # Split on commas ONLY (not whitespace): Play Store trackIds can
+          # contain spaces, e.g. "closed-testing google-group". Trim surrounding
+          # whitespace from each entry and skip blanks and the primary track
+          # (already published above). Process substitution (rather than a pipe
+          # into the loop) keeps the loop in this shell so a failed promote can
+          # fail the step; FAILED collects per-track failures so one bad track
+          # doesn't stop the others but the step still ends non-zero.
+          FAILED=""
+          while IFS= read -r RAW_TRACK; do
+            # Strip leading/trailing whitespace.
+            TRACK="$(echo "${RAW_TRACK}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             [ -z "${TRACK}" ] && continue
             if [ "${TRACK}" = "${PRIMARY_TRACK}" ]; then
               echo "Skipping '${TRACK}' — already published as the primary track."
               continue
             fi
             echo "::group::Promote versionCode ${VERSION_CODE}: ${PRIMARY_TRACK} → ${TRACK}"
-            PROMOTE_VERSION_CODE="${VERSION_CODE}" \
-            PROMOTE_FROM="${PRIMARY_TRACK}" \
-            PROMOTE_TO="${TRACK}" \
-            fastlane promote --verbose 2>&1 | tee -a /tmp/fastlane.log
+            if PROMOTE_VERSION_CODE="${VERSION_CODE}" \
+               PROMOTE_FROM="${PRIMARY_TRACK}" \
+               PROMOTE_TO="${TRACK}" \
+               fastlane promote --verbose 2>&1 | tee -a /tmp/fastlane.log; then
+              echo "✅ Promoted to '${TRACK}'."
+            else
+              echo "❌ Failed to promote to '${TRACK}'."
+              FAILED="${FAILED} '${TRACK}'"
+            fi
             echo "::endgroup::"
-          done
+          done < <(echo "${EXTRA_TRACKS}" | tr ',' '\n')
+          if [ -n "${FAILED}" ]; then
+            echo "Promotion failed for tracks:${FAILED}"
+            exit 1
+          fi
 
       - name: Upload Fastlane log on failure
         # Captures the verbose fastlane log + any report.xml so the underlying

--- a/android/README.md
+++ b/android/README.md
@@ -389,7 +389,7 @@ run the pipeline.
 | Variable | Description |
 |---|---|
 | `ANDROID_AUTO_TRACK` | The single track a `vX.Y.Z` tag push publishes to. Accepts a named track (`internal`, `alpha`, `beta`, `production`) or any custom closed-testing `trackId` (routed through the `closed_testing` lane). Empty/unset → `internal`. |
-| `ANDROID_EXTRA_TRACKS` | Comma/space-separated list of **additional** tracks to release the same build to on a tag push, on top of `ANDROID_AUTO_TRACK`. Each is served by promoting the just-built `versionCode` (no rebuild). Use it to also reach a public Google-Group closed-testing track for tester recruitment. Empty/unset → only `ANDROID_AUTO_TRACK` is published. |
+| `ANDROID_EXTRA_TRACKS` | **Comma-separated** list of **additional** tracks to release the same build to on a tag push, on top of `ANDROID_AUTO_TRACK`. Split on commas only — individual `trackId`s may contain spaces (e.g. `closed-testing google-group`), and surrounding whitespace around each entry is trimmed. Each track is served by promoting the just-built `versionCode` (no rebuild). Use it to also reach a public Google-Group closed-testing track for tester recruitment. Empty/unset → only `ANDROID_AUTO_TRACK` is published. |
 
 To discover a custom track's `trackId`, run the **Android Publish** workflow
 once via _Run workflow_ (`workflow_dispatch`): the **List available Play Store


### PR DESCRIPTION
## Summary

Fixes a parsing bug in the `ANDROID_EXTRA_TRACKS` fan-out added in #656, so the multi-track publish works with the real track name. The v1.20.0 publish run confirmed the Play Store `trackId`s are:

```
alpha, beta, "closed-testing google-group", "extend testing", internal, production
```

The track to recruit testers — **`closed-testing google-group`** — contains a space, but the fan-out step split the list on commas **and** whitespace (`tr ',' ' '`), which would break it into two invalid tokens (`closed-testing` + `google-group`).

## Changes

- **Split on commas only**, and trim surrounding whitespace from each entry, so `trackId`s containing spaces work. Verified against single, multi, padded, and primary-track-dedup cases.
- **Fail the step on a failed promote**: run the loop in the current shell (process substitution rather than piping into `while`) and collect per-track failures into `FAILED`, exiting non-zero if any track failed — previously a failed `fastlane promote` was masked by the trailing `::endgroup::` echo.
- Update `android/README.md` to document comma-only separation.

## Behavior (answering "will the previous track still get the build?")

Yes. Two independent stages, unchanged in spirit:
1. The **primary upload** publishes to `ANDROID_AUTO_TRACK` (currently `extend testing`).
2. The **fan-out step** then promotes that same `versionCode` to each track in `ANDROID_EXTRA_TRACKS` — no rebuild.

So with `ANDROID_EXTRA_TRACKS = closed-testing google-group`, a tagged release lands on **both** `extend testing` and `closed-testing google-group`.

## To activate (repo owner)

Set **Settings → Secrets and variables → Actions → Variables**:
- Name: `ANDROID_EXTRA_TRACKS`
- Value: `closed-testing google-group`

https://claude.ai/code/session_01Q3gyWEfk5NBMVfGZxk16m2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3gyWEfk5NBMVfGZxk16m2)_