### PR TITLE
docs(backlog): add BITB-038 (verbatim scripture citation) and BITB-039 (preserve chat on rotation)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Prioritized list of user stories and features for Vox Quieta.
 
-**Last Updated:** 2026-05-26
+**Last Updated:** 2026-06-04
 
 **Verification Note (2026-04-20):** PR status reconciliation pass completed against GitHub.
 Confirmed merged PRs: #68, #171, #182, #191, #193, #194, #195, #196, #197, #208, #225, #226,
@@ -173,6 +173,63 @@ positives on Bible queries. This unblocks it.
 ---
 
 ## P1 - High Priority (Next Sprint)
+
+### 🎯 BITB-038: Quote Scripture Verbatim — Never Paraphrase a Cited Verse
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+**As a** user who trusts this app to quote the Bible accurately,
+**I want** every verse presented as a direct quotation to match my translation's real wording,
+**so that** I'm never shown an altered citation that changes the meaning of scripture.
+
+**Why P1:** Reported bug — an Italian response said *"la frutta dello Spirito"* (Galatians 5:22-23)
+when the Italian Bible reads *"il frutto dello Spirito"* (singular). Verse text shown to users is
+LLM-generated prose, and the system prompts never forbid paraphrasing/re-translating a quoted
+verse. A Bible app that misquotes the Bible undermines its core promise. Small, prompt-level fix.
+
+**Acceptance Criteria:**
+
+- [ ] All three system prompts (`get_system_prompt`, `get_verse_lookup_prompt`,
+  `get_prayer_lookup_prompt`) instruct the model to quote scripture verbatim from the Scripture
+  Context and never paraphrase, re-translate, or alter wording (incl. singular/plural, articles)
+- [ ] Prompt instructs the model not to fabricate verse wording when the verse text is absent
+- [ ] Italian "fruit of the Spirit" query returns *"il frutto…"* (not *"la frutta"*) when the verse is in context
+- [ ] Unit test asserts the verbatim rule is present in all three prompt builders
+- [ ] Full backend test suite passes
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-038-verbatim-scripture-citation.md`
+
+---
+
+### 🎯 BITB-039: Android — Keep the Current Chat When the Phone Is Rotated
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+**As an** Android user mid-conversation,
+**I want** rotating my phone to keep me in the same chat with all my messages,
+**so that** I don't lose my conversation just because the screen orientation changed.
+
+**Why P1:** Reported bug — rotation resets the user into an empty/new chat. `MainActivity` has no
+`android:configChanges`, so rotation recreates the Activity; the recreated Compose tree re-runs
+`LaunchedEffect(conversationId)` and, because an in-progress chat keeps the `chat/new` route,
+calls `startNewConversation()` which wipes the in-memory conversation. Data-loss UX bug on a
+common interaction; one-line manifest fix plus a defensive guard.
+
+**Acceptance Criteria:**
+
+- [ ] New chat + send message + rotate → same messages and conversation remain visible
+- [ ] Existing saved conversation survives rotation
+- [ ] Rotating during an in-flight response does not start a new chat
+- [ ] Locale switching from Settings still works (still recreates Activity, applies new language)
+- [ ] Existing Android unit tests pass; guard logic is covered by a test
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-039-android-preserve-chat-on-rotation.md`
+
+---
 
 ### ✅ BITB-021: Instrument LLM and Database Performance Metrics
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -231,6 +231,40 @@ common interaction; one-line manifest fix plus a defensive guard.
 
 ---
 
+### 🎯 BITB-041: Verse Detail Never Loads — Add Timeout, Error/Retry, and Monitoring
+
+**Status:** 🎯 Todo
+**Size:** M (1-2 days)
+**Created:** 2026-06-04
+
+**As a** user who taps a Bible verse,
+**I want** the verse text to load promptly or fail with a clear, retryable error,
+**so that** I never get stuck on a `////` placeholder and a spinner that never stops — and as the operator I want this failure monitored and alerted.
+
+**Why P1:** Reported bug — tapping a verse in Italian (ITA1927) shows `////` and an
+infinite spinner (English/German work). Root causes: `ChatViewModel.loadChapter()`
+has no timeout (never reaches `Error`), the backend verse/chapter query has no timeout
+(hangs while health checks stay green), empty synthetic text is rendered as a verse,
+and `deployment/monitoring.tf` has no alert for verse-fetch latency/errors — so a hung
+fetch that returns a bad 200/500 is invisible. Shares an Italian root cause with BITB-040.
+
+**Acceptance Criteria:**
+
+- [ ] Slow/unreachable chapter fetch shows a clear error + working Retry within a bounded time — never an infinite spinner
+- [ ] Verse text area never shows `////`/empty quotes (loading → verse or error)
+- [ ] Backend verse/chapter reads time out to 504 instead of hanging
+- [ ] Italian (ITA1927) detail loads for the reported references; corrupt data repaired + empty-text integrity check added
+- [ ] Monitoring alert fires on elevated verse/chapter fetch error-rate or p95 latency/timeouts (existing action group)
+- [ ] New Android + backend tests cover timeout, error, retry, and empty-text paths
+
+**Test note:** existing tests over-mock and skip integration — `loadChapter` is tested
+only for `IOException`, `VerseDetailBottomSheet` has no UI test, and the chapter route
+covers only 200/404. These gaps let the bug ship.
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md`
+
+---
+
 ### ✅ BITB-021: Instrument LLM and Database Performance Metrics
 
 **Status:** ✅ Done (PR #229, #233, #236, #237, #242 merged 2026-03-06)
@@ -618,6 +652,35 @@ Testing & Documentation:
 ---
 
 ## P2 - Medium Priority (Backlog)
+
+### 🎯 BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+**As a** non-English user tapping a Bible verse,
+**I want** the verse-detail header to use my translation's book name (e.g. *"Esodo 30:22"*),
+**so that** the reference matches the language I'm reading in.
+
+**Why P2:** Reported bug — Italian shows *"Exodus 30:22"* instead of *"Esodo 30:22"*
+(English/German work). `buildSyntheticVerse()` never sets `localizedBook`
+(`ChatMessageItem.kt:753-770`), so `verse.reference` falls back to the English `book`
+until the chapter loads. Backend already returns `localized_book`; tests mock the real
+`get_localized_book_name`, so the gap went uncaught. Shares an Italian root cause with
+BITB-041 (when the fetch fails, the header also stays English).
+
+**Acceptance Criteria:**
+
+- [ ] Tapping a verse in Italian shows the localized header (*"Esodo 30:22"*) before and after load
+- [ ] Verified for German and a non-Latin-script locale (no regression)
+- [ ] Real (un-mocked) unit test for `get_localized_book_name` across translations
+- [ ] Compose UI test covers the localized header in the verse-detail sheet
+- [ ] All existing Android + backend tests pass
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md`
+
+---
 
 ### 🎯 BITB-036: Android Inline Amber Chip for Quoted Scripture — Web Parity
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -265,6 +265,36 @@ covers only 200/404. These gaps let the bug ship.
 
 ---
 
