### PR TITLE
feat: require contact email and make negative feedback actionable (BITB-043)

### DIFF
--- a/.claude/commands/plan-build-verify.md
+++ b/.claude/commands/plan-build-verify.md
@@ -1,0 +1,53 @@
+---
+description: Run a task through the Plan (Opus) → Build (Sonnet) → Verify (Opus) relay
+argument-hint: <task description>
+---
+
+Run the task below through this project's standard **Plan → Build → Verify**
+relay (see `AGENTS.md` → *Standard Workflow*). Do not shortcut it for anything
+beyond a trivial one-line change.
+
+## Task
+
+$ARGUMENTS
+
+## Stage 1 — Plan (you, Opus)
+
+1. Explore before deciding: read the files involved and search for existing
+   functions, utilities, and patterns to reuse instead of writing new code.
+2. Resolve any genuine ambiguity with the user via `AskUserQuestion` *before*
+   writing the plan — do not guess on decisions that change the outcome.
+3. Write an explicit plan: the problem/why, the precise change per file, and a
+   verification section (which tests/commands prove it works).
+4. Create or update the backlog story and `docs/BACKLOG.md` entry per
+   *Backlog Hygiene* in `AGENTS.md` (sequential `BITB-NNN`).
+
+## Stage 2 — Build (delegate to Sonnet)
+
+Launch a single `Agent` with `subagent_type: general-purpose` and
+`model: sonnet`, handing it the full approved plan as its brief. It must:
+
+- Make all code, test, migration, and i18n changes on the current feature branch.
+- Follow `AGENTS.md` (code style, every-change-ships-with-tests, i18n in all 11
+  locales, conventional commits).
+- Report exactly what it changed (files + a short summary), and NOT open a PR
+  unless the user explicitly asked for one.
+
+## Stage 3 — Verify (delegate to Opus)
+
+Launch a *separate* `Agent` with `model: opus` (read-capable, e.g.
+`subagent_type: general-purpose` or the `verify` skill). It must, independently:
+
+- Run the backend tests, frontend tests/lint/type-check, and Android tests if
+  those areas were touched (commands in `AGENTS.md` → *Testing*).
+- Review the diff against the plan's acceptance criteria.
+- Report **PASS/FAIL with evidence** (test output, specific gaps). It must not
+  rubber-stamp — call out anything missing or untested.
+
+## Close-out
+
+- Fix any gaps the verifier found (re-delegating to Sonnet if substantial).
+- Mark the story status and update `docs/BACKLOG.md`.
+- Summarize for the user: what changed, test results, and any follow-ups.
+- Commit/push only when the user has asked; never push to a closed/merged PR
+  branch.

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ frontend/.playwright/
 .claude/*
 !.claude/agents/
 !.claude/skills/
+!.claude/commands/
 verify_acpx_claude.txt
 
 # Patch files and conflict rejects

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,34 @@ in responses, linking them to scripture. Deployed on Azure.
 **Tech stack:** Python 3.12 / FastAPI / PostgreSQL 16 + pgvector /
 Next.js / React / TypeScript / Kotlin / Jetpack Compose / Terraform / Azure
 
+## Standard Workflow: Plan → Build → Verify
+
+**This is the default operating procedure for any non-trivial task** (a feature,
+a bug fix, or a refactor — anything beyond a true one-line/typo change). It runs
+as a three-stage relay across models so that planning and verification are done
+by a stronger model and the bulk implementation by a faster one:
+
+1. **Plan — Opus.** Explore the codebase first (read the relevant files, find
+   existing utilities/patterns to reuse), then write an explicit plan: the
+   problem, the precise changes per file, and how it will be verified. Resolve
+   ambiguity with the user *before* coding, not after. Also create/update the
+   backlog story (see *Backlog Hygiene*) as part of planning.
+2. **Build — Sonnet.** Delegate the implementation to a Sonnet subagent
+   (`Agent` with `model: sonnet`), handing it the approved plan as its brief.
+   It makes all the code, test, migration, and i18n changes on the feature branch.
+3. **Verify — Opus.** Spin up a *separate* Opus subagent (`Agent` with
+   `model: opus`) to independently run the backend + frontend (+ Android, if
+   touched) test suites and review the diff against the plan's acceptance
+   criteria. It reports pass/fail with evidence; the main session fixes any gaps
+   it finds before commit/PR.
+
+This composes with — it does not replace — the **Testing** rule (every change
+ships with tests) and **Backlog Hygiene** (every change has a story). Trivial
+one-liners may skip the relay, but still need tests where behaviour changes.
+
+> One-shot entry point: the `/plan-build-verify <task>` slash command
+> (`.claude/commands/plan-build-verify.md`) runs this relay end to end.
+
 ## Repository Layout
 
 ```text

--- a/api/feedback/models.py
+++ b/api/feedback/models.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
@@ -36,6 +36,9 @@ class FeedbackRequest(BaseModel):
     model_used: str | None = Field(None, description="LLM model that generated the response")
     response_time_ms: int | None = Field(None, description="Response generation time in ms")
     session_id: str | None = Field(None, description="Optional session identifier")
+    reason: str | None = Field(
+        None, description="Optional category of what went wrong (negative feedback)"
+    )
 
 
 class FeedbackResponse(BaseModel):
@@ -50,7 +53,7 @@ class FeedbackResponse(BaseModel):
 class ContactRequest(BaseModel):
     """Request model for contact form submission."""
 
-    email: str | None = Field(None, description="Optional reply email address")
+    email: EmailStr = Field(..., description="Reply email address")
     subject: Literal["spiritual", "bug", "feature", "feedback", "other"] = Field(
         ..., description="Subject category"
     )
@@ -88,6 +91,7 @@ class Feedback(Base):
     verses_cited: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
     model_used: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     response_time_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    reason: Mapped[Optional[str]] = mapped_column(String(40), nullable=True)
 
     def __repr__(self) -> str:
         return f"<Feedback(id={self.id}, rating='{self.rating}', message_id='{self.message_id}')>"

--- a/api/feedback/repository.py
+++ b/api/feedback/repository.py
@@ -38,6 +38,7 @@ class FeedbackRepository:
             verses_cited=request.verses_cited,
             model_used=request.model_used,
             response_time_ms=request.response_time_ms,
+            reason=request.reason,
             created_at=datetime.now(UTC),
         )
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "getinspiredbythebible-api"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "email-validator>=2.2.0",
+]
+
 [tool.black]
 line-length = 100
 target-version = ['py312']

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,6 +3,7 @@ fastapi==0.136.3
 uvicorn[standard]==0.48.0
 pydantic==2.13.4
 pydantic-settings==2.14.1
+email-validator==2.2.0
 
 # Database
 sqlalchemy==2.0.50

--- a/api/routes/feedback.py
+++ b/api/routes/feedback.py
@@ -64,13 +64,21 @@ async def submit_feedback(
             extra={"feedback_id": feedback.id, "rating": feedback.rating},
         )
 
-        # Send email notification for negative feedback
-        if request.rating == "negative":
+        # Send email notification for negative feedback, or positive with a comment
+        should_notify = request.rating == "negative" or (
+            request.rating == "positive" and bool(request.comment)
+        )
+        if should_notify:
             email_service.send_feedback_notification(
                 rating=request.rating,
                 comment=request.comment,
                 user_message=request.user_message,
                 assistant_response=request.assistant_response,
+                message_id=request.message_id,
+                verses_cited=request.verses_cited,
+                model_used=request.model_used,
+                response_time_ms=request.response_time_ms,
+                reason=request.reason,
             )
 
         return FeedbackResponse(

--- a/api/tests/test_email_service.py
+++ b/api/tests/test_email_service.py
@@ -361,8 +361,13 @@ class TestSendFeedbackNotification:
                 assert result is True
                 mock_client_instance.post.assert_called_once()
 
-    def test_feedback_notification_skips_positive(self):
-        """Test that notification is skipped for positive feedback."""
+    def test_feedback_notification_renders_positive(self):
+        """Positive feedback now renders and sends; gating moved to the route.
+
+        ``send_feedback_notification`` renders whatever rating it is given —
+        the decision of *when* to notify (negative, or positive with a comment)
+        lives in the route. So a direct call for positive feedback sends.
+        """
         with patch("utils.email_service.settings") as mock_settings:
             mock_settings.smtp2go_enabled = True
             mock_settings.smtp2go_api_key = "test-api-key"  # pragma: allowlist secret
@@ -374,8 +379,13 @@ class TestSendFeedbackNotification:
 
             service = EmailService()
 
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"data": {"succeeded": 1}}
+
             with patch("httpx.Client") as mock_client:
                 mock_client_instance = MagicMock()
+                mock_client_instance.post.return_value = mock_response
                 mock_client.return_value.__enter__.return_value = mock_client_instance
 
                 result = service.send_feedback_notification(
@@ -385,12 +395,13 @@ class TestSendFeedbackNotification:
                     assistant_response="Love is...",
                 )
 
-                # Should return True (success) but not send email
                 assert result is True
-                mock_client_instance.post.assert_not_called()
+                mock_client_instance.post.assert_called_once()
+                payload = mock_client_instance.post.call_args[1]["json"]
+                assert "Positive" in payload["subject"]
 
-    def test_feedback_notification_truncates_long_messages(self):
-        """Test that long messages are truncated to 500 chars."""
+    def test_feedback_notification_includes_full_messages(self):
+        """Long messages are sent in full — no 500-char truncation."""
         with patch("utils.email_service.settings") as mock_settings:
             mock_settings.smtp2go_enabled = True
             mock_settings.smtp2go_api_key = "test-api-key"  # pragma: allowlist secret
@@ -422,10 +433,9 @@ class TestSendFeedbackNotification:
 
                 call_args = mock_client_instance.post.call_args
                 payload = call_args[1]["json"]
-                # Check that the text body contains truncated messages
-                # Should have "A" * 500 + "..."
-                assert "A" * 500 in payload["text_body"]
-                assert "..." in payload["text_body"]
+                # The full 600-char message is present, untruncated.
+                assert "A" * 600 in payload["text_body"]
+                assert "..." not in payload["text_body"]
 
     def test_feedback_notification_handles_no_comment(self):
         """Test feedback notification with no comment."""

--- a/api/tests/test_feedback.py
+++ b/api/tests/test_feedback.py
@@ -182,6 +182,7 @@ class TestContactEndpoint:
         response = client.post(
             "/api/v1/feedback/contact",
             json={
+                "email": "user@example.com",
                 "subject": "feature",
                 "message": "It would be great to have a dark mode option.",
             },
@@ -193,6 +194,7 @@ class TestContactEndpoint:
         response = client.post(
             "/api/v1/feedback/contact",
             json={
+                "email": "user@example.com",
                 "subject": "feedback",
                 "message": "I love this app! It's been very helpful for my Bible study.",
             },
@@ -225,6 +227,7 @@ class TestContactEndpoint:
             response = client.post(
                 "/api/v1/feedback/contact",
                 json={
+                    "email": "user@example.com",
                     "subject": "spiritual",
                     "message": "I am struggling with doubt. Can you share a verse?",
                 },
@@ -268,7 +271,7 @@ class TestContactEndpoint:
         assert response.status_code == 422
 
     def test_submit_contact_no_email(self):
-        """Test that email is optional."""
+        """Test that email is now required — omitting it returns 422."""
         response = client.post(
             "/api/v1/feedback/contact",
             json={
@@ -276,8 +279,31 @@ class TestContactEndpoint:
                 "message": "Just wanted to say thanks!",
             },
         )
-        # Should succeed without email
-        assert response.status_code in [200, 500]
+        # Email is required; missing email must be rejected
+        assert response.status_code == 422
+
+    def test_submit_contact_missing_email(self):
+        """Test that missing email is rejected with 422."""
+        response = client.post(
+            "/api/v1/feedback/contact",
+            json={
+                "subject": "feature",
+                "message": "It would be great to have a dark mode option.",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_submit_contact_invalid_email(self):
+        """Test that an invalid email address is rejected with 422."""
+        response = client.post(
+            "/api/v1/feedback/contact",
+            json={
+                "email": "not-an-email",
+                "subject": "feedback",
+                "message": "Some feedback.",
+            },
+        )
+        assert response.status_code == 422
 
 
 class TestFeedbackEmailIntegration:
@@ -302,24 +328,23 @@ class TestFeedbackEmailIntegration:
         # Endpoint should succeed (or fail due to DB, not email)
         assert response.status_code in [200, 500]
 
-        # Verify email service was called with correct params
+        # Verify email service was called with correct core params
         if response.status_code == 200:
-            mock_email_service.send_feedback_notification.assert_called_once_with(
-                rating="negative",
-                comment="The response wasn't helpful.",
-                user_message="How can I find peace?",
-                assistant_response="Let me help you find peace...",
-            )
+            call_kwargs = mock_email_service.send_feedback_notification.call_args.kwargs
+            assert call_kwargs["rating"] == "negative"
+            assert call_kwargs["comment"] == "The response wasn't helpful."
+            assert call_kwargs["user_message"] == "How can I find peace?"
+            assert call_kwargs["assistant_response"] == "Let me help you find peace..."
+            mock_email_service.send_feedback_notification.assert_called_once()
 
     @patch("routes.feedback.email_service")
-    def test_positive_feedback_skips_email(self, mock_email_service):
-        """Test that positive feedback does NOT trigger email notification."""
+    def test_positive_feedback_bare_skips_email(self, mock_email_service):
+        """Test that bare positive feedback (no comment) does NOT trigger email notification."""
         response = client.post(
             "/api/v1/feedback",
             json={
                 "message_id": str(uuid.uuid4()),
                 "rating": "positive",
-                "comment": "Great response!",
                 "user_message": "What does the Bible say about hope?",
                 "assistant_response": "The Bible speaks about hope...",
             },
@@ -327,8 +352,33 @@ class TestFeedbackEmailIntegration:
 
         assert response.status_code in [200, 500]
 
-        # Email should NOT be called for positive feedback
+        # Email should NOT be called for bare positive feedback (no comment)
         mock_email_service.send_feedback_notification.assert_not_called()
+
+    @patch("routes.feedback.email_service")
+    def test_positive_feedback_with_comment_sends_email(self, mock_email_service):
+        """Test that positive feedback WITH a comment triggers email notification."""
+        mock_email_service.send_feedback_notification.return_value = True
+
+        response = client.post(
+            "/api/v1/feedback",
+            json={
+                "message_id": str(uuid.uuid4()),
+                "rating": "positive",
+                "comment": "Great response! The verse was perfect.",
+                "user_message": "What does the Bible say about hope?",
+                "assistant_response": "The Bible speaks about hope...",
+            },
+        )
+
+        assert response.status_code in [200, 500]
+
+        # Email SHOULD be called for positive feedback with a comment
+        if response.status_code == 200:
+            mock_email_service.send_feedback_notification.assert_called_once()
+            call_kwargs = mock_email_service.send_feedback_notification.call_args.kwargs
+            assert call_kwargs["rating"] == "positive"
+            assert call_kwargs["comment"] == "Great response! The verse was perfect."
 
     @patch("routes.feedback.email_service")
     def test_feedback_succeeds_when_email_fails(self, mock_email_service):
@@ -380,13 +430,14 @@ class TestContactEmailIntegration:
             )
 
     @patch("routes.feedback.email_service")
-    def test_contact_sends_email_without_reply_email(self, mock_email_service):
-        """Test contact notification with no reply email provided."""
+    def test_contact_sends_email_with_reply_email(self, mock_email_service):
+        """Test contact notification with reply email provided."""
         mock_email_service.send_contact_notification.return_value = True
 
         response = client.post(
             "/api/v1/feedback/contact",
             json={
+                "email": "user@example.com",
                 "subject": "feedback",
                 "message": "Great app!",
             },
@@ -398,7 +449,7 @@ class TestContactEmailIntegration:
             mock_email_service.send_contact_notification.assert_called_once_with(
                 subject_type="feedback",
                 message="Great app!",
-                reply_email=None,
+                reply_email="user@example.com",
                 user_agent=None,
             )
 
@@ -410,6 +461,7 @@ class TestContactEmailIntegration:
         response = client.post(
             "/api/v1/feedback/contact",
             json={
+                "email": "user@example.com",
                 "subject": "feature",
                 "message": "Please add dark mode.",
             },
@@ -438,7 +490,7 @@ class TestContactRequestModel:
         ValidationError and the endpoint returns 422.
         """
         for subject in ("spiritual", "bug", "feature", "feedback", "other"):
-            req = ContactRequest(subject=subject, message="Test message")
+            req = ContactRequest(email="user@example.com", subject=subject, message="Test message")
             assert req.subject == subject, f"ContactRequest rejected subject='{subject}'"
 
     def test_spiritual_subject_is_valid(self):
@@ -450,19 +502,37 @@ class TestContactRequestModel:
         causing HTTP 500 on every contact form submission with subject='spiritual'.
         Pairing this test with TestContactRouteWithMockedDB gives full coverage.
         """
-        req = ContactRequest(subject="spiritual", message="I need guidance from the Bible.")
+        req = ContactRequest(
+            email="user@example.com",
+            subject="spiritual",
+            message="I need guidance from the Bible.",
+        )
         assert req.subject == "spiritual"
         assert req.message == "I need guidance from the Bible."
+
+    def test_email_required(self):
+        """Email is now required — omitting it raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ContactRequest(subject="feedback", message="Test message.")
+
+    def test_invalid_email_rejected(self):
+        """Invalid email format must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ContactRequest(email="not-an-email", subject="feedback", message="Test message.")
 
     def test_invalid_subject_rejected(self):
         """Non-allowed subjects must be rejected with a ValidationError."""
         with pytest.raises(ValidationError):
-            ContactRequest(subject="question", message="This should fail.")
+            ContactRequest(
+                email="user@example.com", subject="question", message="This should fail."
+            )
 
     def test_all_subjects_roundtrip(self):
         """All valid subjects survive a JSON round-trip (model_dump → model_validate)."""
         for subject in ("spiritual", "bug", "feature", "feedback", "other"):
-            req = ContactRequest(subject=subject, message="Round-trip test")
+            req = ContactRequest(
+                email="user@example.com", subject=subject, message="Round-trip test"
+            )
             data = req.model_dump()
             restored = ContactRequest.model_validate(data)
             assert restored.subject == subject
@@ -502,6 +572,7 @@ class TestContactRouteWithMockedDB:
         mock_repo.save_contact = AsyncMock(return_value=mock_submission)
 
         request = ContactRequest(
+            email="user@example.com",
             subject="spiritual",
             message="I am struggling with doubt. Please share a verse about faith.",
         )
@@ -539,6 +610,7 @@ class TestContactRouteWithMockedDB:
         )
 
         request = ContactRequest(
+            email="user@example.com",
             subject="spiritual",
             message="Help me find a verse about hope.",
         )

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -615,6 +615,7 @@ class TestFeedbackRoutes:
         request = ContactRequest(
             subject="feedback",
             message="Great app!",
+            email="user@example.com",
         )
 
         with patch("routes.feedback.email_service") as mock_email:
@@ -636,6 +637,7 @@ class TestFeedbackRoutes:
         request = ContactRequest(
             subject="bug",
             message="Test message",
+            email="user@example.com",
         )
 
         with pytest.raises(HTTPException) as exc_info:

--- a/api/utils/email_service.py
+++ b/api/utils/email_service.py
@@ -193,43 +193,107 @@ User Agent: {user_agent or 'Not provided'}
         comment: str | None,
         user_message: str,
         assistant_response: str,
+        message_id: str | None = None,
+        verses_cited: list[str] | None = None,
+        model_used: str | None = None,
+        response_time_ms: int | None = None,
+        reason: str | None = None,
     ) -> bool:
         """
-        Send notification for negative feedback (for quality monitoring).
+        Send notification for feedback that warrants maintainer attention.
 
-        Only sends for negative feedback to alert about potential issues.
+        Sends for negative feedback, or positive feedback with a comment.
+        The caller decides when to invoke this; this method renders whatever
+        rating is passed.
 
         Args:
             rating: positive or negative
             comment: User's optional comment
             user_message: Original user question
             assistant_response: AI response that received feedback
+            message_id: Optional chat message UUID
+            verses_cited: Optional list of verse references
+            model_used: LLM model that generated the response
+            response_time_ms: Response generation time in ms
+            reason: Optional category of what went wrong (negative feedback)
 
         Returns:
             True if sent successfully
         """
-        # Only notify on negative feedback
-        if rating != "negative":
-            return True
-
         to_email = settings.contact_notification_email
-        subject = "[Vox Quieta] Negative Feedback Received"
+        rating_label = "Negative" if rating == "negative" else "Positive"
+        subject = f"[Vox Quieta] {rating_label} Feedback Received"
+
+        verses_str = ", ".join(verses_cited) if verses_cited else "None"
 
         body_text = f"""
-Negative feedback received on a response:
+{rating_label} feedback received on a response:
 
 User Comment: {comment or 'No comment provided'}
+Reason: {reason or 'Not specified'}
 
 ---
 Original Question:
-{user_message[:500]}{'...' if len(user_message) > 500 else ''}
+{user_message}
 
 ---
 AI Response:
-{assistant_response[:500]}{'...' if len(assistant_response) > 500 else ''}
+{assistant_response}
+
+---
+Metadata:
+Model: {model_used or 'Not specified'}
+Response time (ms): {response_time_ms if response_time_ms is not None else 'Not specified'}
+Verses cited: {verses_str}
+Message ID: {message_id or 'Not specified'}
         """.strip()
 
-        return self.send_email(to_email, subject, body_text)
+        body_html = f"""
+<html>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <h2 style="color: {'#c0392b' if rating == 'negative' else '#27ae60'};">{rating_label} Feedback Received</h2>
+
+    <h3>Comment</h3>
+    <div style="background: #f9f9f9; padding: 15px; border-left: 4px solid {'#c0392b' if rating == 'negative' else '#27ae60'}; margin: 10px 0;">
+        {(comment or '<em>No comment provided</em>').replace(chr(10), '<br>')}
+    </div>
+
+    {f'<h3>Reason</h3><div style="display:inline-block; background:#e8e8e8; padding:4px 10px; border-radius:12px; font-size:13px;">{reason}</div>' if reason else ''}
+
+    <h3>Original Question</h3>
+    <div style="background: #f9f9f9; padding: 15px; border-left: 4px solid #5c6ac4; margin: 10px 0;">
+        {user_message.replace(chr(10), '<br>')}
+    </div>
+
+    <h3>AI Response</h3>
+    <div style="background: #f9f9f9; padding: 15px; border-left: 4px solid #5c6ac4; margin: 10px 0;">
+        {assistant_response.replace(chr(10), '<br>')}
+    </div>
+
+    <h3>Metadata</h3>
+    <table style="border-collapse: collapse; margin: 10px 0;">
+        <tr>
+            <td style="padding: 6px 12px; font-weight: bold; background: #f5f5f5;">Model</td>
+            <td style="padding: 6px 12px;">{model_used or '<em>Not specified</em>'}</td>
+        </tr>
+        <tr>
+            <td style="padding: 6px 12px; font-weight: bold; background: #f5f5f5;">Response time (ms)</td>
+            <td style="padding: 6px 12px;">{response_time_ms if response_time_ms is not None else '<em>Not specified</em>'}</td>
+        </tr>
+        <tr>
+            <td style="padding: 6px 12px; font-weight: bold; background: #f5f5f5;">Verses cited</td>
+            <td style="padding: 6px 12px;">{verses_str}</td>
+        </tr>
+        <tr>
+            <td style="padding: 6px 12px; font-weight: bold; background: #f5f5f5;">Message ID</td>
+            <td style="padding: 6px 12px;">{message_id or '<em>Not specified</em>'}</td>
+        </tr>
+    </table>
+</body>
+</html>
+        """.strip()
+
+        return self.send_email(to_email, subject, body_text, body_html)
 
 
 # Singleton instance

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Prioritized list of user stories and features for Vox Quieta.
 
-**Last Updated:** 2026-06-05
+**Last Updated:** 2026-06-08
 
 **Verification Note (2026-04-20):** PR status reconciliation pass completed against GitHub.
 Confirmed merged PRs: #68, #171, #182, #191, #193, #194, #195, #196, #197, #208, #225, #226,
@@ -682,6 +682,35 @@ Testing & Documentation:
 ---
 
 ## P2 - Medium Priority (Backlog)
+
+### 🚧 BITB-043: Require Contact Email + Full Feedback Email Content + Negative-Feedback Reason Chips
+
+**Status:** 🚧 In Progress
+**Size:** M (1-2 days)
+**Created:** 2026-06-08
+
+**As a** user submitting a contact form or leaving feedback,
+**I want** to be prompted for my email (so the team can actually reply) and to quickly label
+what went wrong on a thumbs-down with a single-tap reason chip,
+**so that** the team can follow up and act on precise, categorised feedback.
+
+**Acceptance Criteria:**
+
+- [ ] POST `/api/v1/feedback/contact` without email → HTTP 422 (email is required)
+- [ ] POST `/api/v1/feedback/contact` with invalid email → HTTP 422
+- [ ] Contact form send button disabled when email is empty; input has `required`
+- [ ] `Contact.emailLabel` updated to required phrasing in all 11 locales
+- [ ] Negative feedback email includes full (untruncated) user message and AI response + HTML + metadata
+- [ ] Positive feedback WITH comment triggers maintainer email; bare positive does not
+- [ ] Thumbs-down panel shows 5 reason chips; selected chip passed as `reason` to `onSubmit`
+- [ ] Chip selection is optional — auto-commit still works without it
+- [ ] `reason` column added to `feedback` table (migration 006)
+- [ ] All 11 locales have 6 new reason keys + updated `emailLabel`
+- [ ] Backend + frontend tests pass
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-043-require-contact-email-and-actionable-negative-feedback.md`
+
+---
 
 ### 🚧 BITB-042: Feedback "Rethink" Delay + Explicit Maintainer-Sharing Notice on Thumbs-Down
 

--- a/docs/BACKLOG_STORIES/BITB-043-require-contact-email-and-actionable-negative-feedback.md
+++ b/docs/BACKLOG_STORIES/BITB-043-require-contact-email-and-actionable-negative-feedback.md
@@ -1,0 +1,120 @@
+# BITB-043: Require Contact Email + Full Feedback Email Content + Negative-Feedback Reason Chips
+
+**Status:** 🚧 In Progress
+**Priority:** P2
+**Size:** M (1-2 days)
+**Created:** 2026-06-08
+
+## User Story
+
+**As a** user submitting a contact form or leaving feedback,
+**I want** to be prompted for my email address (so the team can actually reply),
+and when I leave negative feedback I want to quickly label what went wrong with a single tap,
+**so that** the team can follow up with me and act on precise, categorised feedback rather
+than guessing what the problem was.
+
+## Why
+
+1. **Contact form without email = dead end.** The current contact form makes email optional.
+   In practice most users do not fill it in, leaving the team with a message they cannot
+   follow up on. Making email required closes that loop.
+
+2. **Feedback emails were truncated and content-poor.** The maintainer email sent on negative
+   feedback silently cut the user message and AI response at 500 characters (losing context),
+   lacked structured metadata (model, response time, verses cited, message ID), and had no HTML
+   formatting. A bare positive rating with a comment also went silently into the DB but sent
+   no email — the team never saw it.
+
+3. **Negative feedback has no category.** A thumbs-down means "something was wrong" but not
+   *what* was wrong. Five quick-tap reason chips (Inaccurate / Unhelpful / Wrong verse / Tone /
+   Other) let the user express the failure type in one tap, giving the team actionable signal
+   without asking them to write an essay.
+
+## Current Behaviour
+
+- `ContactRequest.email` is optional (`str | None`); the frontend sends it only if filled in.
+- The submit button is not blocked when email is empty.
+- `send_feedback_notification` only fires on `rating == "negative"`, truncates both message
+  fields at 500 characters, has no HTML, and no metadata table.
+- `FeedbackRequest` and the `Feedback` SQLAlchemy model have no `reason` field (the plan
+  already added it, but the UI and email path do not use it).
+- No "What went wrong?" chips in `FeedbackControls.tsx`.
+
+## Proposed Behaviour
+
+### Contact form — email required
+
+- Backend: `ContactRequest.email: EmailStr = Field(...)` — required, validated.
+- Frontend: `required` attribute on the `<input type="email">`, guard in `handleSubmit`,
+  disabled send button when email is empty, body sends `email: email.trim()` (not `|| undefined`).
+- i18n: `Contact.emailLabel` updated to "Your email (for our reply)" in all 11 locales.
+
+### Feedback email — full content + context + HTML + positive-with-comment
+
+- Route: also notifies maintainer when `rating == "positive"` AND comment is non-empty.
+- Route: passes all fields (message_id, verses_cited, model_used, response_time_ms, reason)
+  to `send_feedback_notification`.
+- Email service: removes the `if rating != "negative": return True` early-exit guard.
+- Email service: removes all truncation — full user message and AI response rendered.
+- Email service: adds HTML body with sectioned layout (Comment, Reason chip, Original
+  Question, AI Response, metadata table).
+
+### "What went wrong?" reason chips — negative panel only
+
+- `FeedbackControls.tsx` adds a `reason` state (string | null) and renders five quick-tap
+  chips (Inaccurate, Unhelpful, Wrong verse, Tone, Other) when `pending === "negative"`.
+- Selecting a chip is optional — auto-commit still proceeds without it.
+- `onSubmit` prop widened: `(rating, comment, reason?) => void`.
+- Wiring through `ChatMessage.tsx` → `ChatIsland.tsx` → `FeedbackRequest.reason`.
+- New migration `scripts/migrations/006_add_feedback_reason.py` adds
+  `ALTER TABLE feedback ADD COLUMN IF NOT EXISTS reason VARCHAR(40)`.
+
+## Acceptance Criteria
+
+- [ ] POST `/api/v1/feedback/contact` without email → HTTP 422
+- [ ] POST `/api/v1/feedback/contact` with invalid email → HTTP 422
+- [ ] POST `/api/v1/feedback/contact` with valid email → HTTP 200/500 (depending on DB)
+- [ ] Frontend contact form: send button disabled when email is empty; `required` on input
+- [ ] `Contact.emailLabel` updated in all 11 locale files to required phrasing
+- [ ] Negative feedback email sent with full (untruncated) user message and AI response
+- [ ] Positive feedback WITH a comment triggers a maintainer email
+- [ ] Positive feedback WITHOUT a comment sends no email (unchanged)
+- [ ] Maintainer email includes HTML body with metadata table (model, response time, verses, ID)
+- [ ] Thumbs-down panel shows 5 reason chips; selecting one then Send passes it to `onSubmit`
+- [ ] Chip selection is optional — auto-commit still works without it
+- [ ] `reason` persisted to DB via `Feedback.reason` column
+- [ ] Migration 006 adds `reason VARCHAR(40)` column safely (`IF NOT EXISTS`)
+- [ ] All 11 locale files have `reasonPrompt`, `reasonInaccurate`, `reasonUnhelpful`,
+      `reasonWrongVerse`, `reasonTone`, `reasonOther`
+- [ ] Backend tests pass: `test_submit_contact_missing_email` and
+      `test_submit_contact_invalid_email` assert 422
+- [ ] Frontend tests: reason chips coverage in `FeedbackControls.test.tsx`
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `api/feedback/models.py` | `ContactRequest.email` required; `FeedbackRequest.reason` + SQLAlchemy column (already in plan) |
+| `api/requirements.txt` | `email-validator` (already present) |
+| `api/pyproject.toml` | `email-validator` dependency (already present) |
+| `api/routes/feedback.py` | Broaden email trigger; pass all fields |
+| `api/utils/email_service.py` | Full content, HTML, no truncation, new params |
+| `api/feedback/repository.py` | `reason=request.reason` on `Feedback(...)` |
+| `api/tests/test_feedback.py` | Add email to fixtures; new 422 tests; update email call assertions |
+| `scripts/migrations/006_add_feedback_reason.py` | New migration |
+| `frontend/src/components/ContactForm.tsx` | `required`, guard, body change |
+| `frontend/src/components/FeedbackControls.tsx` | `reason` state, chips, widened `onSubmit` |
+| `frontend/src/components/ChatMessage.tsx` | Widened `onSubmitFeedback` type |
+| `frontend/src/app/[locale]/ChatIsland.tsx` | `reason` param wiring |
+| `frontend/src/lib/api.ts` | `reason?: string` on `FeedbackRequest` |
+| `frontend/messages/*.json` | `emailLabel` + 6 reason keys in all 11 locales |
+| `frontend/src/components/FeedbackControls.test.tsx` | New chip coverage tests |
+| `docs/BACKLOG.md` | Summary entry |
+| `docs/BACKLOG_STORIES/BITB-043-*.md` | This file |
+
+## Out of Scope
+
+- Android parity for reason chips — track separately if desired.
+- Changing `contact_submissions.email` DB column (stays nullable for historical rows).
+- Making the reason chips available on thumbs-up feedback.
+- Changing the email routing destination (handled by BITB-032).

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -171,7 +171,13 @@
     "submit": "إرسال الملاحظات",
     "submitting": "جارٍ الإرسال...",
     "close": "إغلاق",
-    "toastError": "تعذر حفظ ملاحظاتك الآن، لكن شكراً على المحاولة!"
+    "toastError": "تعذر حفظ ملاحظاتك الآن، لكن شكراً على المحاولة!",
+    "reasonPrompt": "ماذا حدث خطأ؟",
+    "reasonInaccurate": "غير دقيق",
+    "reasonUnhelpful": "غير مفيد",
+    "reasonWrongVerse": "آية خاطئة",
+    "reasonTone": "الأسلوب",
+    "reasonOther": "أخرى"
   },
   "ChurchFinder": {
     "bannerText": "هل تبحث عن مجتمع إيماني؟",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "تواصل معنا",
     "emailUs": "راسلنا:",
-    "emailLabel": "بريدك الإلكتروني (اختياري، للرد)",
+    "emailLabel": "بريدك الإلكتروني (لردنا عليك)",
     "emailPlaceholder": "anta@example.com",
     "subjectLabel": "الموضوع",
     "subjectSpiritual": "هل تريد التعمق في سؤال روحي أو كتابي؟",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -171,7 +171,13 @@
     "submit": "Feedback absenden",
     "submitting": "Wird gesendet...",
     "close": "Schließen",
-    "toastError": "Dein Feedback konnte gerade nicht gespeichert werden, aber danke für den Versuch!"
+    "toastError": "Dein Feedback konnte gerade nicht gespeichert werden, aber danke für den Versuch!",
+    "reasonPrompt": "Was ist schiefgelaufen?",
+    "reasonInaccurate": "Ungenau",
+    "reasonUnhelpful": "Nicht hilfreich",
+    "reasonWrongVerse": "Falscher Vers",
+    "reasonTone": "Ton",
+    "reasonOther": "Sonstiges"
   },
   "ChurchFinder": {
     "bannerText": "Suchst du eine Glaubensgemeinschaft?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Kontakt",
     "emailUs": "Schreib uns:",
-    "emailLabel": "Deine E-Mail (optional, für Antwort)",
+    "emailLabel": "Deine E-Mail (für unsere Antwort)",
     "emailPlaceholder": "du@beispiel.de",
     "subjectLabel": "Betreff",
     "subjectSpiritual": "Möchtest du eine geistliche oder biblische Frage vertiefen?",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -171,7 +171,13 @@
     "submit": "Submit Feedback",
     "submitting": "Submitting...",
     "close": "Close",
-    "toastError": "Couldn't save your feedback right now, but thank you for trying!"
+    "toastError": "Couldn't save your feedback right now, but thank you for trying!",
+    "reasonPrompt": "What went wrong?",
+    "reasonInaccurate": "Inaccurate",
+    "reasonUnhelpful": "Unhelpful",
+    "reasonWrongVerse": "Wrong verse",
+    "reasonTone": "Tone",
+    "reasonOther": "Other"
   },
   "ChurchFinder": {
     "bannerText": "Looking for a faith community?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Get in Touch",
     "emailUs": "Email us:",
-    "emailLabel": "Your email (optional, for reply)",
+    "emailLabel": "Your email (for our reply)",
     "emailPlaceholder": "you@example.com",
     "subjectLabel": "Subject",
     "subjectSpiritual": "Do you want to talk deeper about any spiritual or biblical question?",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -171,7 +171,13 @@
     "submit": "Enviar Comentarios",
     "submitting": "Enviando...",
     "close": "Cerrar",
-    "toastError": "No se pudieron guardar tus comentarios en este momento, ¡pero gracias por intentarlo!"
+    "toastError": "No se pudieron guardar tus comentarios en este momento, ¡pero gracias por intentarlo!",
+    "reasonPrompt": "¿Qué salió mal?",
+    "reasonInaccurate": "Inexacto",
+    "reasonUnhelpful": "Poco útil",
+    "reasonWrongVerse": "Versículo incorrecto",
+    "reasonTone": "Tono",
+    "reasonOther": "Otro"
   },
   "ChurchFinder": {
     "bannerText": "¿Buscas una comunidad de fe?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Contáctanos",
     "emailUs": "Escríbenos:",
-    "emailLabel": "Tu correo electrónico (opcional, para responder)",
+    "emailLabel": "Tu correo electrónico (para nuestra respuesta)",
     "emailPlaceholder": "tu@ejemplo.com",
     "subjectLabel": "Asunto",
     "subjectSpiritual": "¿Quieres profundizar en alguna pregunta espiritual o bíblica?",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -171,7 +171,13 @@
     "submit": "Envoyer le retour",
     "submitting": "Envoi en cours...",
     "close": "Fermer",
-    "toastError": "Impossible de sauvegarder votre retour pour l'instant, mais merci d'avoir essayé !"
+    "toastError": "Impossible de sauvegarder votre retour pour l'instant, mais merci d'avoir essayé !",
+    "reasonPrompt": "Qu'est-ce qui s'est mal passé ?",
+    "reasonInaccurate": "Inexact",
+    "reasonUnhelpful": "Peu utile",
+    "reasonWrongVerse": "Mauvais verset",
+    "reasonTone": "Ton",
+    "reasonOther": "Autre"
   },
   "ChurchFinder": {
     "bannerText": "Vous cherchez une communauté de foi ?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Nous contacter",
     "emailUs": "Écrivez-nous :",
-    "emailLabel": "Votre e-mail (facultatif, pour répondre)",
+    "emailLabel": "Votre e-mail (pour notre réponse)",
     "emailPlaceholder": "vous@exemple.com",
     "subjectLabel": "Sujet",
     "subjectSpiritual": "Voulez-vous approfondir une question spirituelle ou biblique ?",

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -171,7 +171,13 @@
     "submit": "प्रतिक्रिया सबमिट करें",
     "submitting": "सबमिट हो रहा है...",
     "close": "बंद करें",
-    "toastError": "अभी आपकी प्रतिक्रिया सहेजी नहीं जा सकी, लेकिन प्रयास के लिए धन्यवाद!"
+    "toastError": "अभी आपकी प्रतिक्रिया सहेजी नहीं जा सकी, लेकिन प्रयास के लिए धन्यवाद!",
+    "reasonPrompt": "क्या गलत हुआ?",
+    "reasonInaccurate": "अशुद्ध",
+    "reasonUnhelpful": "अनुपयोगी",
+    "reasonWrongVerse": "गलत पद",
+    "reasonTone": "लहजा",
+    "reasonOther": "अन्य"
   },
   "ChurchFinder": {
     "bannerText": "क्या आप एक विश्वास समुदाय खोज रहे हैं?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "संपर्क करें",
     "emailUs": "हमें ईमेल करें:",
-    "emailLabel": "आपका ईमेल (वैकल्पिक, उत्तर के लिए)",
+    "emailLabel": "आपका ईमेल (हमारे उत्तर के लिए)",
     "emailPlaceholder": "you@example.com",
     "subjectLabel": "विषय",
     "subjectSpiritual": "क्या आप किसी आध्यात्मिक या बाइबिल प्रश्न पर गहराई से बात करना चाहते हैं?",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -171,7 +171,13 @@
     "submit": "Invia Feedback",
     "submitting": "Invio in corso...",
     "close": "Chiudi",
-    "toastError": "Non è stato possibile salvare il tuo feedback, ma grazie per aver provato!"
+    "toastError": "Non è stato possibile salvare il tuo feedback, ma grazie per aver provato!",
+    "reasonPrompt": "Cosa non ha funzionato?",
+    "reasonInaccurate": "Impreciso",
+    "reasonUnhelpful": "Poco utile",
+    "reasonWrongVerse": "Versetto sbagliato",
+    "reasonTone": "Tono",
+    "reasonOther": "Altro"
   },
   "ChurchFinder": {
     "bannerText": "Cerchi una comunità di fede?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Contattaci",
     "emailUs": "Scrivici:",
-    "emailLabel": "La tua email (facoltativa, per rispondere)",
+    "emailLabel": "La tua email (per la nostra risposta)",
     "emailPlaceholder": "tu@esempio.com",
     "subjectLabel": "Oggetto",
     "subjectSpiritual": "Vuoi approfondire una domanda spirituale o biblica?",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -171,7 +171,13 @@
     "submit": "피드백 제출",
     "submitting": "제출 중...",
     "close": "닫기",
-    "toastError": "지금은 피드백을 저장할 수 없지만 시도해 주셔서 감사합니다!"
+    "toastError": "지금은 피드백을 저장할 수 없지만 시도해 주셔서 감사합니다!",
+    "reasonPrompt": "무엇이 잘못되었나요?",
+    "reasonInaccurate": "부정확함",
+    "reasonUnhelpful": "도움이 안 됨",
+    "reasonWrongVerse": "잘못된 구절",
+    "reasonTone": "어조",
+    "reasonOther": "기타"
   },
   "ChurchFinder": {
     "bannerText": "신앙 공동체를 찾고 계신가요?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "문의하기",
     "emailUs": "이메일 보내기:",
-    "emailLabel": "이메일 (선택 사항, 답변용)",
+    "emailLabel": "이메일 (답변을 위한 필수 항목)",
     "emailPlaceholder": "you@example.com",
     "subjectLabel": "제목",
     "subjectSpiritual": "영적 또는 성경적 질문에 대해 더 깊이 이야기하고 싶으신가요?",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -171,7 +171,13 @@
     "submit": "Enviar Feedback",
     "submitting": "A enviar...",
     "close": "Fechar",
-    "toastError": "Não foi possível guardar o seu feedback agora, mas obrigado por tentar!"
+    "toastError": "Não foi possível guardar o seu feedback agora, mas obrigado por tentar!",
+    "reasonPrompt": "O que correu mal?",
+    "reasonInaccurate": "Impreciso",
+    "reasonUnhelpful": "Pouco útil",
+    "reasonWrongVerse": "Versículo errado",
+    "reasonTone": "Tom",
+    "reasonOther": "Outro"
   },
   "ChurchFinder": {
     "bannerText": "À procura de uma comunidade de fé?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Fale Connosco",
     "emailUs": "Escreva-nos:",
-    "emailLabel": "O seu e-mail (opcional, para responder)",
+    "emailLabel": "O seu e-mail (para a nossa resposta)",
     "emailPlaceholder": "voce@exemplo.com",
     "subjectLabel": "Assunto",
     "subjectSpiritual": "Quer aprofundar uma questão espiritual ou bíblica?",

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -171,7 +171,13 @@
     "submit": "Отправить отзыв",
     "submitting": "Отправка...",
     "close": "Закрыть",
-    "toastError": "Не удалось сохранить ваш отзыв прямо сейчас, но спасибо за попытку!"
+    "toastError": "Не удалось сохранить ваш отзыв прямо сейчас, но спасибо за попытку!",
+    "reasonPrompt": "Что пошло не так?",
+    "reasonInaccurate": "Неточно",
+    "reasonUnhelpful": "Бесполезно",
+    "reasonWrongVerse": "Неверный стих",
+    "reasonTone": "Тон",
+    "reasonOther": "Другое"
   },
   "ChurchFinder": {
     "bannerText": "Ищете религиозное сообщество?",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "Связаться с нами",
     "emailUs": "Напишите нам:",
-    "emailLabel": "Ваш email (необязательно, для ответа)",
+    "emailLabel": "Ваш email (для нашего ответа)",
     "emailPlaceholder": "вы@example.com",
     "subjectLabel": "Тема",
     "subjectSpiritual": "Хотите углубиться в духовный или библейский вопрос?",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -171,7 +171,13 @@
     "submit": "提交反馈",
     "submitting": "提交中...",
     "close": "关闭",
-    "toastError": "目前无法保存您的反馈，但感谢您的尝试！"
+    "toastError": "目前无法保存您的反馈，但感谢您的尝试！",
+    "reasonPrompt": "哪里出了问题？",
+    "reasonInaccurate": "不准确",
+    "reasonUnhelpful": "没有帮助",
+    "reasonWrongVerse": "引用错误",
+    "reasonTone": "语气",
+    "reasonOther": "其他"
   },
   "ChurchFinder": {
     "bannerText": "正在寻找信仰社区？",
@@ -209,7 +215,7 @@
   "Contact": {
     "getInTouch": "联系我们",
     "emailUs": "发邮件给我们：",
-    "emailLabel": "您的邮箱（可选，用于回复）",
+    "emailLabel": "您的邮箱（用于我们回复）",
     "emailPlaceholder": "you@example.com",
     "subjectLabel": "主题",
     "subjectSpiritual": "您想深入探讨某个属灵或圣经问题吗？",

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -688,6 +688,7 @@ export default function ChatIsland({
     messageId: string,
     rating: "positive" | "negative",
     comment: string,
+    reason?: string,
   ) => {
     const message = messages.find((m) => m.messageId === messageId);
     if (!message || message.role !== "assistant") return;
@@ -701,6 +702,7 @@ export default function ChatIsland({
         assistant_response: message.content,
         verses_cited: message.versesCited,
         model_used: message.model,
+        reason,
       };
 
       await submitFeedback(feedbackRequest);
@@ -894,11 +896,12 @@ export default function ChatIsland({
                     onVerseClick={handleVerseClick}
                     onSubmitFeedback={
                       message.messageId
-                        ? (rating, comment) =>
+                        ? (rating, comment, reason) =>
                             handleFeedbackSubmit(
                               message.messageId!,
                               rating,
                               comment,
+                              reason,
                             )
                         : undefined
                     }

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -28,7 +28,7 @@ interface ChatMessageProps {
   messageId?: string;
   userMessage?: string;
   onVerseClick?: (book: string, chapter: number, verse: number) => void;
-  onSubmitFeedback?: (rating: "positive" | "negative", comment: string) => void;
+  onSubmitFeedback?: (rating: "positive" | "negative", comment: string, reason?: string) => void;
   feedbackGiven?: "positive" | "negative" | null;
   feedbackDisabled?: boolean;
 }

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -28,7 +28,11 @@ interface ChatMessageProps {
   messageId?: string;
   userMessage?: string;
   onVerseClick?: (book: string, chapter: number, verse: number) => void;
-  onSubmitFeedback?: (rating: "positive" | "negative", comment: string, reason?: string) => void;
+  onSubmitFeedback?: (
+    rating: "positive" | "negative",
+    comment: string,
+    reason?: string,
+  ) => void;
   feedbackGiven?: "positive" | "negative" | null;
   feedbackDisabled?: boolean;
 }

--- a/frontend/src/components/ContactForm.test.tsx
+++ b/frontend/src/components/ContactForm.test.tsx
@@ -47,6 +47,9 @@ describe("ContactForm", () => {
     renderWithIntl(<ContactForm />);
     fireEvent.click(screen.getByText("Get in Touch"));
 
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: "user@example.com" } });
+
     const messageInput = screen.getByLabelText("Message");
     fireEvent.change(messageInput, { target: { value: "Hello!" } });
     fireEvent.submit(messageInput.closest("form")!);
@@ -66,6 +69,9 @@ describe("ContactForm", () => {
     renderWithIntl(<ContactForm />);
     fireEvent.click(screen.getByText("Get in Touch"));
 
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: "user@example.com" } });
+
     const messageInput = screen.getByLabelText("Message");
     fireEvent.change(messageInput, { target: { value: "Test" } });
     fireEvent.submit(messageInput.closest("form")!);
@@ -83,6 +89,9 @@ describe("ContactForm", () => {
 
     renderWithIntl(<ContactForm />);
     fireEvent.click(screen.getByText("Get in Touch"));
+
+    const emailInput = screen.getByLabelText(/email/i);
+    fireEvent.change(emailInput, { target: { value: "user@example.com" } });
 
     const messageInput = screen.getByLabelText("Message");
     fireEvent.change(messageInput, { target: { value: "Hello!" } });
@@ -149,7 +158,7 @@ describe("ContactForm", () => {
     expect(screen.getByLabelText("Expected vs. actual behavior")).toBeDefined();
   });
 
-  it("bug report submit stays disabled until both fields are filled", () => {
+  it("bug report submit stays disabled until email and both fields are filled", () => {
     renderWithIntl(<ContactForm />);
     fireEvent.click(screen.getByText("Get in Touch"));
     fireEvent.change(screen.getByLabelText("Subject"), {
@@ -157,6 +166,12 @@ describe("ContactForm", () => {
     });
 
     const submitBtn = screen.getByText("Send Message").closest("button")!;
+    expect(submitBtn.disabled).toBe(true);
+
+    // Fill email — still missing bug fields
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
+    });
     expect(submitBtn.disabled).toBe(true);
 
     fireEvent.change(screen.getByLabelText("Steps to reproduce"), {
@@ -181,6 +196,10 @@ describe("ContactForm", () => {
     fireEvent.click(screen.getByText("Get in Touch"));
     fireEvent.change(screen.getByLabelText("Subject"), {
       target: { value: "bug" },
+    });
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "user@example.com" },
     });
 
     const steps = screen.getByLabelText("Steps to reproduce");

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -42,6 +42,8 @@ export default function ContactForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (!email.trim()) return;
+
     if (isBug) {
       if (!bugSteps.trim() || !bugBehavior.trim()) return;
     } else if (!message.trim()) {
@@ -57,7 +59,7 @@ export default function ContactForm() {
 
     try {
       const request: ContactRequest = {
-        email: email.trim() || undefined,
+        email: email.trim(),
         subject,
         message: messageBody,
         user_agent:
@@ -231,7 +233,7 @@ export default function ContactForm() {
                 </div>
               )}
 
-              {/* Email (optional) — shown last */}
+              {/* Email (required) — shown last */}
               <div>
                 <label
                   htmlFor="contact-email"
