### PR TITLE
feat: add weekly activity digest email and dashboard backlog story

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -1,0 +1,69 @@
+name: Weekly Report
+
+# Weekly activity digest email.
+#
+# Triggers the backend's probe-gated /api/v1/admin/weekly-report endpoint,
+# which builds a digest of feedback, contact submissions, and session
+# engagement over the last 7 days and emails it to the configured recipient
+# (settings.weekly_report_recipient, default support@voxquieta.org).
+#
+# Postgres cannot send email, so the schedule lives here rather than in
+# pg_cron; the backend (which already has DB + SMTP configured) does the work.
+#
+# Required repo secrets:
+#   MONITOR_PROBE_SECRET - shared secret; must match settings.monitor_probe_secret
+#                          in the deployed backend (same one prod-monitor uses).
+#
+# Required repo variables (vars.*):
+#   BACKEND_URL          - e.g. https://bible-app-backend.<region>.azurecontainerapps.io
+#                          (default: production hardcoded fallback below)
+#
+# Manual run:
+#   Actions → Weekly Report → Run workflow (set dry_run=true to preview without
+#   sending an email).
+
+# yamllint flags the unquoted `on` key as a YAML 1.1 truthy value.
+"on":
+  schedule:
+    # Every Sunday 18:00 UTC, covering the previous 7 days. GH cron is UTC.
+    - cron: "0 18 * * 0"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute the digest but do not send the email"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+env:
+  BACKEND_URL:
+    ${{ vars.BACKEND_URL || 'https://bible-app-backend.agreeablesea-6ee07535.northeurope.azurecontainerapps.io' }}
+
+jobs:
+  weekly-report:
+    name: Send weekly digest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger weekly report
+        env:
+          MONITOR_PROBE_SECRET: ${{ secrets.MONITOR_PROBE_SECRET }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          set -o pipefail
+          resp=$(curl -fsS --max-time 60 -X POST \
+            "${BACKEND_URL%/}/api/v1/admin/weekly-report?dry_run=${DRY_RUN}" \
+            -H "X-Monitor-Probe-Secret: ${MONITOR_PROBE_SECRET}")
+          echo "$resp" | jq '{dry_run, email_sent}' || echo "$resp"
+          # Fail the job if a live run did not actually send the email
+          # (e.g. SMTP disabled/misconfigured in the backend).
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "$resp" | jq -e '.dry_run == true' > /dev/null
+          else
+            echo "$resp" | jq -e '.email_sent == true' > /dev/null || {
+              echo "::error::weekly report did not send (email_sent != true)"
+              exit 1
+            }
+          fi

--- a/api/config.py
+++ b/api/config.py
@@ -90,6 +90,9 @@ class Settings(BaseSettings):
     smtp2go_sender_email: str = "noreply@voxquieta.org"
     smtp2go_sender_name: str = "Vox Quieta"
     contact_notification_email: str = "support@voxquieta.org"
+    # Recipient for the weekly activity digest (kept separate from the
+    # contact-form recipient so the two can be retargeted independently).
+    weekly_report_recipient: str = "support@voxquieta.org"
 
     # Production frontend URL (used for CORS, access audit, and Referer headers)
     # Change this when migrating to a new domain.

--- a/api/main.py
+++ b/api/main.py
@@ -39,6 +39,7 @@ from middleware.access_audit import AccessAuditMiddleware  # noqa: E402
 from middleware.correlation_id import CorrelationIDMiddleware  # noqa: E402
 from providers import ProviderError, get_embedding_provider, get_llm_provider  # noqa: E402
 from routes import (  # noqa: E402
+    admin_router,
     chat_router,
     church_router,
     feedback_router,
@@ -261,6 +262,7 @@ app.include_router(church_router, prefix="/api/v1")
 app.include_router(feedback_router, prefix="/api/v1")
 app.include_router(health_router)  # Health endpoints at root level
 app.include_router(scripture_router, prefix="/api/v1")
+app.include_router(admin_router, prefix="/api/v1")  # internal probe-gated endpoints
 
 
 # ==================== Health & Info ====================

--- a/api/reports/__init__.py
+++ b/api/reports/__init__.py
@@ -1,0 +1,1 @@
+"""Periodic activity reports (weekly digest)."""

--- a/api/reports/weekly_report.py
+++ b/api/reports/weekly_report.py
@@ -1,0 +1,415 @@
+"""
+Weekly activity digest builder.
+
+Pure, independently testable: queries the backend Postgres DB for the last
+``window_days`` of feedback, contact submissions, and session engagement, and
+renders a plain-text + HTML email body. Both the web app and the Android app
+hit the same API, so this DB-only view already covers both clients.
+
+Firebase/GA4 Android engagement (screen views, verse taps, retention) is
+deliberately out of scope here — it needs a separate Google Analytics Data API
+integration.
+"""
+
+import html
+from datetime import UTC, datetime, timedelta
+
+from pydantic import BaseModel
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from feedback.models import ContactSubmission, Feedback
+
+# How many recent negative comments to surface in the digest.
+MAX_NEGATIVE_COMMENTS = 10
+# How many top languages to list.
+MAX_LANGUAGES = 5
+
+
+# ==================== Result models ====================
+
+
+class NegativeComment(BaseModel):
+    created_at: datetime
+    comment: str
+
+
+class FeedbackStats(BaseModel):
+    total: int
+    positive: int
+    negative: int
+    # None when there is no feedback at all (avoids a misleading 0%/divide).
+    positive_ratio: float | None
+    recent_negative: list[NegativeComment]
+
+
+class ContactStats(BaseModel):
+    total: int
+    by_subject: dict[str, int]
+
+
+class LanguageCount(BaseModel):
+    language: str
+    count: int
+
+
+class EngagementStats(BaseModel):
+    active_sessions: int
+    new_sessions: int
+    # Approximate: message_count is a per-session lifetime counter, summed over
+    # sessions active in the window.
+    total_messages: int
+    web_sessions: int
+    mobile_sessions: int
+    top_languages: list[LanguageCount]
+
+
+class WeeklyReport(BaseModel):
+    window_start: datetime
+    window_end: datetime
+    window_days: int
+    feedback: FeedbackStats
+    contact: ContactStats
+    engagement: EngagementStats
+    # Week-over-week comparison points (previous window of equal length).
+    feedback_total_prev: int
+    new_sessions_prev: int
+
+
+# ==================== Builder ====================
+
+
+async def build_weekly_report(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    window_days: int = 7,
+) -> WeeklyReport:
+    """Build the weekly activity report over the last ``window_days``.
+
+    ``now`` is injectable so tests are deterministic. Issues a fixed sequence
+    of queries (order matters for unit tests that mock ``db.execute``):
+
+    1. feedback ratings grouped by rating (current window)
+    2. recent negative comments (current window)
+    3. contact submissions grouped by subject (current window)
+    4. session engagement aggregate (one row)
+    5. top languages among active sessions
+    6. feedback total in the previous window (delta)
+    7. new sessions in the previous window (delta)
+    """
+    end = now or datetime.now(UTC)
+    start = end - timedelta(days=window_days)
+    prev_start = start - timedelta(days=window_days)
+
+    # 1. Feedback by rating (ORM).
+    fb_rows = (
+        await db.execute(
+            select(Feedback.rating, func.count())
+            .where(Feedback.created_at >= start, Feedback.created_at < end)
+            .group_by(Feedback.rating)
+        )
+    ).all()
+    rating_counts = {rating: count for rating, count in fb_rows}
+    positive = rating_counts.get("positive", 0)
+    negative = rating_counts.get("negative", 0)
+    total_fb = sum(rating_counts.values())
+    positive_ratio = (positive / total_fb) if total_fb else None
+
+    # 2. Recent negative comments (ORM).
+    neg_rows = (
+        await db.execute(
+            select(Feedback.created_at, Feedback.comment)
+            .where(
+                Feedback.rating == "negative",
+                Feedback.created_at >= start,
+                Feedback.created_at < end,
+                Feedback.comment.isnot(None),
+                Feedback.comment != "",
+            )
+            .order_by(Feedback.created_at.desc())
+            .limit(MAX_NEGATIVE_COMMENTS)
+        )
+    ).all()
+    recent_negative = [
+        NegativeComment(created_at=created_at, comment=comment) for created_at, comment in neg_rows
+    ]
+
+    feedback = FeedbackStats(
+        total=total_fb,
+        positive=positive,
+        negative=negative,
+        positive_ratio=positive_ratio,
+        recent_negative=recent_negative,
+    )
+
+    # 3. Contact submissions by subject (ORM).
+    contact_rows = (
+        await db.execute(
+            select(ContactSubmission.subject, func.count())
+            .where(
+                ContactSubmission.created_at >= start,
+                ContactSubmission.created_at < end,
+            )
+            .group_by(ContactSubmission.subject)
+        )
+    ).all()
+    by_subject = {subject: count for subject, count in contact_rows}
+    contact = ContactStats(total=sum(by_subject.values()), by_subject=by_subject)
+
+    # 4. Engagement aggregate (raw SQL — there is no ORM model for `sessions`).
+    eng_row = (
+        await db.execute(
+            text("""
+                SELECT
+                    COUNT(*) FILTER (
+                        WHERE last_activity >= :start AND last_activity < :end
+                    ) AS active_sessions,
+                    COUNT(*) FILTER (
+                        WHERE created_at >= :start AND created_at < :end
+                    ) AS new_sessions,
+                    COALESCE(SUM(message_count) FILTER (
+                        WHERE last_activity >= :start AND last_activity < :end
+                    ), 0) AS total_messages,
+                    COUNT(*) FILTER (
+                        WHERE last_activity >= :start AND last_activity < :end
+                        AND is_mobile
+                    ) AS mobile_sessions,
+                    COUNT(*) FILTER (
+                        WHERE last_activity >= :start AND last_activity < :end
+                        AND NOT is_mobile
+                    ) AS web_sessions
+                FROM sessions
+            """),
+            {"start": start, "end": end},
+        )
+    ).one()
+    active_sessions, new_sessions, total_messages, mobile_sessions, web_sessions = eng_row
+
+    # 5. Top languages among active sessions (raw SQL).
+    lang_rows = (
+        await db.execute(
+            text("""
+                SELECT language, COUNT(*) AS cnt
+                FROM sessions
+                WHERE last_activity >= :start AND last_activity < :end
+                  AND language IS NOT NULL
+                GROUP BY language
+                ORDER BY cnt DESC
+                LIMIT :limit
+            """),
+            {"start": start, "end": end, "limit": MAX_LANGUAGES},
+        )
+    ).all()
+    top_languages = [LanguageCount(language=language, count=count) for language, count in lang_rows]
+
+    engagement = EngagementStats(
+        active_sessions=active_sessions,
+        new_sessions=new_sessions,
+        total_messages=total_messages,
+        web_sessions=web_sessions,
+        mobile_sessions=mobile_sessions,
+        top_languages=top_languages,
+    )
+
+    # 6. Previous-window feedback total (ORM) — week-over-week delta.
+    feedback_total_prev = (
+        await db.execute(
+            select(func.count()).where(
+                Feedback.created_at >= prev_start, Feedback.created_at < start
+            )
+        )
+    ).scalar() or 0
+
+    # 7. Previous-window new sessions (raw SQL) — week-over-week delta.
+    new_sessions_prev = (
+        (
+            await db.execute(
+                text("""
+                SELECT COUNT(*) FROM sessions
+                WHERE created_at >= :prev_start AND created_at < :start
+            """),
+                {"prev_start": prev_start, "start": start},
+            )
+        ).scalar()
+        or 0
+    )
+
+    return WeeklyReport(
+        window_start=start,
+        window_end=end,
+        window_days=window_days,
+        feedback=feedback,
+        contact=contact,
+        engagement=engagement,
+        feedback_total_prev=feedback_total_prev,
+        new_sessions_prev=new_sessions_prev,
+    )
+
+
+# ==================== Rendering ====================
+
+
+def _pct(ratio: float | None) -> str:
+    return "n/a" if ratio is None else f"{ratio * 100:.0f}%"
+
+
+def _delta(current: int, previous: int) -> str:
+    """Human-readable signed delta vs. the previous window."""
+    diff = current - previous
+    sign = "+" if diff >= 0 else ""
+    return f"{sign}{diff} vs. previous {previous}"
+
+
+def render_text(report: WeeklyReport) -> str:
+    """Render the digest as plain text."""
+    r = report
+    lines: list[str] = []
+    lines.append("Vox Quieta — Weekly Activity Digest")
+    lines.append(
+        f"{r.window_start:%Y-%m-%d %H:%M} to {r.window_end:%Y-%m-%d %H:%M} UTC "
+        f"(last {r.window_days} days)"
+    )
+    lines.append("(covers both the web app and the Android app)")
+    lines.append("")
+
+    lines.append("FEEDBACK")
+    lines.append(
+        f"  Total: {r.feedback.total} " f"({_delta(r.feedback.total, r.feedback_total_prev)})"
+    )
+    lines.append(f"  Positive: {r.feedback.positive}")
+    lines.append(f"  Negative: {r.feedback.negative}")
+    lines.append(f"  Positive ratio: {_pct(r.feedback.positive_ratio)}")
+    if r.feedback.recent_negative:
+        lines.append("  Recent negative comments:")
+        for nc in r.feedback.recent_negative:
+            lines.append(f"    - [{nc.created_at:%Y-%m-%d}] {nc.comment}")
+    lines.append("")
+
+    lines.append("CONTACT SUBMISSIONS")
+    lines.append(f"  Total: {r.contact.total}")
+    for subject, count in sorted(r.contact.by_subject.items()):
+        lines.append(f"    {subject}: {count}")
+    lines.append("")
+
+    e = r.engagement
+    lines.append("ENGAGEMENT")
+    lines.append(f"  Active sessions: {e.active_sessions}")
+    lines.append(
+        f"  New sessions: {e.new_sessions} " f"({_delta(e.new_sessions, r.new_sessions_prev)})"
+    )
+    lines.append(f"  Messages (approx, lifetime per active session): {e.total_messages}")
+    lines.append(f"  Web sessions: {e.web_sessions}")
+    lines.append(f"  Mobile sessions: {e.mobile_sessions}")
+    if e.top_languages:
+        lines.append("  Top languages:")
+        for lc in e.top_languages:
+            lines.append(f"    {lc.language}: {lc.count}")
+    lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def _esc(value: str) -> str:
+    """HTML-escape free text, then turn newlines into <br>."""
+    return html.escape(value).replace("\n", "<br>")
+
+
+def render_html(report: WeeklyReport) -> str:
+    """Render the digest as HTML (mirrors the contact-notification style)."""
+    r = report
+    e = r.engagement
+
+    neg_html = ""
+    if r.feedback.recent_negative:
+        items = "".join(
+            f'<div style="background: #f9f9f9; padding: 10px 15px; '
+            f'border-left: 4px solid #5c6ac4; margin: 8px 0;">'
+            f'<span style="font-size: 12px; color: #888;">'
+            f"{nc.created_at:%Y-%m-%d}</span><br>{_esc(nc.comment)}</div>"
+            for nc in r.feedback.recent_negative
+        )
+        neg_html = f"<h3>Recent negative comments</h3>{items}"
+
+    contact_rows = (
+        "".join(
+            f'<tr><td style="padding: 8px; background: #f5f5f5;">{_esc(subject)}</td>'
+            f'<td style="padding: 8px;">{count}</td></tr>'
+            for subject, count in sorted(r.contact.by_subject.items())
+        )
+        or '<tr><td style="padding: 8px;" colspan="2"><em>None</em></td></tr>'
+    )
+
+    lang_rows = (
+        "".join(
+            f'<tr><td style="padding: 8px; background: #f5f5f5;">{_esc(lc.language)}</td>'
+            f'<td style="padding: 8px;">{lc.count}</td></tr>'
+            for lc in e.top_languages
+        )
+        or '<tr><td style="padding: 8px;" colspan="2"><em>None</em></td></tr>'
+    )
+
+    return f"""
+<html>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <h2 style="color: #5c6ac4;">Vox Quieta — Weekly Activity Digest</h2>
+    <p style="color: #888; font-size: 13px;">
+        {r.window_start:%Y-%m-%d} to {r.window_end:%Y-%m-%d} UTC
+        (last {r.window_days} days) — covers both the web app and the Android app.
+    </p>
+
+    <h3>Feedback</h3>
+    <table style="border-collapse: collapse; margin: 10px 0;">
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Total</td>
+            <td style="padding: 8px;">{r.feedback.total} ({_delta(r.feedback.total, r.feedback_total_prev)})</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Positive</td>
+            <td style="padding: 8px;">{r.feedback.positive}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Negative</td>
+            <td style="padding: 8px;">{r.feedback.negative}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Positive ratio</td>
+            <td style="padding: 8px;">{_pct(r.feedback.positive_ratio)}</td>
+        </tr>
+    </table>
+    {neg_html}
+
+    <h3>Contact submissions ({r.contact.total})</h3>
+    <table style="border-collapse: collapse; margin: 10px 0;">{contact_rows}</table>
+
+    <h3>Engagement</h3>
+    <table style="border-collapse: collapse; margin: 10px 0;">
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Active sessions</td>
+            <td style="padding: 8px;">{e.active_sessions}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">New sessions</td>
+            <td style="padding: 8px;">{e.new_sessions} ({_delta(e.new_sessions, r.new_sessions_prev)})</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Messages (approx)</td>
+            <td style="padding: 8px;">{e.total_messages}</td>
+        </tr>
+        <tr>
+            <td style="padding: 8px; font-weight: bold; background: #f5f5f5;">Web / Mobile</td>
+            <td style="padding: 8px;">{e.web_sessions} / {e.mobile_sessions}</td>
+        </tr>
+    </table>
+    <h4 style="margin-bottom: 4px;">Top languages</h4>
+    <table style="border-collapse: collapse; margin: 10px 0;">{lang_rows}</table>
+
+    <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
+    <p style="font-size: 12px; color: #888;">
+        Automated weekly digest. Messages figure is approximate (per-session
+        lifetime counter). Android in-app engagement (screen views, verse taps)
+        is not yet included.
+    </p>
+</body>
+</html>
+    """.strip()

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -2,6 +2,7 @@
 API Routes package.
 """
 
+from .admin import router as admin_router
 from .chat import router as chat_router
 from .church import router as church_router
 from .feedback import router as feedback_router
@@ -9,6 +10,7 @@ from .health import router as health_router
 from .scripture import router as scripture_router
 
 __all__ = [
+    "admin_router",
     "chat_router",
     "church_router",
     "feedback_router",

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,0 +1,64 @@
+"""
+Admin routes — internal, server-to-server operational endpoints.
+
+Not part of the public API (``include_in_schema=False``). Authenticated with
+the same shared-secret probe header used by the production monitor, so the
+weekly-report GitHub Actions cron can trigger a digest without a session/token.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config import settings
+from reports.weekly_report import build_weekly_report, render_html, render_text
+from scripture import get_db_session
+from utils.email_service import email_service
+from utils.logging_config import get_logger
+from utils.monitor_probe import is_monitor_probe
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.post("/weekly-report", include_in_schema=False)
+async def trigger_weekly_report(
+    request: Request,
+    dry_run: bool = Query(False, description="Compute and return stats without sending email"),
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Build the weekly activity digest and email it to the configured recipient.
+
+    Guarded by the monitor-probe shared secret (``X-Monitor-Probe-Secret``).
+    Fail-closed: if the secret is unset on the server, every request is 401.
+    """
+    if not is_monitor_probe(request):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    report = await build_weekly_report(db)
+
+    email_sent = False
+    if not dry_run:
+        subject = (
+            "[Vox Quieta] Weekly Activity Digest — "
+            f"{report.window_start:%Y-%m-%d} to {report.window_end:%Y-%m-%d}"
+        )
+        # send_email is synchronous (httpx.Client) — do not await.
+        email_sent = email_service.send_email(
+            to_email=settings.weekly_report_recipient,
+            subject=subject,
+            body_text=render_text(report),
+            body_html=render_html(report),
+        )
+        logger.info(
+            "Weekly report processed",
+            extra={"email_sent": email_sent, "recipient": settings.weekly_report_recipient},
+        )
+    else:
+        logger.info("Weekly report dry-run (no email sent)")
+
+    return {
+        "dry_run": dry_run,
+        "email_sent": email_sent,
+        "report": report.model_dump(mode="json"),
+    }

--- a/api/tests/test_admin_report.py
+++ b/api/tests/test_admin_report.py
@@ -1,0 +1,112 @@
+"""
+Tests for the probe-gated POST /api/v1/admin/weekly-report endpoint.
+
+No DB or network: the report builder and email send are patched. Focus is on
+the auth gate (fail-closed) and the dry-run / send wiring.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from config import settings
+from main import app
+from reports.weekly_report import (
+    ContactStats,
+    EngagementStats,
+    FeedbackStats,
+    WeeklyReport,
+)
+from scripture import get_db_session
+
+client = TestClient(app)
+
+ENDPOINT = "/api/v1/admin/weekly-report"
+SECRET = "probe-secret"  # pragma: allowlist secret
+HEADERS = {"X-Monitor-Probe-Secret": SECRET}
+
+
+def _fake_report() -> WeeklyReport:
+    now = datetime(2026, 6, 8, 18, 0, tzinfo=UTC)
+    return WeeklyReport(
+        window_start=now,
+        window_end=now,
+        window_days=7,
+        feedback=FeedbackStats(
+            total=0, positive=0, negative=0, positive_ratio=None, recent_negative=[]
+        ),
+        contact=ContactStats(total=0, by_subject={}),
+        engagement=EngagementStats(
+            active_sessions=0,
+            new_sessions=0,
+            total_messages=0,
+            web_sessions=0,
+            mobile_sessions=0,
+            top_languages=[],
+        ),
+        feedback_total_prev=0,
+        new_sessions_prev=0,
+    )
+
+
+def setup_module():
+    app.dependency_overrides[get_db_session] = lambda: MagicMock()
+
+
+def teardown_module():
+    app.dependency_overrides.pop(get_db_session, None)
+
+
+def test_missing_header_returns_401():
+    with patch.object(settings, "monitor_probe_secret", SECRET):
+        resp = client.post(ENDPOINT)
+    assert resp.status_code == 401
+
+
+def test_wrong_header_returns_401():
+    with patch.object(settings, "monitor_probe_secret", SECRET):
+        resp = client.post(ENDPOINT, headers={"X-Monitor-Probe-Secret": "nope"})
+    assert resp.status_code == 401
+
+
+def test_unset_secret_fails_closed():
+    """Even a 'correct' header is rejected when the server secret is unset."""
+    with patch.object(settings, "monitor_probe_secret", None):
+        resp = client.post(ENDPOINT, headers=HEADERS)
+    assert resp.status_code == 401
+
+
+def test_authorized_send():
+    with (
+        patch.object(settings, "monitor_probe_secret", SECRET),
+        patch("routes.admin.build_weekly_report", AsyncMock(return_value=_fake_report())),
+        patch("routes.admin.email_service.send_email", return_value=True) as send,
+    ):
+        resp = client.post(ENDPOINT, headers=HEADERS)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dry_run"] is False
+    assert body["email_sent"] is True
+    assert "report" in body
+    send.assert_called_once()
+
+
+def test_dry_run_does_not_send():
+    with (
+        patch.object(settings, "monitor_probe_secret", SECRET),
+        patch("routes.admin.build_weekly_report", AsyncMock(return_value=_fake_report())),
+        patch("routes.admin.email_service.send_email", return_value=True) as send,
+    ):
+        resp = client.post(f"{ENDPOINT}?dry_run=true", headers=HEADERS)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dry_run"] is True
+    assert body["email_sent"] is False
+    send.assert_not_called()

--- a/api/tests/test_weekly_report.py
+++ b/api/tests/test_weekly_report.py
@@ -1,0 +1,146 @@
+"""
+Tests for the weekly activity digest builder and renderers.
+
+The builder issues a fixed sequence of `db.execute` calls (documented in
+`build_weekly_report`); these tests mock that sequence with canned results.
+"""
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from reports.weekly_report import (
+    ContactStats,
+    EngagementStats,
+    FeedbackStats,
+    LanguageCount,
+    NegativeComment,
+    WeeklyReport,
+    build_weekly_report,
+    render_html,
+    render_text,
+)
+
+NOW = datetime(2026, 6, 8, 18, 0, tzinfo=UTC)
+
+
+def _result(all_=None, one_=None, scalar_=None):
+    """Build a mock SQLAlchemy Result exposing .all()/.one()/.scalar()."""
+    r = MagicMock()
+    r.all.return_value = all_ if all_ is not None else []
+    r.one.return_value = one_
+    r.scalar.return_value = scalar_
+    return r
+
+
+def _db_with(results):
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=results)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_build_report_happy_path():
+    db = _db_with(
+        [
+            _result(all_=[("positive", 8), ("negative", 2)]),  # 1 ratings
+            _result(all_=[(NOW, "too slow"), (NOW, "wrong verse")]),  # 2 neg comments
+            _result(all_=[("bug", 3), ("feature", 1)]),  # 3 contact
+            _result(one_=(40, 12, 95, 7, 33)),  # 4 engagement aggregate
+            _result(all_=[("en", 20), ("it", 8)]),  # 5 languages
+            _result(scalar_=6),  # 6 prev feedback total
+            _result(scalar_=9),  # 7 prev new sessions
+        ]
+    )
+
+    report = await build_weekly_report(db, now=NOW)
+
+    assert report.feedback.total == 10
+    assert report.feedback.positive == 8
+    assert report.feedback.negative == 2
+    assert report.feedback.positive_ratio == pytest.approx(0.8)
+    assert len(report.feedback.recent_negative) == 2
+
+    assert report.contact.total == 4
+    assert report.contact.by_subject == {"bug": 3, "feature": 1}
+
+    assert report.engagement.active_sessions == 40
+    assert report.engagement.new_sessions == 12
+    assert report.engagement.total_messages == 95
+    assert report.engagement.mobile_sessions == 7
+    assert report.engagement.web_sessions == 33
+    assert report.engagement.top_languages[0].language == "en"
+
+    assert report.feedback_total_prev == 6
+    assert report.new_sessions_prev == 9
+    assert report.window_days == 7
+
+
+@pytest.mark.asyncio
+async def test_build_report_empty_data_no_divide_error():
+    db = _db_with(
+        [
+            _result(all_=[]),  # ratings
+            _result(all_=[]),  # neg comments
+            _result(all_=[]),  # contact
+            _result(one_=(0, 0, 0, 0, 0)),  # engagement
+            _result(all_=[]),  # languages
+            _result(scalar_=None),  # prev feedback total (None -> 0)
+            _result(scalar_=None),  # prev new sessions
+        ]
+    )
+
+    report = await build_weekly_report(db, now=NOW)
+
+    assert report.feedback.total == 0
+    assert report.feedback.positive_ratio is None  # not a ZeroDivisionError
+    assert report.contact.total == 0
+    assert report.engagement.active_sessions == 0
+    assert report.feedback_total_prev == 0
+    assert report.new_sessions_prev == 0
+
+    # Renderers must not crash on an empty report.
+    assert "Weekly Activity Digest" in render_text(report)
+    assert "n/a" in render_text(report)
+    assert "<html>" in render_html(report)
+
+
+def _report_with_comment(comment: str) -> WeeklyReport:
+    return WeeklyReport(
+        window_start=NOW,
+        window_end=NOW,
+        window_days=7,
+        feedback=FeedbackStats(
+            total=1,
+            positive=0,
+            negative=1,
+            positive_ratio=0.0,
+            recent_negative=[NegativeComment(created_at=NOW, comment=comment)],
+        ),
+        contact=ContactStats(total=0, by_subject={}),
+        engagement=EngagementStats(
+            active_sessions=0,
+            new_sessions=0,
+            total_messages=0,
+            web_sessions=0,
+            mobile_sessions=0,
+            top_languages=[LanguageCount(language="en", count=1)],
+        ),
+        feedback_total_prev=0,
+        new_sessions_prev=0,
+    )
+
+
+def test_render_html_escapes_user_text():
+    report = _report_with_comment("<script>alert('x')</script> & bad")
+    html_out = render_html(report)
+
+    # Raw tag/entity must be escaped, not present verbatim.
+    assert "<script>" not in html_out
+    assert "&lt;script&gt;" in html_out
+    assert "&amp; bad" in html_out

--- a/docs/BACKLOG_STORIES/BITB-043-product-analytics-dashboard.md
+++ b/docs/BACKLOG_STORIES/BITB-043-product-analytics-dashboard.md
@@ -1,0 +1,137 @@
+# BITB-043: Product Analytics Dashboard (Metabase)
+
+**Priority:** P2 — Medium. Follows the weekly digest email (which ships the
+same metrics now); this is the longer-term, interactive successor.
+**Status:** 📋 Proposed — not yet started.
+**Size:** L (multi-day: infra + DB role + dashboard authoring).
+**Created:** 2026-06-08
+
+---
+
+## Context
+
+The owner wants a **proper dashboard** for product/business signals — positive
+vs. negative feedback, contact submissions, web-vs-mobile engagement, languages,
+DAU/MAU — across both the web app and the Android app. The weekly digest email
+(`api/reports/weekly_report.py` + `.github/workflows/weekly-report.yml`) is the
+deliberate **stopgap**: it surfaces these numbers now, by email, with zero new
+infra. This story is the planned evolution into an interactive dashboard, and
+it's designed so the email work is a stepping stone rather than a throwaway.
+
+## What already exists (and why it isn't this)
+
+There IS a dashboard in the repo:
+`deployment/azure-monitor/workbook-performance-dashboard.json` — an Azure
+Monitor Workbook (stories BITB-021 / BITB-022, deployed via Terraform
+`azurerm_application_insights_workbook.performance_dashboard` in
+`deployment/main.tf:1055`). But it is an **SRE / operational** view over
+Application Insights using KQL: request volume, latency percentiles, TTFT, LLM
+duration, errors, container CPU/memory.
+
+It does **not** cover the **product/business** signals this request is about,
+and it **cannot** easily: those signals live in the backend **Postgres** tables
+(`feedback`, `contact_submissions`, `sessions`), not in Application Insights,
+and the workbook is KQL-only against App Insights. So this is a *new, separate,
+product-analytics* dashboard — not an extension of the SRE workbook.
+
+## User Story
+
+**As** the product owner,
+**I want** an interactive dashboard of feedback, contact, and engagement metrics
+sourced from the production Postgres DB,
+**so that** I can explore trends (not just receive a weekly snapshot) without
+writing SQL or logging into the database.
+
+## Recommended solution: Metabase (self-hosted)
+
+Evaluated Metabase vs. Grafana vs. Looker Studio vs. extending the Azure
+Workbook. **Metabase** is the best fit because it uniquely covers all three
+needs at once:
+
+- **Business analytics, not just ops.** Built for non-technical users to build
+  dashboards on a SQL DB without writing SQL — the right tool for product KPIs.
+- **Connects straight to the existing Postgres DB** (`feedback`,
+  `contact_submissions`, `sessions`) — the *same* data the weekly digest already
+  queries. No new data pipeline needed for phase 1.
+- **Built-in scheduled email "dashboard subscriptions"** — Metabase can email a
+  dashboard digest on a weekly cadence out of the box. This is what lets the
+  custom email endpoint be retired/relegated once the dashboard exists.
+- **Self-hostable via Docker** — consistent with the existing Azure Container
+  Apps + Postgres stack and Terraform-managed infra; data stays in-house.
+
+### Self-host sketch (Azure Container Apps)
+
+- Run the official `metabase/metabase` container as a new Container App
+  (Terraform, alongside the backend).
+- Metabase needs its **own small app-metadata database** (a dedicated Postgres
+  DB / schema for Metabase's internal state — do **not** point it at the app
+  tables for this).
+- Give Metabase a **read-only Postgres role** scoped to the analytics tables
+  (`feedback`, `contact_submissions`, `sessions`) for the data connection —
+  never the app's read/write credentials.
+- Put it behind authentication (Metabase has its own user management; optional
+  SSO) and restrict ingress.
+- Store the DB credentials as Container App secrets, same pattern as the backend.
+
+### Dashboard content (phase 1)
+
+Rebuild the digest's metrics as Metabase questions/dashboard cards:
+feedback total + positive ratio + recent negative comments, contact submissions
+by subject, active/new sessions, web-vs-mobile split, top languages, plus
+week-over-week and longer trend lines that the email can't show.
+
+### Email migration
+
+Once the dashboard exists, switch the weekly Sunday email from the custom
+endpoint to a **Metabase dashboard subscription**. Keep
+`api/routes/admin.py` + the `weekly-report.yml` workflow as a lightweight,
+no-dashboard fallback, or retire them — decide at migration time.
+
+### Phase 2 — unify Android/Firebase engagement
+
+Bring GA4 / Firebase Analytics (Android screen views, verse taps, retention)
+into the picture — either export **GA4 → BigQuery** and add BigQuery as a
+second Metabase data source, or stand up a **Looker Studio** board native to
+GA4 and link it alongside. This is also where the Firebase work deferred from
+the weekly-email story lands.
+
+## Alternatives considered
+
+- **Grafana** — excellent for ops/time-series and can read Postgres, but it is
+  observability-oriented, not built for business reporting, and weak on
+  scheduled business-KPI emails. Keep it for SRE, not this.
+- **Looker Studio (free, Google)** — native GA4/Firebase connector; best
+  reserved for the Android-engagement piece (phase 2). Can read Postgres via a
+  connector but is less ergonomic for self-hosted SQL than Metabase.
+- **Extend the Azure Monitor Workbook** — wrong data source (App Insights, not
+  Postgres) and KQL-only authoring; not suited to feedback/business analytics.
+
+## Acceptance Criteria
+
+- [ ] Metabase runs as a Terraform-managed Azure Container App with its own
+      metadata DB.
+- [ ] A **read-only** Postgres role scoped to `feedback`, `contact_submissions`,
+      `sessions` is created and used for the Metabase data connection.
+- [ ] Metabase is behind authentication; ingress is restricted.
+- [ ] A dashboard reproduces the weekly digest metrics (feedback, contact,
+      engagement) plus trend views.
+- [ ] A weekly Metabase email subscription is configured to
+      `weekly_report_recipient`; the custom `weekly-report.yml` cron is then
+      disabled or documented as fallback.
+- [ ] Setup documented in `deployment/README.md`.
+
+## Out of Scope
+
+- Phase-2 GA4/Firebase/BigQuery integration (tracked as a follow-up).
+- Replacing or modifying the SRE Azure Monitor workbook.
+- Embedding the dashboard in the public web app (internal/admin use only).
+
+## Dependencies / Prerequisites
+
+- Weekly digest story (the metric SQL in `api/reports/weekly_report.py` is the
+  reference for the dashboard cards).
+- Read-only DB role provisioning on the production Postgres server.
+
+## Assignee
+
+devops / backend


### PR DESCRIPTION
## Summary

Adds a **weekly activity digest email** — a Sunday snapshot of what's happening across both the web app and the Android app (both hit the same API, so the backend-DB view covers both) — and a backlog story planning the medium/long-term interactive dashboard it leads toward.

### Story 1 — Weekly digest email
- **`api/reports/weekly_report.py`** — pure, testable builder over the Postgres `feedback`, `contact_submissions`, and `sessions` tables for the last 7 days: positive/negative ratio, recent negative comments, contact submissions by subject, active/new sessions, web-vs-mobile split, top languages, and week-over-week deltas. Text + HTML renderers; user-supplied text is HTML-escaped; empty-data safe (no divide error).
- **`api/routes/admin.py`** — `POST /api/v1/admin/weekly-report`, gated by the existing monitor-probe shared secret (`X-Monitor-Probe-Secret`, fail-closed), with a `dry_run` flag. Returns `{dry_run, email_sent, report}`.
- **`.github/workflows/weekly-report.yml`** — cron `0 18 * * 0` (Sun 18:00 UTC) + `workflow_dispatch`; triggers the endpoint and fails the job if a live run did not actually send (catches SMTP misconfig).
- **`api/config.py`** — `weekly_report_recipient` (default `support@voxquieta.org`), independent of the contact-form recipient.
- Router wiring in `api/main.py` / `api/routes/__init__.py`.

### Story 2 — Dashboard planning
- **`docs/BACKLOG_STORIES/BITB-043-product-analytics-dashboard.md`** — recommends self-hosted **Metabase** against the existing Postgres (business analytics + built-in scheduled email subscriptions), with the email as a deliberate stepping stone, a migration path, and a phase-2 GA4/Firebase note. Explains why the existing Azure Monitor workbook (SRE/ops over App Insights) doesn't fit this need.

## Reuses existing infra
- SMTP2GO `email_service` singleton, the `monitor_probe` shared-secret gate (same as `prod-monitor.yml`), and `vars.BACKEND_URL` / `secrets.MONITOR_PROBE_SECRET` — **no new credentials**.

## Testing
- `api/tests/test_weekly_report.py` — builder incl. empty-data edge + HTML escaping.
- `api/tests/test_admin_report.py` — endpoint auth (missing/wrong/unset-secret → 401), authorized send, and dry-run-doesn't-send.
- 8/8 new tests pass; 104 adjacent tests (`test_monitor_probe`, `test_email_service`, `test_config_validation`, `test_routes_main_coverage`) still green; `ruff` + `black` clean.

## Operational notes
- Requires `support@voxquieta.org` to be a real mailbox and the deployed backend to have `smtp2go_enabled=True` + `smtp2go_api_key` set; otherwise the digest is computed but `email_sent:false` (the first live workflow run will flag this).
- Out of scope (v1): Firebase/GA4 Android in-app engagement — deferred, lands in the dashboard story's phase 2.

https://claude.ai/code/session_01KFk1wvaNerikVCh3wMQBZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFk1wvaNerikVCh3wMQBZY)_