+### 🎯 BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+**As a** non-English user tapping a Bible verse,
+**I want** the verse-detail header to use my translation's book name (e.g. *"Esodo 30:22"*, *"2. Mose 30:22"*),
+**so that** the reference matches the language I'm reading in.
+
+**Why P1:** Reported bug affecting **all non-English locales** on **every** verse tap —
+the header shows the English book name (*"Exodus 30:22"*) even when the verse text loads
+correctly. `buildSyntheticVerse()` never sets `localizedBook` (`ChatMessageItem.kt:753-770`),
+so the sheet header (`VerseDetailBottomSheet.kt:106`) always falls back to the English
+`book`. Independent of BITB-041 (which only made it more visible). Tests mock the real
+`get_localized_book_name` and skip the verse-flow UI, so it went uncaught. Small fix:
+carry the localized name the LLM already wrote through the verse link.
+
+**Acceptance Criteria:**
+
+- [ ] Tapping a verse shows the localized header before and after load, and even if the fetch fails
+- [ ] Verified across several non-English locales (incl. one non-Latin-script); no English regression
+- [ ] Real (un-mocked) unit test for `get_localized_book_name` across all translations
+- [ ] Compose UI test covers the localized header in the verse-detail sheet
+- [ ] All existing Android + backend tests pass
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md`
+
+---
+
 ### ✅ BITB-021: Instrument LLM and Database Performance Metrics
 
 **Status:** ✅ Done (PR #229, #233, #236, #237, #242 merged 2026-03-06)
@@ -652,35 +682,6 @@ Testing & Documentation:
 ---
 
 ## P2 - Medium Priority (Backlog)
-
-### 🎯 BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
-
-**Status:** 🎯 Todo
-**Size:** S (< 4 hours)
-**Created:** 2026-06-04
-
-**As a** non-English user tapping a Bible verse,
-**I want** the verse-detail header to use my translation's book name (e.g. *"Esodo 30:22"*),
-**so that** the reference matches the language I'm reading in.
-
-**Why P2:** Reported bug — Italian shows *"Exodus 30:22"* instead of *"Esodo 30:22"*
-(English/German work). `buildSyntheticVerse()` never sets `localizedBook`
-(`ChatMessageItem.kt:753-770`), so `verse.reference` falls back to the English `book`
-until the chapter loads. Backend already returns `localized_book`; tests mock the real
-`get_localized_book_name`, so the gap went uncaught. Shares an Italian root cause with
-BITB-041 (when the fetch fails, the header also stays English).
-
-**Acceptance Criteria:**
-
-- [ ] Tapping a verse in Italian shows the localized header (*"Esodo 30:22"*) before and after load
-- [ ] Verified for German and a non-Latin-script locale (no regression)
-- [ ] Real (un-mocked) unit test for `get_localized_book_name` across translations
-- [ ] Compose UI test covers the localized header in the verse-detail sheet
-- [ ] All existing Android + backend tests pass
-
-**Full Story:** `docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md`
-
----
 
 ### 🎯 BITB-036: Android Inline Amber Chip for Quoted Scripture — Web Parity
 

--- a/docs/BACKLOG_STORIES/BITB-038-verbatim-scripture-citation.md
+++ b/docs/BACKLOG_STORIES/BITB-038-verbatim-scripture-citation.md
@@ -1,0 +1,113 @@
+# BITB-038: Quote Scripture Verbatim — Never Paraphrase a Cited Verse
+
+**Status:** 🎯 Todo
+**Priority:** P1 (High) — correctness/trust defect in the app's core promise
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+## User Story
+
+As a user who trusts this app to quote the Bible accurately, I want every Bible
+verse the assistant presents as a direct quotation to match the real wording of
+my selected translation, so that I am never shown an altered citation that
+changes the meaning of scripture.
+
+## Problem
+
+A user in Italian was shown:
+
+> "In Galati 5:22-23, la Bibbia descrive la **'frutta'** dello Spirito Santo…"
+
+The Italian Bible reads **"il frutto dello Spirito"** (singular — *the fruit*),
+not **"la frutta"** (*the fruits* / produce). The word choice changes the
+meaning, and — more importantly — it is presented as a direct biblical
+quotation when it is not what the Bible actually says.
+
+### Root cause
+
+The verse text shown to users is **LLM-generated prose**, not a stored string.
+Verses are retrieved correctly and injected into the prompt under a
+"Scripture Context" block by `build_search_context_prompt()`
+(`api/chat/prompts.py:418`). However, the system prompts only instruct the model
+to *use the provided verses as a source* and to *avoid inventing references*
+(`api/chat/prompts.py:44-48`). There is **no rule forbidding the model from
+re-wording, paraphrasing, or re-translating the verse text** when it quotes it.
+So the model reproduces scripture from its own training/paraphrase rather than
+copying the exact text supplied to it — producing "frutta" instead of "frutto".
+
+This is a content-fidelity defect: a Bible app that misquotes the Bible
+undermines its central value proposition.
+
+## Proposed Changes
+
+The fix is **prompt-level** and reuses the existing "append a shared guidance
+block" pattern already used by `BIBLE_VERSION_GUIDANCE` (`api/chat/prompts.py:308`).
+
+### 1. Add a shared scripture-fidelity guidance block
+
+Add a new constant in `api/chat/prompts.py`, e.g. `SCRIPTURE_FIDELITY_GUIDANCE`,
+instructing the model:
+
+- When presenting a Bible verse as a **direct quotation**, reproduce the verse
+  text **word-for-word exactly** as it appears in the "Scripture Context" — do
+  **not** paraphrase, summarise, modernise, re-translate, or otherwise change
+  the wording, including articles and singular/plural forms (e.g. Italian
+  *"il frutto"*, never *"la frutta"*).
+- The quoted words must be a real quotation of the provided verse. Only the
+  surrounding warm/explanatory prose is the model's own.
+- If the exact verse text is **not** present in the Scripture Context, do not
+  reconstruct or guess the wording. Refer to the passage and its reference, or
+  describe it, rather than presenting reconstructed text as a verbatim quote.
+
+### 2. Append it to all three prompt builders
+
+Wire the new block into the three builders the same way `BIBLE_VERSION_GUIDANCE`
+is appended (`api/chat/prompts.py:362-415`):
+
+- `get_system_prompt()`
+- `get_verse_lookup_prompt()`
+- `get_prayer_lookup_prompt()`
+
+### 3. Tighten the inline references
+
+Point the existing "Using Scripture Context" bullets (`prompts.py:44-48`) and the
+verse-lookup "Present the verse" step (`prompts.py:95`) at the new verbatim rule
+so the instruction is reinforced where verses are introduced.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `api/chat/prompts.py` | Add `SCRIPTURE_FIDELITY_GUIDANCE`; append it in `get_system_prompt`, `get_verse_lookup_prompt`, `get_prayer_lookup_prompt`; reinforce inline bullets at lines 44-48 and 95 |
+| `api/tests/` (prompt tests) | Add a test asserting the verbatim/no-paraphrase rule is present in the output of all three `get_*_prompt(...)` builders |
+
+## Acceptance Criteria
+
+- [ ] All three system prompts (`get_system_prompt`, `get_verse_lookup_prompt`,
+      `get_prayer_lookup_prompt`) include an explicit rule to quote scripture
+      verbatim from the Scripture Context and never paraphrase/re-translate it.
+- [ ] The prompt instructs the model not to fabricate verse wording when the verse
+      text is absent from the Scripture Context.
+- [ ] Manual check: an Italian query about the fruit of the Spirit returns the
+      singular wording *"il frutto dello Spirito"* (not *"la frutta"*) when the
+      Italian verse is in context.
+- [ ] A unit test asserts the verbatim rule appears in all three prompt builders.
+- [ ] Full backend test suite passes.
+
+## Out of Scope
+
+- Changing scripture retrieval, ranking, or which translation is selected.
+- Post-generation verbatim enforcement (e.g. validating the model's quote against
+  the DB text) — a possible follow-up if prompt-level guidance proves insufficient.
+- Any Bible data/translation import changes (`data/bible/`, `scripts/load_bible.py`).
+
+## Notes
+
+This is a prompt-robustness fix; it strongly reduces but cannot mathematically
+guarantee model behaviour. It is the correct lowest-risk first fix for the
+reported defect. If misquotes recur, the out-of-scope post-generation validation
+becomes a follow-up story.
+
+## Assignee
+
+backend-expert

--- a/docs/BACKLOG_STORIES/BITB-039-android-preserve-chat-on-rotation.md
+++ b/docs/BACKLOG_STORIES/BITB-039-android-preserve-chat-on-rotation.md
@@ -1,0 +1,116 @@
+# BITB-039: Android — Keep the Current Chat When the Phone Is Rotated
+
+**Status:** 🎯 Todo
+**Priority:** P1 (High) — data-loss UX bug on a common interaction
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+## User Story
+
+As an Android user mid-conversation, I want rotating my phone to keep me in the
+same chat with all my messages, so that I don't lose my conversation just because
+the screen orientation changed.
+
+## Problem
+
+Rotating the device during a chat drops the user back into an empty/new chat
+instead of preserving the current conversation and its messages.
+
+### Root cause
+
+`MainActivity` has **no `android:configChanges`** attribute
+(`android/app/src/main/AndroidManifest.xml:21-25`), so a rotation destroys and
+recreates the Activity. The `ChatViewModel` is Activity-scoped (`by viewModels()`
+/ `hiltViewModel()`) and therefore *survives* the change — the messages are still
+in memory after rotation. The data loss comes from the UI layer:
+
+1. Recreating the Activity restarts the Compose tree, which re-runs
+   `LaunchedEffect(conversationId)` in `ChatScreen.kt:141-146`.
+2. For an in-progress **new** chat, the nav route is still `chat/new` — it is
+   never rewritten to `chat/<realId>` after `ensureConversation()` mints a UUID
+   (`ChatViewModel.kt:606-615`).
+3. So on rotation the effect hits the `conversationId == "new"` branch and calls
+   `startNewConversation()` (`ChatViewModel.kt:650-669`), which **unconditionally
+   clears messages, `currentConversationId`, and the session** — the visible
+   "reset to a new chat".
+
+## Proposed Changes
+
+### 1. Primary fix — declare config changes on `MainActivity`
+
+**File:** `android/app/src/main/AndroidManifest.xml` (MainActivity, lines 21-25)
+
+Add:
+
+```xml
+android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|density"
+```
+
+This stops Android from destroying/recreating the Activity on rotation. Jetpack
+Compose reads the new `Configuration` and recomposes automatically, so **no
+`onConfigurationChanged` override is needed**. The locale-switch flow is
+unaffected, because `AppCompatDelegate.setApplicationLocales(...)` recreates the
+Activity explicitly regardless of `configChanges` (see the comment at
+`MainActivity.kt:97-101`).
+
+### 2. Defense-in-depth — guard the conversation-loading effect
+
+**File:** `android/app/src/main/kotlin/.../screens/ChatScreen.kt` (lines 141-146)
+
+Make the `LaunchedEffect(conversationId)` idempotent so a fresh/`new` route does
+not wipe an already-active in-memory conversation:
+
+```kotlin
+LaunchedEffect(conversationId) {
+    when {
+        conversationId == null || conversationId == "new" -> {
+            val s = viewModel.uiState.value
+            if (s.messages.isEmpty() && s.currentConversationId == null) {
+                viewModel.startNewConversation()
+            }
+        }
+        else -> viewModel.loadConversation(conversationId)
+    }
+}
+```
+
+This also protects the conversation across the locale-change recreation path and
+process-death restoration — not just rotation.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `android/app/src/main/AndroidManifest.xml` | Add `android:configChanges="orientation\|screenSize\|screenLayout\|smallestScreenSize\|keyboardHidden\|density"` to `MainActivity` |
+| `android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt` | Guard the `LaunchedEffect(conversationId)` so a `new` route only starts a new conversation when none is active |
+| `android/app/src/test/kotlin/...` (or `composeTest`) | Test the guard logic: a `new` route with an active in-memory conversation does not call `startNewConversation()` |
+
+## Acceptance Criteria
+
+- [ ] Start a new chat, send a message, then rotate the device → the same messages
+      and conversation remain visible (no reset to an empty chat).
+- [ ] Open an existing saved conversation, then rotate → still on the same
+      conversation.
+- [ ] Rotating during an in-flight (loading) response does not start a new chat.
+- [ ] Locale switching from Settings still works (still recreates the Activity and
+      applies the new language).
+- [ ] Existing Android unit tests pass; the guard logic is covered by a test.
+
+## Out of Scope
+
+- Locking the app to a single orientation.
+- Persisting transient draft input text across process death beyond the existing
+  `rememberSaveable` for the input field (`ChatScreen.kt:116`).
+- Rewriting the navigation graph or the `resume`-route start-destination logic
+  (`MainActivity.kt:125-155`).
+
+## Notes
+
+The primary fix (`configChanges`) directly satisfies the reported "rotation
+resets the chat" symptom with a one-line manifest change and is the standard
+recommended approach for Jetpack Compose apps. The `LaunchedEffect` guard is
+defense-in-depth that also covers the locale-recreation and process-death paths.
+
+## Assignee
+
+android-expert

--- a/docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md
+++ b/docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md
@@ -1,7 +1,7 @@
 # BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
 
 **Status:** 🎯 Todo
-**Priority:** P2 (Medium) — localization/trust defect, verse still readable once loaded
+**Priority:** P1 (High) — pervasive localization defect affecting every non-English locale on every verse tap
 **Size:** S (< 4 hours)
 **Created:** 2026-06-04
 
@@ -14,11 +14,14 @@ language I'm reading in and the app feels trustworthy and consistent.
 
 ## Problem
 
-Tapping a verse in an Italian chat opens the bottom sheet with the header
-**"Exodus 30:22"** (English) instead of **"Esodo 30:22"**. Reported as happening
-in **Italian** while **English and German work**.
+Tapping a verse opens the bottom sheet with the header showing the **English**
+book name (e.g. **"Exodus 30:22"**) instead of the translation's localized name
+(e.g. Italian **"Esodo 30:22"**, German **"2. Mose 30:22"**). **Reported across
+multiple non-English languages** — it is not Italian-specific, and it happens
+**even when the verse text loads correctly**. (Originally surfaced alongside the
+Italian load failure in BITB-041, but it is an independent, general defect.)
 
-### Root cause (Android)
+### Root cause (Android — affects all non-English locales)
 
 When a verse link is tapped, `buildSyntheticVerse()` builds a `Verse` for the
 sheet but never sets `localizedBook`
@@ -43,41 +46,53 @@ English `book` when `localizedBook` is null (`domain/models/Verse.kt:16`):
 val reference: String get() = "${localizedBook ?: book} $chapter:$verse"
 ```
 
