### PR TITLE
fix(android): float feedback rethink panel as a popover over the thumbs

### DIFF
--- a/android/COMPOSE_TESTS.md
+++ b/android/COMPOSE_TESTS.md
@@ -63,7 +63,10 @@ Reference: `VersesPanelComposeTest.kt` is the canonical template.
 
 - **`ModalBottomSheet`, `Dialog`, `Popup`** have known rendering quirks under Robolectric
   (window insets, animation clocks). Test the *content* composable directly instead of the
-  sheet wrapper. See how `VersesPanelContent` is used instead of `VersesPanel`.
+  sheet wrapper. See how `VersesPanelContent` is used instead of `VersesPanel`, and
+  `FeedbackPendingPanel` (asserted in `FeedbackPendingPanelComposeTest`) instead of the
+  `Popup` rendered by `FeedbackControls`. Popover *positioning* and keyboard focus are left
+  to manual / instrumented QA.
 - **API level**: Robolectric 4.14.1 pins to API 34 via `@Config(sdk = [34])`.
   Behaviors that only appear on API 35 must be covered by instrumented tests.
 - **Hilt is intentionally excluded**: the harness uses `android.app.Application` as the

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/FeedbackControls.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/FeedbackControls.kt
@@ -3,8 +3,8 @@ package org.voxquieta.app.presentation.components
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -29,6 +29,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -39,10 +40,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.voxquieta.app.R
@@ -67,6 +76,11 @@ const val FEEDBACK_RETHINK_MS = 10_000L
  * The commit is driven by [delay], not by the bar animation, so it is unaffected
  * by the system "remove animations" setting (which would otherwise complete a
  * Compose animation instantly and skip the rethink window).
+ *
+ * The pending affordance renders in a [Popup] floating **above** the thumbs (see
+ * [FeedbackPendingPanel] + [AbovePopupPositionProvider]) so it is visible the
+ * instant a thumb is tapped — it does not push chat content down or land below
+ * the fold for the last message in the list.
  *
  * @param feedbackGiven Rating already recorded for this message ("positive" /
  *   "negative"), or null. Locks the controls once set.
@@ -135,123 +149,203 @@ fun FeedbackControls(
         }
     }
 
