### PR TITLE
fix(frontend): restore emphasized tester CTA lost in homepage refactor

### DIFF
--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -12,6 +12,7 @@ import {
   ChevronDown,
   Square,
   FlaskConical,
+  ArrowRight,
 } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 import { Link } from "@/i18n/navigation";
@@ -789,14 +790,19 @@ export default function ChatIsland({
               </div>
             </div>
             <div className="flex items-center gap-2 sm:gap-3">
-              {/* Android tester recruitment */}
+              {/* Android beta tester recruitment — prominent call to participate */}
               <Link
                 href="/tester"
-                className="flex items-center gap-2 px-3 py-2 text-sm text-primary-700 hover:text-primary-900 hover:bg-primary-50 rounded-lg transition-colors"
                 title={tHeader("testerCta")}
+                className="relative flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2 text-sm font-semibold text-white bg-teal-600 hover:bg-teal-700 rounded-full shadow-sm hover:shadow transition-all"
               >
-                <FlaskConical className="w-4 h-4" />
-                <span className="hidden md:inline">{tHeader("testerCta")}</span>
+                {/* Pinging dot draws the eye to the invitation */}
+                <span className="absolute -top-1 -right-1 flex h-3 w-3">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-teal-400 opacity-75" />
+                  <span className="relative inline-flex h-3 w-3 rounded-full bg-teal-500" />
+                </span>
+                <FlaskConical className="w-4 h-4 flex-shrink-0" />
+                <span className="hidden sm:inline">{tHeader("testerCta")}</span>
               </Link>
 
               {/* Language Switcher */}
@@ -882,6 +888,25 @@ export default function ChatIsland({
                   </button>
                 ))}
               </div>
+
+              {/* Beta tester invitation — call to participate */}
+              <Link
+                href="/tester"
+                className="group mt-8 flex items-center gap-3 sm:gap-4 max-w-lg mx-auto px-4 py-3 sm:px-5 sm:py-4 bg-teal-50 border border-teal-200 rounded-xl hover:border-teal-400 hover:bg-teal-100/70 transition-colors text-left"
+              >
+                <span className="flex-shrink-0 flex items-center justify-center w-10 h-10 rounded-full bg-teal-600 text-white">
+                  <FlaskConical className="w-5 h-5" />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block font-semibold text-teal-900">
+                    {tWelcome("testerTitle")}
+                  </span>
+                  <span className="block text-sm text-teal-700">
+                    {tWelcome("testerBody")}
+                  </span>
+                </span>
+                <ArrowRight className="w-5 h-5 text-teal-600 flex-shrink-0 group-hover:translate-x-0.5 transition-transform" />
+              </Link>
             </div>
           ) : (
             <div className="space-y-6">


### PR DESCRIPTION
## What happened

The emphasized tester call-to-action you merged in #658 disappeared because of an ordering collision between two PRs:

1. **#658** (`c27f3e2`) added the bold CTA — header pill button + welcome-screen invitation card.
2. **#657** (`769d338`, "server-render homepage hero") merged **right after**, but was branched from `main` **before** #658. It refactored `page.tsx` into a server component delegating to a new `ChatIsland.tsx`, and in moving the homepage markup it carried the **old muted text-link** version of the CTA and **dropped the welcome card entirely**. No merge conflict — the file was effectively replaced — so the regression was silent.

The translation strings (`Header.testerCta`, `Welcome.testerTitle`, `Welcome.testerBody`) were never touched and are reused as-is.

## Changes

Re-apply both elements in the current `ChatIsland.tsx`:
- **Header**: bold filled teal pill button with a pinging dot (icon-only below the `sm` breakpoint).
- **Welcome screen**: prominent invitation card ("Help shape Vox Quieta — become an Android beta tester →") below the suggested prompts in the empty-chat state, linking to `/tester`.

## Verification

- `tsc --noEmit` clean, `eslint` clean (only the 2 pre-existing `turnstile.tsx` warnings).
- 600/600 unit tests pass (includes #657's new `page.server.test.tsx`).
- `next build` compiles all `/[locale]/tester` routes.
- Rendered the production build and confirmed the header pill, ping dot, and welcome card are all present.

https://claude.ai/code/session_01Q3gyWEfk5NBMVfGZxk16m2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3gyWEfk5NBMVfGZxk16m2)_