-So the header is English until — **and only if** — the chapter fetch succeeds and
-the localized name becomes available (`VerseDetailBottomSheet.kt:184` uses
-`response.localizedBook`). When the Italian chapter fetch fails or hangs (see
-**BITB-041**), the header stays English. This is why the English book name and the
-"never loads" symptom appear together in Italian.
+Because `localizedBook` is never populated on the synthetic verse, the top header
+(`VerseDetailBottomSheet.kt:106`) shows the English book name for **every**
+non-English locale, regardless of whether the chapter fetch succeeds. (The loaded-
+chapter element at `:184` does use `response.localizedBook`, but the sheet's own
+header at `:106` is driven by the synthetic verse and is never corrected — so the
+defect persists even on a successful load.) This is independent of the Italian
+load failure in **BITB-041**; that bug just made it more visible because the header
+never gets a chance to update.
 
-### Backend is mostly correct
+### The book name is already known locally — no fetch needed
 
-The backend already returns a `localized_book` field. `get_verse` /
-`get_chapter` call `get_localized_book_name(name, translation)`
-(`api/routes/scripture.py:93-167`), which maps `ita1927 → ENGLISH_TO_ITALIAN_BOOKS`
-and falls back to English on a miss (`api/utils/language.py:1212-1238`). The
-Italian map should contain "Exodus"→"Esodo"; this must be verified (see AC) since
-a missing/odd key would also explain the English fallback.
+The LLM writes the reference in the user's language (e.g. "Esodo 30:22") and the
+verse-link regex matches that localized token; it is then normalized to the English
+canonical for `link.book`. The **original localized token is discarded**. Carrying
+it through the link lets the header localize **immediately**, without depending on
+the chapter response at all.
+
+### Backend already returns localized names
+
+`get_verse` / `get_chapter` call `get_localized_book_name(name, translation)`
+(`api/routes/scripture.py:93-167`), mapping each translation to its book map
+(`ita1927 → ENGLISH_TO_ITALIAN_BOOKS`, `schlachter → ENGLISH_TO_GERMAN_BOOKS`, …)
+with an English fallback on a miss (`api/utils/language.py:1212-1238`). Verify the
+maps are complete for all supported translations (see AC) — a missing key would be
+a second, per-language source of the same English fallback.
 
 ## Proposed Changes
 
