### PR TITLE
docs(backlog): close out mobile verse FAB reposition — verified, no change needed

### DIFF
--- a/docs/BACKLOG_STORIES/mobile-fab-reposition.md
+++ b/docs/BACKLOG_STORIES/mobile-fab-reposition.md
@@ -1,61 +1,31 @@
 # User Story: Mobile Verse Panel FAB Repositioning
 
-**Status:** ✅ Done — changed `bottom-28 right-4` → `top-20 right-4` on the web frontend FAB in `frontend/src/app/[locale]/ChatIsland.tsx`. (Supersedes the stale PR #664, which edited the pre-refactor `page.tsx` and bundled unrelated dependency bumps.)
+**Status:** ❌ Won't Do — verified on the real frontend at 375px; the proposed `top-20` reposition is a **regression** and the existing `bottom-28 right-4` position is correct. PR #664 closed.
 
 > Scope note: this story covers the **web frontend** (Next.js) FAB only. The native Android app renders verses via its own components (`VersesPanel`, `InlineVerseCard`, `VerseChip`) and is unaffected.
 
 **As a** mobile user
-**I want** the verse references button to be positioned at the top of the screen
-**So that** it doesn't interfere with my typing area and other bottom UI elements
+**I want** the verse references button to not interfere with the chat
+**So that** I can read messages and type without the button covering content
 
-## Functional Requirements
+## Verification finding (2026-06-05)
 
-- [x] Verse references floating action button (FAB) appears at top-right of mobile screen
-- [x] FAB remains visible and accessible during scrolling
-- [x] FAB opens the verse panel when tapped
-- [x] FAB displays the count of relevant verses
+The original premise — "`bottom-28 right-4` sits directly above the chat input" — described the **pre-refactor `page.tsx` layout**. The home page has since been refactored into `ChatIsland.tsx`, which renders a footer below the input. In the current layout the FAB positions behave differently. Captured at a 375px mobile viewport (Playwright, mocked verse response):
 
-## Non-Functional Requirements
+| Position | Result |
+| --- | --- |
+| `top-20 right-4` (proposed) | ❌ Overlaps and clips the message/answer card content |
+| `bottom-28 right-4` (current) | ✅ Floats in the footer gutter below the input — clears messages, input, and send button |
+| `bottom-44 right-4` (candidate) | ❌ Overlaps the send button and disclaimer text |
 
-- **UX:** Button must not overlap with header elements or interfere with page content
-- **UX:** Button must remain easily tappable (minimum 44x44px touch target)
-- **UX:** Transition should feel natural, not jarring
-- **Accessibility:** Button must maintain proper aria-label for screen readers
-- **Performance:** No layout shift or reflow issues
+Conclusion: the existing `bottom-28 right-4` is the cleanest of the three. The reposition is declined. PR #664 was additionally stale (edited the deleted `page.tsx`) and bundled unrelated dependency bumps.
 
-## Acceptance Criteria
+## Possible future work (not scheduled)
 
-- [x] FAB is positioned at top-right instead of bottom-right on mobile viewports (< 1024px)
-- [x] FAB does not overlap with header, language switcher, or translation selector
-- [x] FAB maintains adequate spacing from screen edges (4 units/1rem)
-- [x] FAB z-index ensures it stays above page content but doesn't block critical UI
-- [x] Clicking FAB still opens the verse slide-over panel correctly
-- [x] Verse count badge is still visible and readable
-
-## Tech Constraints
-
-- Mobile-only change (hidden on desktop via `lg:hidden` class)
-- Must work on small viewports (375px width minimum)
-- Should use Tailwind utility classes for positioning
-- Maintain existing z-index layering system
-
-## Out of Scope
-
-- Changing FAB appearance, size, or color
-- Changing verse panel behavior
-- Desktop/tablet layouts (FAB is hidden on large screens)
-- Animation or transition effects (can be added later if needed)
-
-## Current Behavior
-
-FAB was positioned at `bottom-28 right-4` which sat directly above the chat input area on mobile phones.
-
-## Expected Behavior
-
-FAB should be positioned at `top-20 right-4` to stay out of the way while remaining accessible.
+If the FAB is ever felt to compete with content, a non-floating approach — surfacing the verse count as a button inside the sticky header instead of a fixed FAB — would eliminate content overlap entirely. That is a larger change and out of scope here.
 
 ---
 
-**Priority:** High
-**Effort:** Trivial (CSS positioning change)
-**Impact:** Improves mobile UX significantly
+**Priority:** Low (no action needed)
+**Effort:** N/A
+**Impact:** None — current position retained

--- a/docs/BACKLOG_STORIES/mobile-fab-reposition.md
+++ b/docs/BACKLOG_STORIES/mobile-fab-reposition.md
@@ -1,15 +1,19 @@
 # User Story: Mobile Verse Panel FAB Repositioning
 
+**Status:** ✅ Done — changed `bottom-28 right-4` → `top-20 right-4` on the web frontend FAB in `frontend/src/app/[locale]/ChatIsland.tsx`. (Supersedes the stale PR #664, which edited the pre-refactor `page.tsx` and bundled unrelated dependency bumps.)
+
+> Scope note: this story covers the **web frontend** (Next.js) FAB only. The native Android app renders verses via its own components (`VersesPanel`, `InlineVerseCard`, `VerseChip`) and is unaffected.
+
 **As a** mobile user
 **I want** the verse references button to be positioned at the top of the screen
 **So that** it doesn't interfere with my typing area and other bottom UI elements
 
 ## Functional Requirements
 
-- [ ] Verse references floating action button (FAB) appears at top-right of mobile screen
-- [ ] FAB remains visible and accessible during scrolling
-- [ ] FAB opens the verse panel when tapped
-- [ ] FAB displays the count of relevant verses
+- [x] Verse references floating action button (FAB) appears at top-right of mobile screen
+- [x] FAB remains visible and accessible during scrolling
+- [x] FAB opens the verse panel when tapped
+- [x] FAB displays the count of relevant verses
 
 ## Non-Functional Requirements
 
@@ -21,12 +25,12 @@
 
 ## Acceptance Criteria
 
-- [ ] FAB is positioned at top-right instead of bottom-right on mobile viewports (< 1024px)
-- [ ] FAB does not overlap with header, language switcher, or translation selector
-- [ ] FAB maintains adequate spacing from screen edges (4 units/1rem)
-- [ ] FAB z-index ensures it stays above page content but doesn't block critical UI
-- [ ] Clicking FAB still opens the verse slide-over panel correctly
-- [ ] Verse count badge is still visible and readable
+- [x] FAB is positioned at top-right instead of bottom-right on mobile viewports (< 1024px)
+- [x] FAB does not overlap with header, language switcher, or translation selector
+- [x] FAB maintains adequate spacing from screen edges (4 units/1rem)
+- [x] FAB z-index ensures it stays above page content but doesn't block critical UI
+- [x] Clicking FAB still opens the verse slide-over panel correctly
+- [x] Verse count badge is still visible and readable
 
 ## Tech Constraints
 
@@ -44,7 +48,7 @@
 
 ## Current Behavior
 
-FAB is positioned at `bottom-24 right-4` which overlaps with input area on mobile phones.
+FAB was positioned at `bottom-28 right-4` which sat directly above the chat input area on mobile phones.
 
 ## Expected Behavior
 

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -1121,7 +1121,7 @@ export default function ChatIsland({
       {relevantVerses.length > 0 && (
         <button
           onClick={() => setMobileVersesOpen(true)}
-          className="lg:hidden fixed top-20 right-4 z-40 flex items-center gap-2 px-4 py-3 bg-primary-600 text-white rounded-full shadow-lg hover:bg-primary-700 transition-colors"
+          className="lg:hidden fixed bottom-28 right-4 z-40 flex items-center gap-2 px-4 py-3 bg-primary-600 text-white rounded-full shadow-lg hover:bg-primary-700 transition-colors"
           aria-label={tVerses("showScriptureReferences")}
         >
           <BookOpen className="w-5 h-5" />

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -1121,7 +1121,7 @@ export default function ChatIsland({
       {relevantVerses.length > 0 && (
         <button
           onClick={() => setMobileVersesOpen(true)}
-          className="lg:hidden fixed bottom-28 right-4 z-40 flex items-center gap-2 px-4 py-3 bg-primary-600 text-white rounded-full shadow-lg hover:bg-primary-700 transition-colors"
+          className="lg:hidden fixed top-20 right-4 z-40 flex items-center gap-2 px-4 py-3 bg-primary-600 text-white rounded-full shadow-lg hover:bg-primary-700 transition-colors"
           aria-label={tVerses("showScriptureReferences")}
         >
           <BookOpen className="w-5 h-5" />


### PR DESCRIPTION
## Summary

Investigated whether the mobile verse-references FAB needs repositioning (the goal of the now-closed PR #664). **Conclusion: no code change is needed — the existing `bottom-28 right-4` position is correct.** This PR contains only a backlog-story update documenting the decision; `ChatIsland.tsx` is unchanged vs `main`.

## What changed in this branch

- `ChatIsland.tsx`: an initial commit moved the FAB to `top-20`, then a follow-up commit reverted it back to `bottom-28`. **Net diff vs `main` is zero.**
- `docs/BACKLOG_STORIES/mobile-fab-reposition.md`: marked **Won't Do** with the verification findings.

## Why the reposition was rejected

PR #664's premise was that `bottom-28 right-4` sat "directly above the chat input." That described the **pre-refactor `page.tsx`** layout. The home page has since been refactored into `ChatIsland.tsx`, which renders a footer below the input — so `bottom-28` no longer touches the input.

Verified on the real frontend at a 375px viewport (Playwright, mocked verse response):

| Position | Result |
| --- | --- |
| `top-20 right-4` (PR #664 proposal) | ❌ Overlaps / clips the message + answer card |
| `bottom-28 right-4` (current `main`) | ✅ Floats in the footer gutter below the input — clears messages, input, and send button |
| `bottom-44 right-4` (candidate) | ❌ Overlaps the send button + disclaimer |

`bottom-28` is the cleanest of the three, so it is retained.

## Scope note

Web frontend (Next.js) only. The native Android app renders verses via its own components (`VersesPanel`, `InlineVerseCard`, `VerseChip`) and is unaffected.

## Follow-up (not scheduled)

If the FAB is ever felt to compete with content, surfacing the verse count as a button inside the sticky header (instead of a fixed FAB) would remove content overlap entirely — a larger change, left out of scope.

## Test plan

- [x] Frontend builds / FAB renders at 375px (verified via Playwright screenshots)
- [x] `ChatIsland.tsx` diff vs `main` is empty (no behavior change)

---

Supersedes / closes out PR #664 (closed separately).

https://claude.ai/code/session_01LayAwDamymeqiegYCmVqmP