@@ -247,6 +249,7 @@ export default function ContactForm() {
                   placeholder={t("emailPlaceholder")}
                   className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                   disabled={isSubmitting}
+                  required
                 />
               </div>
 
@@ -258,6 +261,7 @@ export default function ContactForm() {
                 type="submit"
                 disabled={
                   isSubmitting ||
+                  !email.trim() ||
                   (isBug
                     ? !bugSteps.trim() || !bugBehavior.trim()
                     : !message.trim())

--- a/frontend/src/components/FeedbackControls.test.tsx
+++ b/frontend/src/components/FeedbackControls.test.tsx
@@ -28,7 +28,7 @@ describe("FeedbackControls", () => {
     fireEvent.click(screen.getByLabelText("Thumbs up"));
     advance(FEEDBACK_RETHINK_MS);
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith("positive", "");
+    expect(onSubmit).toHaveBeenCalledWith("positive", "", undefined);
   });
 
   it("Undo cancels the pending feedback — nothing is sent", () => {
@@ -101,7 +101,7 @@ describe("FeedbackControls", () => {
     fireEvent.change(textarea, { target: { value: "Wrong verse" } });
     fireEvent.click(screen.getByText("Send"));
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith("negative", "Wrong verse");
+    expect(onSubmit).toHaveBeenCalledWith("negative", "Wrong verse", undefined);
   });
 
   it("submits exactly once even if the timer fires after a Send", () => {
@@ -122,5 +122,78 @@ describe("FeedbackControls", () => {
       "disabled",
       true,
     );
+  });
+
+  it("renders reason chips on thumbs-down but NOT on thumbs-up", () => {
+    const onSubmit = vi.fn();
+    const { rerender } = renderWithIntl(
+      <FeedbackControls onSubmit={onSubmit} />,
+    );
+
+    // thumbs-up: no reason prompt
+    fireEvent.click(screen.getByLabelText("Thumbs up"));
+    expect(screen.queryByText("What went wrong?")).toBeNull();
+
+    rerender(<FeedbackControls onSubmit={onSubmit} />);
+
+    // thumbs-down: reason prompt and chip labels present
+    fireEvent.click(screen.getByLabelText("Thumbs down"));
+    expect(screen.getByText("What went wrong?")).toBeDefined();
+    expect(screen.getByText("Inaccurate")).toBeDefined();
+    expect(screen.getByText("Unhelpful")).toBeDefined();
+    expect(screen.getByText("Wrong verse")).toBeDefined();
+    expect(screen.getByText("Tone")).toBeDefined();
+    expect(screen.getAllByText("Other")).toBeDefined();
+  });
+
+  it("selecting a reason chip and clicking Send passes the reason to onSubmit", () => {
+    const onSubmit = vi.fn();
+    renderWithIntl(<FeedbackControls onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByLabelText("Thumbs down"));
+
+    // Select the "Inaccurate" chip
+    fireEvent.click(screen.getByText("Inaccurate"));
+
+    fireEvent.click(screen.getByText("Send"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("negative", "", "inaccurate");
+  });
+
+  it("de-selecting a chip sends undefined reason", () => {
+    const onSubmit = vi.fn();
+    renderWithIntl(<FeedbackControls onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByLabelText("Thumbs down"));
+
+    // Select then deselect
+    fireEvent.click(screen.getByText("Inaccurate"));
+    fireEvent.click(screen.getByText("Inaccurate"));
+
+    fireEvent.click(screen.getByText("Send"));
+    expect(onSubmit).toHaveBeenCalledWith("negative", "", undefined);
+  });
+
+  it("auto-commit on thumbs-down still works without selecting a chip", () => {
+    const onSubmit = vi.fn();
+    renderWithIntl(<FeedbackControls onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByLabelText("Thumbs down"));
+    advance(FEEDBACK_RETHINK_MS);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("negative", "", undefined);
+  });
+
+  it("reason is passed with comment when both are set", () => {
+    const onSubmit = vi.fn();
+    renderWithIntl(<FeedbackControls onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByLabelText("Thumbs down"));
+
+    fireEvent.click(screen.getByText("Tone"));
+
+    const textarea = screen.getByPlaceholderText(
+      "The response didn't address my specific concern...",
+    );
+    fireEvent.focus(textarea);
+    fireEvent.change(textarea, { target: { value: "Too formal" } });
+    fireEvent.click(screen.getByText("Send"));
+    expect(onSubmit).toHaveBeenCalledWith("negative", "Too formal", "tone");
   });
 });

--- a/frontend/src/components/FeedbackControls.tsx
+++ b/frontend/src/components/FeedbackControls.tsx
@@ -14,7 +14,7 @@ type Rating = "positive" | "negative";
 
 interface FeedbackControlsProps {
   /** Called exactly once per rating, when the feedback is actually committed. */
-  onSubmit: (rating: Rating, comment: string) => void;
+  onSubmit: (rating: Rating, comment: string, reason?: string) => void;
   /** Rating already recorded for this message (locks the controls). */
   given?: Rating | null;
   disabled?: boolean;
@@ -42,12 +42,16 @@ export default function FeedbackControls({
 
   const [pending, setPending] = useState<Rating | null>(null);
   const [comment, setComment] = useState("");
+  const [reason, setReason] = useState<string | null>(null);
   const [commentOpen, setCommentOpen] = useState(false);
   const [barShrunk, setBarShrunk] = useState(false);
   const [localGiven, setLocalGiven] = useState<Rating | null>(null);
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const committedRef = useRef(false);
+  // Keep a mutable ref in sync with reason state so the auto-commit timer
+  // callback can read the current value even after state updates.
+  const reasonRef = useRef<string | null>(null);
 
   // The recorded rating drives the final UI; until the parent confirms we show
   // an optimistic local copy so the "thanks" state appears instantly.
@@ -74,20 +78,28 @@ export default function FeedbackControls({
     setBarShrunk(false);
   }, [pending, commentOpen]);
 
+  // Wrapper that keeps reasonRef in sync whenever reason state changes.
+  const updateReason = (value: string | null) => {
+    reasonRef.current = value;
+    setReason(value);
+  };
+
   const commit = (rating: Rating, text: string) => {
     if (committedRef.current) return;
     committedRef.current = true;
     clearTimer();
+    const committedReason = rating === "negative" ? (reasonRef.current ?? undefined) : undefined;
     setLocalGiven(rating);
     setPending(null);
     setCommentOpen(false);
-    onSubmit(rating, text.trim());
+    onSubmit(rating, text.trim(), committedReason);
   };
 
   const startPending = (rating: Rating) => {
     clearTimer();
     committedRef.current = false;
     setComment("");
+    updateReason(null);
     setCommentOpen(false);
     setPending(rating);
     timerRef.current = setTimeout(
@@ -101,6 +113,7 @@ export default function FeedbackControls({
     committedRef.current = false;
     setPending(null);
     setComment("");
+    updateReason(null);
     setCommentOpen(false);
   };
 
@@ -189,6 +202,37 @@ export default function FeedbackControls({
               <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5 text-amber-600" />
               <span>{t("maintainerNotice")}</span>
             </p>
+          )}
+
+          {/* "What went wrong?" reason chips — thumbs-down only, optional */}
+          {pending === "negative" && (
+            <div className="mb-2">
+              <p className="text-xs text-gray-500 mb-1.5">{t("reasonPrompt")}</p>
+              <div className="flex flex-wrap gap-1.5">
+                {(
+                  [
+                    ["inaccurate", t("reasonInaccurate")],
+                    ["unhelpful", t("reasonUnhelpful")],
+                    ["wrong_verse", t("reasonWrongVerse")],
+                    ["tone", t("reasonTone")],
+                    ["other", t("reasonOther")],
+                  ] as [string, string][]
+                ).map(([value, label]) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => updateReason(reason === value ? null : value)}
+                    className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
+                      reason === value
+                        ? "bg-red-100 text-red-700 border-red-300"
+                        : "bg-white text-gray-600 border-gray-300 hover:border-red-300 hover:text-red-600"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
           )}
 
           {/* Single panel: the comment field is shown immediately. Focusing it

--- a/frontend/src/components/FeedbackControls.tsx
+++ b/frontend/src/components/FeedbackControls.tsx
@@ -88,7 +88,8 @@ export default function FeedbackControls({
     if (committedRef.current) return;
     committedRef.current = true;
     clearTimer();
-    const committedReason = rating === "negative" ? (reasonRef.current ?? undefined) : undefined;
+    const committedReason =
+      rating === "negative" ? (reasonRef.current ?? undefined) : undefined;
     setLocalGiven(rating);
     setPending(null);
     setCommentOpen(false);
@@ -207,7 +208,9 @@ export default function FeedbackControls({
           {/* "What went wrong?" reason chips — thumbs-down only, optional */}
           {pending === "negative" && (
             <div className="mb-2">
-              <p className="text-xs text-gray-500 mb-1.5">{t("reasonPrompt")}</p>
+              <p className="text-xs text-gray-500 mb-1.5">
+                {t("reasonPrompt")}
+              </p>
               <div className="flex flex-wrap gap-1.5">
                 {(
                   [
@@ -221,7 +224,9 @@ export default function FeedbackControls({
                   <button
                     key={value}
                     type="button"
-                    onClick={() => updateReason(reason === value ? null : value)}
+                    onClick={() =>
+                      updateReason(reason === value ? null : value)
+                    }
                     className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
                       reason === value
                         ? "bg-red-100 text-red-700 border-red-300"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -249,6 +249,7 @@ export interface FeedbackRequest {
   model_used?: string;
   response_time_ms?: number;
   session_id?: string;
+  reason?: string;
 }
 
 export interface FeedbackResponse {

--- a/scripts/migrations/006_add_feedback_reason.py
+++ b/scripts/migrations/006_add_feedback_reason.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Database migration: Add reason column to feedback table.
+
+This migration adds an optional reason column to the feedback table to store
+the category of what went wrong on negative feedback (e.g. inaccurate, unhelpful,
+wrong_verse, tone, other).
+
+Run with: python scripts/migrations/006_add_feedback_reason.py
+"""
+
+import asyncio
+import os
+import sys
+from datetime import datetime
+
+import asyncpg
+
+# Add the api directory to the path for config access
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "api"))
+
+from config import settings  # noqa: E402
+
+# Add the migrations directory to path for local utils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+
+from utils import get_migration_connection_params  # noqa: E402
+
+
+def log(message: str) -> None:
+    """Print timestamped log message, flushed immediately for CI visibility."""
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    print(f"[{timestamp}] {message}", flush=True)
+
+
+async def run_migration():
+    """Run the migration to add reason column to feedback table."""
+    log("Connecting to database...")
+
+    # Parse connection string - handle both local and Azure formats
+    database_url = settings.database_url
+    clean_url, conn_kwargs = get_migration_connection_params(database_url)
+    conn = await asyncpg.connect(clean_url, **conn_kwargs)
+
+    try:
+        log("Adding reason column to feedback table...")
+        await conn.execute("""
+            ALTER TABLE feedback ADD COLUMN IF NOT EXISTS reason VARCHAR(40);
+        """)
+
+        log("Migration completed successfully!")
+
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_migration())


### PR DESCRIPTION
## Summary

Closes the gap where the maintainer received feedback but **couldn't follow up** (optional contact email) and **couldn't evaluate** what went wrong (negative-feedback emails truncated the question and response to 500 chars).

### Change 1 — Contact form email required
- `ContactRequest.email` is now a validated, required `EmailStr` (adds `email-validator` dependency).
- Frontend: `required` input + submit guards; sends the trimmed email (no longer `|| undefined`).
- `Contact.emailLabel` de-"optional"-ised across all 11 locales.
- Missing / invalid email → `422`.

### Change 2 — Feedback emails are actionable
- Notification now carries the **full, untruncated** question + response.
- Adds a metadata table: **model, response time, verses cited, message id**, plus a readable **HTML** layout (mirrors the existing contact-form email style).
- Positive 👍 feedback now also emails **only when it includes a written comment**; a bare 👍 stays silent. Negative still always emails.

### Change 3 — "What went wrong" chips
- Thumbs-down shows optional quick-tap chips (inaccurate / unhelpful / wrong verse / tone / other), threaded UI → API → DB.
- New nullable `reason` column on `feedback` via **migration `scripts/migrations/006_add_feedback_reason.py`**.
- Chips are non-blocking — the 10s rethink/auto-commit flow is preserved (reason read via a ref to avoid stale-closure in the timer).

## Verification
- Backend `tests/test_feedback.py`: **32/32** (incl. new missing/invalid-email → 422).
- Frontend feedback/contact/translation suites: **31/31**; `tsc --noEmit` clean; ESLint clean on touched files.
- All 11 locales carry the 6 new `reason*` keys (translation consistency test passes).
- Rendered-email check: an 899-char response passes through untruncated with reason + metadata in both text and HTML.

## ⚠️ Deploy note
Run **`scripts/migrations/006_add_feedback_reason.py`** before this reaches production — otherwise feedback writes that include a `reason` will fail.

## Notes
- The feedback email HTML interpolates user text without escaping; this matches the pre-existing `send_contact_notification` pattern in the same file and is an internal maintainer-only email. Flagged as a possible follow-up hardening, not addressed here.

Story: `docs/BACKLOG_STORIES/BITB-043-require-contact-email-and-actionable-negative-feedback.md`

https://claude.ai/code/session_013Sqrah2gLrHkjM8JnmA9AR

---
_Generated by [Claude Code](https://claude.ai/code/session_013Sqrah2gLrHkjM8JnmA9AR)_