-1. **Carry the localized book name into the sheet header (Android).**
-   Populate `localizedBook` on the synthetic verse from the loaded chapter
-   response (`ChapterResponseDto.localizedBook`) so the top header
-   (`VerseDetailBottomSheet.kt:106`) shows the localized reference, consistent
-   with the `:184` path. While the chapter is still loading, prefer the localized
-   name already known from the tapped link if available, rather than the English
-   canonical.
-2. **Verify the Italian book map (backend).** Confirm `ENGLISH_TO_ITALIAN_BOOKS`
-   contains every canonical book (incl. "Exodus"→"Esodo") and that `ita1927` is
-   wired in `get_localized_book_name`'s `book_map`.
+1. **Carry the localized book name through the link (Android) — primary fix.**
+   Retain the originally-matched localized book token on `PendingVerseLink` and set
+   it as `localizedBook` on the synthetic verse in `buildSyntheticVerse()`
+   (`ChatMessageItem.kt:753-770`), so the header (`VerseDetailBottomSheet.kt:106`)
+   is localized **immediately and independently of the chapter fetch**.
+2. **Backstop from the response.** When the chapter loads, also copy
+   `response.localizedBook` into the synthetic verse so the header is consistent
+   with the `:184` element.
+3. **Verify the backend book maps.** Confirm every supported translation's
+   English→localized map is complete and wired in `get_localized_book_name`'s
+   `book_map` (fix any gaps found).
 
 ## Files to Modify
 
 | File | Change |
 |---|---|
