### PR TITLE
fix(ci): add Gemfile and use bundle exec to fix missing multi_json gem

### DIFF
--- a/.github/workflows/android-promote.yml
+++ b/.github/workflows/android-promote.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install Fastlane
         working-directory: android
-        run: gem install fastlane --no-document
+        run: bundle install --jobs 4 --retry 3
 
       - name: Decode Google Play JSON key
         run: |
@@ -88,7 +88,7 @@ jobs:
           SUPPLY_VERBOSE: "true"
         run: |
           set -o pipefail
-          fastlane promote --verbose 2>&1 | tee /tmp/fastlane.log
+          bundle exec fastlane promote --verbose 2>&1 | tee /tmp/fastlane.log
 
       - name: Upload Fastlane log on failure
         if: failure()

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Install Fastlane
         working-directory: android
-        run: gem install fastlane --no-document
+        run: bundle install --jobs 4 --retry 3
 
       - name: Decode Google Play JSON key
         run: |
@@ -356,7 +356,7 @@ jobs:
           SUPPLY_VERBOSE: "true"
         run: |
           set -o pipefail
-          fastlane ${{ steps.lane.outputs.lane }} --verbose 2>&1 \
+          bundle exec fastlane ${{ steps.lane.outputs.lane }} --verbose 2>&1 \
             | tee /tmp/fastlane.log
 
       - name: Also release build to extra closed tracks
@@ -416,7 +416,7 @@ jobs:
             if PROMOTE_VERSION_CODE="${VERSION_CODE}" \
                PROMOTE_FROM="${PRIMARY_TRACK}" \
                PROMOTE_TO="${TRACK}" \
-               fastlane promote --verbose 2>&1 | tee -a /tmp/fastlane.log; then
+               bundle exec fastlane promote --verbose 2>&1 | tee -a /tmp/fastlane.log; then
               echo "✅ Promoted to '${TRACK}'."
             else
               echo "❌ Failed to promote to '${TRACK}'."

--- a/android/Gemfile
+++ b/android/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "multi_json"


### PR DESCRIPTION
Fastlane 2.235.0 requires multi_json >= 1.14.1 transitively via
representable → google-apis-core, but the bare `gem install fastlane`
approach left transitive deps unresolved. Adding android/Gemfile with
explicit multi_json and switching to `bundle install` + `bundle exec
fastlane` ensures the full dependency graph is satisfied on every run.

https://claude.ai/code/session_01LnxJCCQBgUzRtEzZrjXrEX