### PR TITLE
test(frontend): guard beta-tester CTA against silent removal

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,6 +38,27 @@ Re-requesting a review on a doc-only PR will **not** unblock it — the skipped
 check simply doesn't meet a "required: success" rule. The approaches above are
 the only reliable solutions.
 
+### Stale branches can silently overwrite merged work
+
+If a long-lived branch is created from `main` **before** another PR merges, and
+both touch the same file, the older branch can silently revert the newer change
+on merge — no conflict, because one branch wholesale-replaces the file the other
+edited. This is how the emphasized beta-tester CTA was lost: a homepage refactor
+(`page.tsx` → `ChatIsland.tsx`) branched before the CTA landed and carried the
+pre-CTA markup.
+
+**Prevent it (recommended):** enable **Settings → Branches → Branch protection
+→ "Require branches to be up to date before merging"** on `main`. GitHub then
+forces each PR to merge/rebase the latest `main` before it can merge, turning a
+silent overwrite into a visible conflict (or at least re-running CI against the
+combined tree).
+
+**Defense in depth:** add a focused regression test for any user-facing element
+that must not disappear. The CTA is now guarded by the `Android beta-tester CTA`
+tests in `frontend/src/app/[locale]/page.test.tsx`, which assert both entry
+points to `/tester` (the header pill and the welcome-screen card) still render —
+so a future overwrite fails CI instead of shipping.
+
 ## Commit message convention
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/).

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -384,6 +384,39 @@ describe("Home page responsive layout", () => {
     });
   });
 
+  // Regression guard for the Android beta-tester call-to-action. The bold CTA
+  // (header pill + welcome-screen invitation card) was once silently dropped
+  // when a homepage refactor branched off before the CTA landed and replaced
+  // ChatIsland.tsx wholesale (no merge conflict). These assertions fail fast in
+  // CI if either entry point to /tester is removed again.
+  describe("Android beta-tester CTA", () => {
+    it("renders an emphasized header pill link to /tester", () => {
+      renderWithIntl(<Home />);
+
+      const label = screen.getByText(enMessages.Header.testerCta);
+      const headerLink = label.closest('a[href="/tester"]');
+      expect(headerLink).not.toBeNull();
+      // Guard the *emphasis*, not just presence: the regression downgraded the
+      // pill to a muted text link (which still linked to /tester). The filled
+      // pill is what makes it a call to participate.
+      expect(headerLink!.className).toContain("rounded-full");
+      expect(headerLink!.className).toContain("bg-teal-600");
+    });
+
+    it("renders the welcome-screen invitation card in the empty-chat state", () => {
+      renderWithIntl(<Home />);
+
+      const cardTitle = screen.getByText(enMessages.Welcome.testerTitle);
+      expect(cardTitle).toBeInTheDocument();
+      expect(
+        screen.getByText(enMessages.Welcome.testerBody),
+      ).toBeInTheDocument();
+
+      // The card itself links to /tester.
+      expect(cardTitle.closest('a[href="/tester"]')).not.toBeNull();
+    });
+  });
+
   describe("mobile slide-over panel", () => {
     it("opens slide-over panel when FAB is clicked", async () => {
       await renderHomeWithVerses();


### PR DESCRIPTION
## Why

Follow-up to #674. The emphasized beta-tester CTA was silently dropped once already: a homepage refactor (#657) branched from `main` before the CTA (#658) landed and replaced `ChatIsland.tsx` wholesale — no merge conflict, so nothing caught it. This adds two complementary guards so it can't happen unnoticed again.

## Changes

**1. Regression test** (`frontend/src/app/[locale]/page.test.tsx`) — a new `Android beta-tester CTA` describe block asserting both entry points to `/tester` render:
- The **header pill** — and crucially it checks the emphasis styling (`rounded-full`, `bg-teal-600`), so a *downgrade* to a muted text link fails too, not just outright removal. That's the exact failure mode that happened.
- The **welcome-screen invitation card** (title, body, and that it links to `/tester`).

I verified the guard genuinely works: it **fails** when the pill is reverted to the old muted styling and **passes** once restored.

**2. Documentation** (`docs/CONTRIBUTING.md`) — a new "Stale branches can silently overwrite merged work" subsection explaining the root cause and recommending the **"Require branches to be up to date before merging"** branch-protection setting on `main`, which turns this class of silent overwrite into a visible conflict. (Repo-settings change is yours to toggle — I can't change settings.)

## Verification

- `tsc --noEmit` clean, `eslint` clean (2 pre-existing `turnstile.tsx` warnings only).
- 602/602 unit tests pass (the 2 new guard tests included).

https://claude.ai/code/session_01Q3gyWEfk5NBMVfGZxk16m2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3gyWEfk5NBMVfGZxk16m2)_