-| `android/app/src/main/kotlin/.../components/ChatMessageItem.kt` | Set `localizedBook` on the synthetic verse from the chapter response (and/or the link) |
+| `android/app/src/main/kotlin/.../components/ChatMessageItem.kt` | Retain the localized book token on `PendingVerseLink`; set `localizedBook` on the synthetic verse from the link (and backstop from the chapter response) |
 | `android/app/src/main/kotlin/.../components/VerseDetailBottomSheet.kt` | Ensure the header (line 106) uses the localized reference consistently with line 184 |
-| `api/utils/language.py` | Verify/complete `ENGLISH_TO_ITALIAN_BOOKS` and `book_map` wiring (fix if a gap is found) |
+| `api/utils/language.py` | Verify/complete every translation's English→localized book map and `book_map` wiring (fix any gaps) |
 
 ## Test Gaps to Close
 
@@ -97,23 +112,27 @@ Add:
 
 ## Acceptance Criteria
 
-- [ ] Tapping a verse in Italian shows the localized header (e.g. *"Esodo 30:22"*),
-      not the English book name — before and after the chapter loads.
-- [ ] Same verified for German and another non-Latin-script locale (no regression).
+- [ ] Tapping a verse shows the localized header for the selected translation
+      (e.g. *"Esodo 30:22"*, *"2. Mose 30:22"*) — not the English book name —
+      **before and after** the chapter loads, and **even if the fetch fails**.
+- [ ] Verified across several non-English locales (Latin-script and at least one
+      non-Latin-script, e.g. Russian/Korean) — no regression in English.
 - [ ] `get_localized_book_name` is covered by a real (un-mocked) unit test for all
-      supported translations.
+      supported translations (every canonical book round-trips).
 - [ ] A Compose UI test covers the localized header in the verse-detail sheet.
 - [ ] All existing Android and backend tests pass.
 
 ## Out of Scope
 
 - The "verse never loads / infinite spinner" failure and its monitoring — tracked
-  in **BITB-041** (shared root cause; do that one for the loading/resilience fix).
+  in **BITB-041**. (Independent bug; this story fixes the header for all locales,
+  including the cases where the fetch succeeds.)
 - Changing scripture retrieval or translation selection.
 
 ## Related
 
-- **BITB-041** — verse-detail load resilience + monitoring (shared Italian root cause)
+- **BITB-041** — verse-detail load resilience + monitoring (surfaced this bug, but
+  the two are independent — BITB-040 also occurs when loading works)
 - BITB-034 — Android Compose UI test tier (use it for the new header test)
 
 ## Assignee

