### PR TITLE
test(android): add CJK quote tests and fix cross-paragraph amber highlight (BITB-037)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -319,7 +319,7 @@ internal fun injectVerseLinks(
 //          \u00BB guillemet, \u300D CJK corner, \u300B double CJK.
 internal val QUOTE_HIGHLIGHT_REGEX = Regex(
     "([\u0022\u201C\u201D\u00AB\u201E\u300C\u300A]" +
-        "(?:[^\u0022\u201C\u201D\u00BB\u300D\u300B]{3,})" +
+        "(?:[^\u0022\u201C\u201D\u00BB\u300D\u300B\n]{3,})" +
         "[\u0022\u201D\u201C\u00BB\u300D\u300B])"
 )
 

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/QuoteHighlightSpanTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/QuoteHighlightSpanTest.kt
@@ -93,4 +93,34 @@ class QuoteHighlightSpanTest {
         val s = spansOf("Gott ist die Liebe und es gibt keine Furcht.")
         assertEquals(0, s.getSpans(0, s.length, Any::class.java).size)
     }
+
+    @Test
+    fun `highlights CJK corner-bracket quotes`() {
+        // 「 … 」 — U+300C … U+300D
+        val s = spansOf("彼は言った「神は世を愛された」")
+        assertTrue(
+            s.getSpans(0, s.length, BackgroundColorSpan::class.java).isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `highlights double CJK-bracket quotes`() {
+        // 《 … 》 — U+300A … U+300B
+        val s = spansOf("彼は言った《神は世を愛された》")
+        assertTrue(
+            s.getSpans(0, s.length, BackgroundColorSpan::class.java).isNotEmpty(),
+        )
+    }
+
+    @Test
+    fun `does not highlight across a newline`() {
+        // A quote opener and closer separated by a newline must not be highlighted —
+        // the amber span must stay within a single paragraph.
+        val s = spansOf("He said \"For God so loved the world\nand gave his only Son\"")
+        assertEquals(
+            "a quote spanning a paragraph break must not be highlighted",
+            0,
+            s.getSpans(0, s.length, BackgroundColorSpan::class.java).size,
+        )
+    }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
@@ -754,6 +754,45 @@ class VerseRefLinkTest {
         assertTrue("must match the quoted part", QUOTE_HIGHLIGHT_REGEX.containsMatchIn(input))
     }
 
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches CJK corner brackets`() {
+        // 「 … 」 — U+300C … U+300D
+        assertTrue(
+            "must match CJK corner-bracket quote",
+            QUOTE_HIGHLIGHT_REGEX.containsMatchIn("「神は世を愛された」"),
+        )
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX matches double CJK brackets`() {
+        // 《 … 》 — U+300A … U+300B
+        assertTrue(
+            "must match double CJK-bracket quote",
+            QUOTE_HIGHLIGHT_REGEX.containsMatchIn("《神は世を愛された》"),
+        )
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX does not match across a newline`() {
+        // An opener and closer separated by a newline must NOT produce a match —
+        // otherwise the amber highlight would bleed across paragraph breaks.
+        val input = "He said \"For God so loved the world\nand gave his only Son\""
+        assertFalse(
+            "newline inside a quote must break the match",
+            QUOTE_HIGHLIGHT_REGEX.containsMatchIn(input),
+        )
+    }
+
+    @Test
+    fun `QUOTE_HIGHLIGHT_REGEX still matches a single-line quote after newline fix`() {
+        // Guard: the \n exclusion must not break ordinary single-line matching.
+        val input = "First line without quotes\nHe said \"For God so loved the world\""
+        assertTrue(
+            "single-line quote on the second line must still match",
+            QUOTE_HIGHLIGHT_REGEX.containsMatchIn(input),
+        )
+    }
+
     // ── handleVerseLink ───────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- **Bug fix:** `QUOTE_HIGHLIGHT_REGEX` did not exclude `\n` from the content character class, so a quote opener and closer separated by a newline would match as one span — causing amber highlighting to bleed across paragraph breaks. Fixed by adding `\n` to the negated class.
- **New tests:** Added `QUOTE_HIGHLIGHT_REGEX` assertions for CJK corner brackets `「…」` (U+300C/300D) and double CJK brackets `《…》` (U+300A/300B) — two advertised quote styles in `BITB-036` that had no test coverage.
- **Regression tests:** Added newline-no-match and single-line-after-newline guard tests to `VerseRefLinkTest`, plus CJK and no-highlight-across-newline tests to `QuoteHighlightSpanTest`.

This closes the test-coverage gaps documented in `BITB-037: Android Amber Quote Chip — Test Coverage Follow-up`.

## Test plan

- [x] `QUOTE_HIGHLIGHT_REGEX` does not match a quote whose opener/closer are separated by `\n` (new regression test)
- [x] `QUOTE_HIGHLIGHT_REGEX` matches `「…」` CJK corner brackets
- [x] `QUOTE_HIGHLIGHT_REGEX` matches `《…》` double CJK brackets
- [x] `QUOTE_HIGHLIGHT_REGEX` still matches a single-line quote on a line following a newline
- [x] `applyQuoteHighlights` applies a `BackgroundColorSpan` for CJK corner-bracket quotes
- [x] `applyQuoteHighlights` applies a `BackgroundColorSpan` for double CJK-bracket quotes
- [x] `applyQuoteHighlights` does NOT apply any span for a quote spanning a paragraph break
- [ ] Android CI: Unit Tests, Android Lint, Kotlin Compile Check, Compose UI Tests, Instrumented UI Tests, Build Prod APK

## Files changed

| File | Change |
|---|---|
| `android/app/src/main/…/ChatMessageItem.kt` | Add `\n` to `QUOTE_HIGHLIGHT_REGEX` negated content class |
| `android/app/src/test/…/VerseRefLinkTest.kt` | Add 4 regex tests (CJK corner, double CJK, newline regression, guard) |
| `android/app/src/test/…/QuoteHighlightSpanTest.kt` | Add 3 span tests (CJK corner, double CJK, no-highlight-across-newline) |

https://claude.ai/code/session_01WA6bpN4j5srzKWS3uDsNDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA6bpN4j5srzKWS3uDsNDB)_