-    Column(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            val locked = effectiveGiven != null
-            val upActive = effectiveGiven == "positive" || pending == "positive"
-            val downActive = effectiveGiven == "negative" || pending == "negative"
+    val spacingPx = with(LocalDensity.current) { 4.dp.roundToPx() }
+    val positionProvider = remember(spacingPx) { AbovePopupPositionProvider(spacingPx) }
 
-            IconButton(
-                onClick = { if (!locked) if (pending == "positive") cancel() else startPending("positive") },
-                enabled = !locked,
+    Column(modifier = modifier.fillMaxWidth()) {
+        // The thumbs Row is the Popup's anchor: the popover positions itself
+        // relative to this Box's bounds in the window.
+        Box {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    imageVector = if (upActive) Icons.Filled.ThumbUp else Icons.Outlined.ThumbUp,
-                    contentDescription = stringResource(R.string.action_feedback_helpful),
-                    tint = if (upActive) MaterialTheme.colorScheme.primary else LocalContentColor.current,
-                )
+                val locked = effectiveGiven != null
+                val upActive = effectiveGiven == "positive" || pending == "positive"
+                val downActive = effectiveGiven == "negative" || pending == "negative"
+
+                IconButton(
+                    onClick = { if (!locked) if (pending == "positive") cancel() else startPending("positive") },
+                    enabled = !locked,
+                ) {
+                    Icon(
+                        imageVector = if (upActive) Icons.Filled.ThumbUp else Icons.Outlined.ThumbUp,
+                        contentDescription = stringResource(R.string.action_feedback_helpful),
+                        tint = if (upActive) MaterialTheme.colorScheme.primary else LocalContentColor.current,
+                    )
+                }
+                IconButton(
+                    onClick = { if (!locked) if (pending == "negative") cancel() else startPending("negative") },
+                    enabled = !locked,
+                ) {
+                    Icon(
+                        imageVector = if (downActive) Icons.Filled.ThumbDown else Icons.Outlined.ThumbDown,
+                        contentDescription = stringResource(R.string.action_feedback_not_helpful),
+                        tint = if (downActive) MaterialTheme.colorScheme.error else LocalContentColor.current,
+                    )
+                }
+                if (effectiveGiven != null) {
+                    Text(
+                        text = stringResource(R.string.feedback_thanks),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                trailing()
             }
-            IconButton(
-                onClick = { if (!locked) if (pending == "negative") cancel() else startPending("negative") },
-                enabled = !locked,
-            ) {
-                Icon(
-                    imageVector = if (downActive) Icons.Filled.ThumbDown else Icons.Outlined.ThumbDown,
-                    contentDescription = stringResource(R.string.action_feedback_not_helpful),
-                    tint = if (downActive) MaterialTheme.colorScheme.error else LocalContentColor.current,
-                )
+
+            val pendingRating = pending
+            if (pendingRating != null && effectiveGiven == null) {
+                Popup(
+                    popupPositionProvider = positionProvider,
+                    // Tap-outside / back press is a non-destructive cancel: nothing
+                    // is sent and the countdown coroutine is torn down cleanly.
+                    onDismissRequest = { cancel() },
+                    // Focusable so the comment OutlinedTextField can receive the keyboard.
+                    properties = PopupProperties(focusable = true),
+                ) {
+                    Surface(
+                        modifier = Modifier.width(320.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.surface,
+                        tonalElevation = 3.dp,
+                        shadowElevation = 6.dp,
+                    ) {
+                        FeedbackPendingPanel(
+                            rating = pendingRating,
+                            comment = comment,
+                            commentOpen = commentOpen,
+                            progress = { progress.value },
+                            onOpenComment = { commentOpen = true },
+                            onCommentChange = { comment = it },
+                            onUndo = { cancel() },
+                            onSend = { doCommit(pendingRating, comment) },
+                        )
+                    }
+                }
             }
-            if (effectiveGiven != null) {
+        }
+    }
+}
+
+/**
+ * Stateless content of the pending-feedback affordance: maintainer notice (on
+ * thumbs-down), the quiet progress bar with Undo / Add-comment, and the optional
+ * comment field with Send. Hoisted out of [FeedbackControls] so it can be mounted
+ * and asserted directly in Robolectric tests — `Popup` content is unreliable
+ * under Robolectric (see `COMPOSE_TESTS.md`), so behaviour is tested here, on the
+ * content composable, rather than through the popover wrapper.
+ */
+@Composable
+internal fun FeedbackPendingPanel(
+    rating: String,
+    comment: String,
+    commentOpen: Boolean,
+    progress: () -> Float,
+    onOpenComment: () -> Unit,
+    onCommentChange: (String) -> Unit,
+    onUndo: () -> Unit,
+    onSend: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(12.dp)) {
+        // Maintainer-sharing notice is always shown on thumbs-down, even before a
+        // comment is written.
+        if (rating == "negative") {
+            Row(verticalAlignment = Alignment.Top) {
+                Icon(
+                    imageVector = Icons.Filled.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(modifier = Modifier.width(6.dp))
                 Text(
-                    text = stringResource(R.string.feedback_thanks),
+                    text = stringResource(R.string.feedback_maintainer_notice),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Spacer(modifier = Modifier.weight(1f))
-            trailing()
+            Spacer(modifier = Modifier.height(8.dp))
         }
 
-        if (pending != null && effectiveGiven == null) {
-            Spacer(modifier = Modifier.height(4.dp))
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                        shape = RoundedCornerShape(12.dp),
-                    )
-                    .padding(12.dp),
-            ) {
-                // Maintainer-sharing notice is always shown on thumbs-down, even
-                // before a comment is written.
-                if (pending == "negative") {
-                    Row(verticalAlignment = Alignment.Top) {
-                        Icon(
-                            imageVector = Icons.Filled.Info,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.tertiary,
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = stringResource(R.string.feedback_maintainer_notice),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
+        if (!commentOpen) {
+            val sendingDesc = stringResource(R.string.feedback_sending)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                LinearProgressIndicator(
+                    progress = progress,
+                    modifier = Modifier
+                        .weight(1f)
+                        .semantics { contentDescription = sendingDesc },
+                )
+                TextButton(onClick = onOpenComment) {
+                    Text(stringResource(R.string.feedback_add_comment))
                 }
-
-                if (!commentOpen) {
-                    val sendingDesc = stringResource(R.string.feedback_sending)
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        LinearProgressIndicator(
-                            progress = { progress.value },
-                            modifier = Modifier
-                                .weight(1f)
-                                .semantics { contentDescription = sendingDesc },
-                        )
-                        TextButton(onClick = { commentOpen = true }) {
-                            Text(stringResource(R.string.feedback_add_comment))
-                        }
-                        TextButton(onClick = { cancel() }) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.Undo,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                            )
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Text(stringResource(R.string.feedback_undo))
-                        }
-                    }
-                } else {
-                    OutlinedTextField(
-                        value = comment,
-                        onValueChange = { comment = it },
-                        placeholder = { Text(stringResource(R.string.feedback_comment_hint)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        minLines = 2,
+                TextButton(onClick = onUndo) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Undo,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        TextButton(onClick = { cancel() }) {
-                            Text(stringResource(R.string.feedback_undo))
-                        }
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Button(onClick = { pending?.let { doCommit(it, comment) } }) {
-                            Text(stringResource(R.string.feedback_send))
-                        }
-                    }
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(stringResource(R.string.feedback_undo))
+                }
+            }
+        } else {
+            OutlinedTextField(
+                value = comment,
+                onValueChange = onCommentChange,
+                placeholder = { Text(stringResource(R.string.feedback_comment_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 2,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onUndo) {
+                    Text(stringResource(R.string.feedback_undo))
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = onSend) {
+                    Text(stringResource(R.string.feedback_send))
                 }
             }
         }
+    }
+}
+
+/**
+ * Positions a [Popup] just **above** its anchor (the thumbs row), left-aligned and
+ * clamped within the window. Falls back to below the anchor when there isn't room
+ * above; in the pathological case where neither fits, pins to the top edge so the
+ * controls stay reachable. Opening above also keeps the panel clear of the
+ * on-screen keyboard when the comment field is focused.
+ *
+ * LTR left-alignment; [spacingPx] is the gap between the anchor and the popover.
+ */
+private class AbovePopupPositionProvider(
+    private val spacingPx: Int,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val maxX = (windowSize.width - popupContentSize.width).coerceAtLeast(0)
+        val x = anchorBounds.left.coerceIn(0, maxX)
+
+        val above = anchorBounds.top - popupContentSize.height - spacingPx
+        val below = anchorBounds.bottom + spacingPx
+        val y = when {
+            above >= 0 -> above
+            below + popupContentSize.height <= windowSize.height -> below
+            else -> above.coerceAtLeast(0)
+        }
+        return IntOffset(x, y)
     }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/FeedbackControlsComposeTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/FeedbackControlsComposeTest.kt
@@ -2,42 +2,32 @@ package org.voxquieta.app.presentation.components
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.hasSetTextAction
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performTextInput
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.voxquieta.app.testing.ComposeTestHarness
 
 /**
- * Robolectric-backed Compose UI tests for [FeedbackControls] (BITB-042).
+ * Robolectric-backed tests for [FeedbackControls] state / locking behaviour.
  *
- * These cover the deterministic interaction surface: the pending/undo
- * affordance, the thumbs-down maintainer notice, and the inline comment →
- * Send path. The ~10s rethink timer itself is driven by coroutine [delay],
- * which the Robolectric main clock does not advance reliably, so the
- * timeout-commit timing is validated by the web unit tests and the
- * `ChatViewModel` comment-plumbing test instead. We disable [autoAdvance] so
- * the timer never fires mid-test and the assertions stay deterministic.
+ * The pending affordance now renders in a [androidx.compose.ui.window.Popup]
+ * (see [FeedbackPendingPanel]), whose content is unreliable to assert under
+ * Robolectric (see `COMPOSE_TESTS.md`). So the popover *content* — Undo, the
+ * maintainer notice, and the comment → Send path — is covered directly in
+ * [FeedbackPendingPanelComposeTest]. These tests only assert facts that render
+ * inline: the locked "Thanks" state, and that tapping the thumbs does not send
+ * before the rethink window elapses.
  *
- * With [autoAdvance] false, the `clickable` tap-gesture detector and the
- * resulting recomposition only run when the clock advances. So every
- * [performClick] / [performTextInput] is followed by [settle], which advances
- * the clock by a tiny amount ([SETTLE_MS], far below the 10s window) — enough
- * for the gesture and recomposition to land, never enough to auto-commit.
+ * [autoAdvance] is disabled so the 10s timer never fires mid-test; each
+ * [performClick] is followed by [settle] so the tap gesture + recomposition land.
  */
 class FeedbackControlsComposeTest : ComposeTestHarness() {
 
     private val helpful = "This was helpful"
     private val notHelpful = "This was not helpful"
-    private val maintainerNotice = "Your message will be shared with the app's maintainer."
-    private val addComment = "Add a comment (optional)"
 
     @Before
     fun freezeClock() {
@@ -48,83 +38,33 @@ class FeedbackControlsComposeTest : ComposeTestHarness() {
     /** Advance just enough for a gesture + recomposition to settle, never the 10s timer. */
     private fun settle() = composeRule.mainClock.advanceTimeBy(SETTLE_MS)
 
-    private fun maintainerNoticeAbsent(): Boolean =
-        composeRule.onAllNodesWithText(maintainerNotice, useUnmergedTree = false)
-            .fetchSemanticsNodes(atLeastOneRootRequired = false).isEmpty()
-
     @Test
-    fun `tapping a thumb shows undo without sending immediately`() {
+    fun `tapping a thumb does not send immediately`() {
         var submitted: Pair<String, String>? = null
         setContentThemed {
             FeedbackControls(feedbackGiven = null, onSubmit = { r, c -> submitted = r to c })
         }
 
-        composeRule.onNodeWithContentDescription(helpful).performClick()
+        composeRule.onNodeWithContentDescription(notHelpful).performClick()
         settle()
 
-        composeRule.onNodeWithText("Undo").assertIsDisplayed()
         assertNull("rating must not be sent before the rethink window elapses", submitted)
     }
 
     @Test
-    fun `thumbs-down shows the maintainer-sharing notice`() {
-        setContentThemed {
-            FeedbackControls(feedbackGiven = null, onSubmit = { _, _ -> })
-        }
-
-        composeRule.onNodeWithContentDescription(notHelpful).performClick()
-        settle()
-
-        composeRule.onNodeWithText(maintainerNotice).assertIsDisplayed()
-    }
-
-    @Test
-    fun `thumbs-up does not show the maintainer notice`() {
-        setContentThemed {
-            FeedbackControls(feedbackGiven = null, onSubmit = { _, _ -> })
-        }
-
-        composeRule.onNodeWithContentDescription(helpful).performClick()
-        settle()
-
-        assertTrue("maintainer notice must not appear for thumbs-up", maintainerNoticeAbsent())
-    }
-
-    @Test
-    fun `undo cancels the pending feedback`() {
+    fun `re-tapping the same thumb cancels and sends nothing`() {
         var submitted: Pair<String, String>? = null
         setContentThemed {
             FeedbackControls(feedbackGiven = null, onSubmit = { r, c -> submitted = r to c })
         }
 
-        composeRule.onNodeWithContentDescription(notHelpful).performClick()
+        val up = composeRule.onNodeWithContentDescription(helpful)
+        up.performClick()
         settle()
-        composeRule.onNodeWithText(maintainerNotice).assertIsDisplayed()
-
-        composeRule.onNodeWithText("Undo").performClick()
-        settle()
-
-        assertTrue("maintainer notice must disappear after undo", maintainerNoticeAbsent())
-        assertNull("undo must not send any feedback", submitted)
-    }
-
-    @Test
-    fun `adding a comment and tapping Send submits rating with comment`() {
-        var submitted: Pair<String, String>? = null
-        setContentThemed {
-            FeedbackControls(feedbackGiven = null, onSubmit = { r, c -> submitted = r to c })
-        }
-
-        composeRule.onNodeWithContentDescription(notHelpful).performClick()
-        settle()
-        composeRule.onNodeWithText(addComment).performClick()
-        settle()
-        composeRule.onNode(hasSetTextAction()).performTextInput("Off-topic verse")
-        settle()
-        composeRule.onNodeWithText("Send").performClick()
+        up.performClick() // re-tapping the pending thumb = undo
         settle()
 
-        assertEquals("negative" to "Off-topic verse", submitted)
+        assertNull("re-tapping the same thumb must cancel without sending", submitted)
     }
 
     @Test

--- a/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/FeedbackPendingPanelComposeTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/FeedbackPendingPanelComposeTest.kt
@@ -1,0 +1,143 @@
+package org.voxquieta.app.presentation.components
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.voxquieta.app.testing.ComposeTestHarness
+
+/**
+ * Robolectric tests for [FeedbackPendingPanel] — the stateless content of the
+ * feedback popover. Mounted DIRECTLY (no Popup, no rethink timer) per the
+ * `COMPOSE_TESTS.md` guidance, so every assertion is deterministic. The popover
+ * positioning and keyboard focus are verified by manual / instrumented QA.
+ */
+class FeedbackPendingPanelComposeTest : ComposeTestHarness() {
+
+    private val maintainerNotice = "Your message will be shared with the app's maintainer."
+    private val addComment = "Add a comment (optional)"
+
+    private fun noticeAbsent(): Boolean =
+        composeRule.onAllNodesWithText(maintainerNotice, useUnmergedTree = false)
+            .fetchSemanticsNodes(atLeastOneRootRequired = false).isEmpty()
+
+    @Test
+    fun `negative rating shows the maintainer-sharing notice`() {
+        setContentThemed {
+            FeedbackPendingPanel(
+                rating = "negative",
+                comment = "",
+                commentOpen = false,
+                progress = { 1f },
+                onOpenComment = {},
+                onCommentChange = {},
+                onUndo = {},
+                onSend = {},
+            )
+        }
+        composeRule.onNodeWithText(maintainerNotice).assertIsDisplayed()
+    }
+
+    @Test
+    fun `positive rating hides the maintainer notice`() {
+        setContentThemed {
+            FeedbackPendingPanel(
+                rating = "positive",
+                comment = "",
+                commentOpen = false,
+                progress = { 1f },
+                onOpenComment = {},
+                onCommentChange = {},
+                onUndo = {},
+                onSend = {},
+            )
+        }
+        assertTrue("maintainer notice must not appear for thumbs-up", noticeAbsent())
+    }
+
+    @Test
+    fun `tapping Undo invokes onUndo`() {
+        var undone = false
+        setContentThemed {
+            FeedbackPendingPanel(
+                rating = "negative",
+                comment = "",
+                commentOpen = false,
+                progress = { 1f },
+                onOpenComment = {},
+                onCommentChange = {},
+                onUndo = { undone = true },
+                onSend = {},
+            )
+        }
+        composeRule.onNodeWithText("Undo").performClick()
+        assertTrue("Undo must invoke onUndo", undone)
+    }
+
+    @Test
+    fun `tapping Add a comment invokes onOpenComment`() {
+        var opened = false
+        setContentThemed {
+            FeedbackPendingPanel(
+                rating = "negative",
+                comment = "",
+                commentOpen = false,
+                progress = { 1f },
+                onOpenComment = { opened = true },
+                onCommentChange = {},
+                onUndo = {},
+                onSend = {},
+            )
+        }
+        composeRule.onNodeWithText(addComment).performClick()
+        assertTrue("Add a comment must invoke onOpenComment", opened)
+    }
+
+    @Test
+    fun `typing a comment and tapping Send forwards the text`() {
+        var sentComment: String? = null
+        setContentThemed {
+            var comment by remember { mutableStateOf("") }
+            FeedbackPendingPanel(
+                rating = "negative",
+                comment = comment,
+                commentOpen = true,
+                progress = { 1f },
+                onOpenComment = {},
+                onCommentChange = { comment = it },
+                onUndo = {},
+                onSend = { sentComment = comment },
+            )
+        }
+        composeRule.onNode(hasSetTextAction()).performTextInput("Off-topic verse")
+        composeRule.onNodeWithText("Send").performClick()
+        assertEquals("Off-topic verse", sentComment)
+    }
+
+    @Test
+    fun `progress bar exposes the sending content description`() {
+        setContentThemed {
+            FeedbackPendingPanel(
+                rating = "positive",
+                comment = "",
+                commentOpen = false,
+                progress = { 0.5f },
+                onOpenComment = {},
+                onCommentChange = {},
+                onUndo = {},
+                onSend = {},
+            )
+        }
+        composeRule.onNodeWithContentDescription("Sending feedback…").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Problem

On Android, tapping 👍/👎 opens the "rethink" affordance (10s progress bar + Undo / Add‑comment / Send, plus the maintainer‑sharing notice on 👎). It rendered **inline below the thumbs**. Combined with `ChatScreen`'s auto‑scroll to the last message, for the bottom message the panel landed **below the fold** — the user had to scroll to see Undo/Send, so it looked like nothing happened.

## Fix

Render that same affordance in a **`Popup` floating above the thumbs**, so it's visible the instant a thumb is tapped and no longer pushes chat content down.

- **`AbovePopupPositionProvider`** — prefers above the anchor, falls back below when there isn't room, clamps within the window. Opening upward also keeps the panel clear of the on‑screen keyboard when the comment field is focused.
- Styled as an **elevated opaque `Surface` card** (shadow, 320dp to match the message bubble width).
- `PopupProperties(focusable = true)` so the comment `OutlinedTextField` gets the keyboard.
- **Tap‑outside / back = non‑destructive cancel** (nothing is sent; the countdown coroutine is torn down via the existing `cancel()` path).

**No behavior change otherwise:** 10s delay‑driven commit, Undo, switch/re‑tap‑to‑cancel, comment‑pauses‑countdown, single‑send guard, optimistic "Thanks" lock, and the copy/share `trailing` slot are all preserved. The public `FeedbackControls(...)` signature and its `ChatMessageItem` call site are unchanged.

## Tests

- Extracted the affordance into a stateless **`FeedbackPendingPanel`** composable and added **`FeedbackPendingPanelComposeTest`** that asserts content/interaction **directly** (maintainer notice on negative / absent on positive, Undo callback, Add‑comment callback, type→Send forwards the text, progress `contentDescription`). This is the Robolectric‑safe pattern the repo's own `COMPOSE_TESTS.md` prescribes — `Popup` content isn't reliably assertable under Robolectric.
- Trimmed `FeedbackControlsComposeTest` to inline‑only facts: no‑send on tap, re‑tap cancels, given → Thanks + disabled.
- Noted the panel‑direct approach in `COMPOSE_TESTS.md`.

## Verification

⚠️ No Android SDK in the authoring environment, so the Gradle build / tests were **not run locally** — CI is the gate (Compose UI Tests, Unit Tests, Android Lint, Build Prod APK).

Two device‑dependent aspects are **out of scope for the Robolectric tier** and want a quick manual check (or an instrumented follow‑up): the popover's above/below **positioning**, and the **keyboard** behavior in the focusable Popup. Manual QA: send a message so it sits at the bottom of the chat, tap 👍 and 👎 — the panel must appear **immediately, above the thumbs, fully visible without scrolling**; on 👎 the maintainer notice shows; "Add a comment" focuses the field and raises the keyboard without covering the panel; Undo / tap‑outside / back dismiss with nothing sent; doing nothing ~10s still commits once.

## Out of scope

- Web (this bug/fix is Android‑only).
- The instrumented‑tier positioning/keyboard test (follow‑up).

https://claude.ai/code/session_01Ntg1Wo3quQsWgDGWYcxrLf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntg1Wo3quQsWgDGWYcxrLf)_