--- a/docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md
+++ b/docs/BACKLOG_STORIES/BITB-040-verse-detail-localized-book-name.md
@@ -1,0 +1,121 @@
+# BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
+
+**Status:** 🎯 Todo
+**Priority:** P2 (Medium) — localization/trust defect, verse still readable once loaded
+**Size:** S (< 4 hours)
+**Created:** 2026-06-04
+
+## User Story
+
+As a non-English user, when I tap a Bible verse reference and the verse-detail
+bottom sheet opens, I want the header to show the reference using my translation's
+book name (e.g. Italian *"Esodo 30:22"*), so that the reference matches the
+language I'm reading in and the app feels trustworthy and consistent.
+
+## Problem
+
+Tapping a verse in an Italian chat opens the bottom sheet with the header
+**"Exodus 30:22"** (English) instead of **"Esodo 30:22"**. Reported as happening
+in **Italian** while **English and German work**.
+
+### Root cause (Android)
+
+When a verse link is tapped, `buildSyntheticVerse()` builds a `Verse` for the
+sheet but never sets `localizedBook`
+(`android/app/src/main/kotlin/.../components/ChatMessageItem.kt:753-770`):
+
+```kotlin
+return Verse(
+    book = link.book,          // English canonical, e.g. "Exodus"
+    chapter = link.chapter,
+    verse = link.verseNumber,
+    text = actualText,
+    translation = translation,
+    // localizedBook is never set → defaults to null
+)
+```
+
+The header renders `verse.reference`
+(`VerseDetailBottomSheet.kt:106`), and the reference getter falls back to the
+English `book` when `localizedBook` is null (`domain/models/Verse.kt:16`):
+
+```kotlin
+val reference: String get() = "${localizedBook ?: book} $chapter:$verse"
+```
+
+So the header is English until — **and only if** — the chapter fetch succeeds and
+the localized name becomes available (`VerseDetailBottomSheet.kt:184` uses
+`response.localizedBook`). When the Italian chapter fetch fails or hangs (see
+**BITB-041**), the header stays English. This is why the English book name and the
+"never loads" symptom appear together in Italian.
+
+### Backend is mostly correct
+
+The backend already returns a `localized_book` field. `get_verse` /
+`get_chapter` call `get_localized_book_name(name, translation)`
+(`api/routes/scripture.py:93-167`), which maps `ita1927 → ENGLISH_TO_ITALIAN_BOOKS`
+and falls back to English on a miss (`api/utils/language.py:1212-1238`). The
+Italian map should contain "Exodus"→"Esodo"; this must be verified (see AC) since
+a missing/odd key would also explain the English fallback.
+
+## Proposed Changes
+
+1. **Carry the localized book name into the sheet header (Android).**
+   Populate `localizedBook` on the synthetic verse from the loaded chapter
+   response (`ChapterResponseDto.localizedBook`) so the top header
+   (`VerseDetailBottomSheet.kt:106`) shows the localized reference, consistent
+   with the `:184` path. While the chapter is still loading, prefer the localized
+   name already known from the tapped link if available, rather than the English
+   canonical.
+2. **Verify the Italian book map (backend).** Confirm `ENGLISH_TO_ITALIAN_BOOKS`
+   contains every canonical book (incl. "Exodus"→"Esodo") and that `ita1927` is
+   wired in `get_localized_book_name`'s `book_map`.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `android/app/src/main/kotlin/.../components/ChatMessageItem.kt` | Set `localizedBook` on the synthetic verse from the chapter response (and/or the link) |
+| `android/app/src/main/kotlin/.../components/VerseDetailBottomSheet.kt` | Ensure the header (line 106) uses the localized reference consistently with line 184 |
+| `api/utils/language.py` | Verify/complete `ENGLISH_TO_ITALIAN_BOOKS` and `book_map` wiring (fix if a gap is found) |
+
+## Test Gaps to Close
+
+The existing suite let this ship because it **over-mocks** localization:
+
+- Backend `test_multilanguage_routes.py` **mocks** `get_localized_book_name`, so the
+  real function is never validated; `test_api.py` integration coverage is **skipped**.
+- No Compose UI test exists for `VerseDetailBottomSheet` (header rendering untested).
+
+Add:
+
+- [ ] Backend unit test for the **real** `get_localized_book_name(...)` across
+      translations (incl. `ita1927 → Esodo`, every canonical book round-trips).
+- [ ] Android Compose UI test (in the `composeTest` tier from BITB-034) asserting
+      the verse-detail header renders the **localized** reference for a non-English
+      translation, both before and after the chapter loads.
+
+## Acceptance Criteria
+
+- [ ] Tapping a verse in Italian shows the localized header (e.g. *"Esodo 30:22"*),
+      not the English book name — before and after the chapter loads.
+- [ ] Same verified for German and another non-Latin-script locale (no regression).
+- [ ] `get_localized_book_name` is covered by a real (un-mocked) unit test for all
+      supported translations.
+- [ ] A Compose UI test covers the localized header in the verse-detail sheet.
+- [ ] All existing Android and backend tests pass.
+
+## Out of Scope
+
+- The "verse never loads / infinite spinner" failure and its monitoring — tracked
+  in **BITB-041** (shared root cause; do that one for the loading/resilience fix).
+- Changing scripture retrieval or translation selection.
+
+## Related
+
+- **BITB-041** — verse-detail load resilience + monitoring (shared Italian root cause)
+- BITB-034 — Android Compose UI test tier (use it for the new header test)
+
+## Assignee
+
+android-expert

--- a/docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md
+++ b/docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md
@@ -1,0 +1,152 @@
+# BITB-041: Verse Detail Never Loads — Add Timeout, Error/Retry, and Monitoring
+
+**Status:** 🎯 Todo
+**Priority:** P1 (High) — broken feature with no error path and a monitoring blind spot
+**Size:** M (1-2 days)
+**Created:** 2026-06-04
+
+## User Story
+
+As a user who taps a Bible verse, I want the verse text to either load promptly or
+fail with a clear, retryable error, so that I never stare at a garbled placeholder
+(`////`) and a spinner that never stops — and as the operator, I want this failure
+to be monitored and alerted so I learn about it before users report it.
+
+## Problem
+
+Tapping a verse in **Italian** sometimes shows a `////` placeholder and a spinner
+that never resolves and never errors. **English and German work.** (See first
+screenshot in the bug report.) This shares a root cause with **BITB-040** — when the
+chapter fetch fails/hangs, the header also stays English.
+
+### Root causes
+
+**Android — no timeout, empty text rendered, no terminal state:**
+
+- `ChatViewModel.loadChapter()` has **no timeout**
+  (`android/app/src/main/kotlin/.../viewmodels/ChatViewModel.kt:811-828`). If
+  `bibleApiService.getChapter()` hangs, the state stays `Loading` forever — it never
+  reaches `Success` or `Error`, so the sheet spins indefinitely.
+- While loading, `buildSyntheticVerse()` sets `text = ""`
+  (`ChatMessageItem.kt:753-770`), and the sheet renders `"\"${verse.text}\""`
+  (`VerseDetailBottomSheet.kt:135`) → empty/garbled quoted content (the `////`).
+- The `Error` branch (`VerseDetailBottomSheet.kt:166-180`) is only reached if the
+  call throws; a silent hang bypasses it entirely.
+
+**Backend — no query timeout, failures aren't alertable:**
+
+- `ScriptureRepository.get_verse` / chapter queries have **no per-query timeout**
+  (`api/scripture/repository.py:109-136`); a slow/stalled PostgreSQL call blocks
+  instead of failing fast. (Health checks *do* use `asyncio.wait_for`, so the
+  service looks healthy while verse queries hang — `api/routes/health.py:49-76`.)
+- The chapter route has no error handling for repo exceptions
+  (`api/routes/scripture.py:122-167`) — a failure becomes a generic 500.
+
+**Italian-specific trigger (must be diagnosed):** since en/de work and it/ITA1927
+fails, confirm whether the `////` is (a) the Android empty-synthetic-text rendering
+or (b) **actual ITA1927 source data** (missing/placeholder verses) returned by the
+backend. Inspect the `verses` rows for the affected references in `ita1927` and
+repair the data load if corrupt (`scripts/load_bible.py`, `data/bible/`).
+
+### Monitoring gap
+
+`deployment/monitoring.tf` alerts on backend availability, container restarts, and
+error-shaped logs only. There is **no alert** on verse/chapter fetch latency or
+error rate. Metrics exist (`db.query.duration_ms` histogram, `db.slow_queries`
+counter — `api/utils/metrics.py`) but nothing fires on them. A hung query that
+returns a bad 200 or 500 is invisible to current uptime checks.
+
+## Proposed Changes
+
+### 1. Android resilience
+- Wrap `loadChapter()` in `withTimeoutOrNull(...)` (e.g. 10s); on timeout set
+  `ChapterSheetState.Error` with a friendly, **retryable** message
+  (`mapExceptionToMessage` already maps `SocketTimeoutException`).
+- Never render empty/garbled verse text: while loading show a loading state in the
+  text area (not empty quotes); on error show the error + a **Retry** action that
+  re-invokes `loadChapter()`.
+- Ensure the OkHttp/Retrofit client has a sane call timeout so the network layer
+  also fails fast.
+
+### 2. Backend resilience
+- Add a per-query timeout (`asyncio.wait_for`) to the verse/chapter repository
+  reads; on timeout return **504** (not a hang) so the client and alerts can react.
+- Add error handling on the chapter route so repo failures return a clear status,
+  not a bare 500.
+- Guard against empty/placeholder verse text (e.g. `////`) — treat as a data error
+  rather than serving it as a valid verse.
+
+### 3. Monitoring & alerting (the "should be monitored and alerted" requirement)
+- Instrument verse/chapter fetch with a success/empty-result and latency signal
+  (reuse the existing `get_verse` span and `db.query.duration_ms` histogram,
+  tagged by operation + translation).
+- Add a Terraform alert in `deployment/monitoring.tf` for verse/chapter fetch
+  **error rate** and **p95 latency / timeout count** (e.g. p95 > 2s sustained 5m,
+  or any 504s), notifying the existing email action group.
+- Enable PostgreSQL slow-query logging threshold already configured
+  (`slow_query_threshold_ms = 100`, `api/config.py:127`) to surface slow verses.
+
+### 4. Diagnose & repair Italian data
+- Verify ITA1927 rows for the reported references; if `////`/empty, fix the loader
+  and reload (`scripts/load_bible.py`). Add a data-integrity check for empty verse
+  text per translation.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `android/app/src/main/kotlin/.../viewmodels/ChatViewModel.kt` | `withTimeoutOrNull` around `loadChapter`; map timeout → retryable `Error` |
+| `android/app/src/main/kotlin/.../components/VerseDetailBottomSheet.kt` | Loading state for text area; Error + Retry action; stop rendering empty quotes |
+| `android/app/src/main/kotlin/.../components/ChatMessageItem.kt` | Don't surface empty synthetic text as a "loaded" verse |
+| `api/scripture/repository.py` | Per-query timeout on verse/chapter reads → 504 |
+| `api/routes/scripture.py` | Error handling + empty-text guard on chapter/verse routes |
+| `deployment/monitoring.tf` | Alert on verse/chapter fetch error-rate and p95 latency/timeouts |
+| `scripts/load_bible.py` / `data/bible/` | Fix/reload ITA1927 data if corrupt; add empty-text integrity check |
+
+## Test Gaps to Close
+
+The suite let this ship because of **integration/resilience gaps** (the flow's
+happy path is unit-tested with mocks; failures and the UI are not):
+
+- Android `ChatViewModelTest.kt:718-860` tests `loadChapter` only for `IOException` —
+  no `SocketTimeoutException`, no **timeout/hang** simulation.
+- No Compose UI test for `VerseDetailBottomSheet` (loading/error/retry untested).
+- Backend `test_routes_main_coverage.py:928-974` covers only 200/404 for chapter —
+  no timeout/DB-error/empty-text cases.
+
+Add:
+
+- [ ] Android: `loadChapter` test where the API stalls past the timeout → state
+      becomes `Error` (not stuck `Loading`); test `SocketTimeoutException` mapping.
+- [ ] Android Compose UI test (BITB-034 tier): sheet shows loading, then error +
+      working **Retry**; empty text is never shown as a quoted verse.
+- [ ] Backend: chapter/verse route tests for repo timeout → 504, DB error, and
+      empty/placeholder verse text → error (not a 200 with `////`).
+
+## Acceptance Criteria
+
+- [ ] When the chapter fetch is slow/unreachable, the sheet shows a clear error with
+      a working **Retry** within a bounded time — never an infinite spinner.
+- [ ] The verse text area never displays `////` or empty quotes; it shows loading,
+      then the verse or an error.
+- [ ] Backend verse/chapter reads time out to **504** instead of hanging.
+- [ ] Italian (ITA1927) verse detail loads correctly for the reported references; if
+      the data was corrupt it is repaired and an integrity check guards against empty text.
+- [ ] A monitoring alert fires on elevated verse/chapter fetch error-rate or p95
+      latency/timeouts, notifying the existing action group.
+- [ ] New Android and backend tests cover timeout, error, retry, and empty-text paths.
+
+## Out of Scope
+
+- The localized-book-name header fix — tracked in **BITB-040** (shared root cause).
+- Reworking semantic search or the navigation graph.
+
+## Related
+
+- **BITB-040** — localized book name in the same sheet (shared Italian root cause)
+- BITB-013 / BITB-021 — performance metrics + dashboard (reuse the metrics/alert plumbing)
+- BITB-034 — Android Compose UI test tier (use it for the sheet tests)
+
+## Assignee
+
+fullstack-expert

--- a/docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md
+++ b/docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md
@@ -14,10 +14,12 @@ to be monitored and alerted so I learn about it before users report it.
 
 ## Problem
 
-Tapping a verse in **Italian** sometimes shows a `////` placeholder and a spinner
-that never resolves and never errors. **English and German work.** (See first
-screenshot in the bug report.) This shares a root cause with **BITB-040** — when the
-chapter fetch fails/hangs, the header also stays English.
+Tapping a verse in **Italian (ITA1927)** sometimes shows a `////` placeholder and a
+spinner that never resolves and never errors. **English and German load.** (See first
+screenshot in the bug report.) When this load failure happens it also leaves the
+header in English — but the English-header defect (**BITB-040**) is a separate, general
+bug that occurs across all non-English locales even when loading succeeds. This story
+covers the **load failure, resilience, and monitoring**; BITB-040 covers the header.
 
 ### Root causes
 
@@ -143,7 +145,7 @@ Add:
 
 ## Related
 
-- **BITB-040** — localized book name in the same sheet (shared Italian root cause)
+- **BITB-040** — localized book name in the same sheet (independent, general bug)
 - BITB-013 / BITB-021 — performance metrics + dashboard (reuse the metrics/alert plumbing)
 - BITB-034 — Android Compose UI test tier (use it for the sheet tests)
 

--- a/docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md
+++ b/docs/BACKLOG_STORIES/BITB-041-verse-detail-load-resilience-and-monitoring.md
@@ -61,6 +61,7 @@ returns a bad 200 or 500 is invisible to current uptime checks.
 ## Proposed Changes
 
 ### 1. Android resilience
+
 - Wrap `loadChapter()` in `withTimeoutOrNull(...)` (e.g. 10s); on timeout set
   `ChapterSheetState.Error` with a friendly, **retryable** message
   (`mapExceptionToMessage` already maps `SocketTimeoutException`).
@@ -71,6 +72,7 @@ returns a bad 200 or 500 is invisible to current uptime checks.
   also fails fast.
 
 ### 2. Backend resilience
+
 - Add a per-query timeout (`asyncio.wait_for`) to the verse/chapter repository
   reads; on timeout return **504** (not a hang) so the client and alerts can react.
 - Add error handling on the chapter route so repo failures return a clear status,
@@ -79,6 +81,7 @@ returns a bad 200 or 500 is invisible to current uptime checks.
   rather than serving it as a valid verse.
 
 ### 3. Monitoring & alerting (the "should be monitored and alerted" requirement)
+
 - Instrument verse/chapter fetch with a success/empty-result and latency signal
   (reuse the existing `get_verse` span and `db.query.duration_ms` histogram,
   tagged by operation + translation).
@@ -89,6 +92,7 @@ returns a bad 200 or 500 is invisible to current uptime checks.
   (`slow_query_threshold_ms = 100`, `api/config.py:127`) to surface slow verses.
 
 ### 4. Diagnose & repair Italian data
+
 - Verify ITA1927 rows for the reported references; if `////`/empty, fix the loader
   and reload (`scripts/load_bible.py`). Add a data-integrity check for empty verse
   text per translation.


### PR DESCRIPTION
Two user stories for reported bugs:

- BITB-038 (P1): the assistant paraphrases quoted scripture. An Italian
  response said "la frutta dello Spirito" for Galatians 5:22-23 when the
  Italian Bible reads "il frutto dello Spirito" (singular). Verse text is
  LLM-generated prose and the prompts never forbid re-wording a quoted
  verse. Prompt-level fix in api/chat/prompts.py.

- BITB-039 (P1): rotating the Android phone resets to a new chat.
  MainActivity has no android:configChanges, so rotation recreates the
  Activity and re-runs LaunchedEffect(conversationId), which calls
  startNewConversation() on the still-"new" route and wipes state.
  Manifest configChanges fix plus a defensive guard in ChatScreen.

Indexed both under P1 in docs/BACKLOG.md (BITB-038 ranked first).

https://claude.ai/code/session_015k8ChNZ7nzTzCeNc3oPqab