### PR TITLE
fix(frontend): show effective Bible translation in header selector (BITB-029)

### DIFF
--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -788,7 +788,12 @@ export default function ChatIsland({
               {/* Translation Selector - always visible, disabled when loading */}
               <div className="flex items-center gap-2">
                 <select
-                  value={selectedTranslation}
+                  value={
+                    selectedTranslation ||
+                    (translations.some((t) => t.code === detectedTranslation)
+                      ? (detectedTranslation as string)
+                      : "")
+                  }
                   onChange={(e) => handleTranslationChange(e.target.value)}
                   disabled={translations.length === 0}
                   aria-label={tHeader("bibleVersion")}

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -236,6 +236,129 @@ describe("Home page responsive layout", () => {
       // streamMessage(userMessageContent, apiMessages, { preferredTranslation, ... })
       expect(call[2]?.preferredTranslation).toBeUndefined();
     });
+
+    it("BITB-029: select reflects detected_translation after first message", async () => {
+      vi.mocked(api.getTranslations).mockResolvedValue([
+        {
+          code: "kjv",
+          language: "English",
+          short_name: "KJV",
+          full_name: "King James Version",
+        },
+      ]);
+      vi.mocked(api.streamMessage).mockImplementation(async function* () {
+        yield {
+          type: "metadata" as const,
+          message_id: "msg-detect",
+          scripture_context: { query: "", verses: [], passages: [] },
+          provider: "test",
+          model: "test-model",
+          detected_translation: "kjv",
+        };
+        yield { type: "content" as const, content: "God loves you." };
+        yield { type: "completion" as const, verses_cited: [] };
+      });
+
+      const { container } = renderWithIntl(<Home />);
+      await screen.findByLabelText("Bible version");
+
+      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      await act(async () => {
+        fireEvent.change(input, { target: { value: "hello" } });
+      });
+      const submitButton = container.querySelector('button[type="submit"]');
+      await act(async () => {
+        fireEvent.click(submitButton!);
+      });
+
+      const select = await screen.findByLabelText<HTMLSelectElement>("Bible version");
+      await waitFor(() => expect(select.value).toBe("kjv"));
+    });
+
+    it("BITB-029: detection does not write to localStorage or preferredTranslation", async () => {
+      vi.mocked(api.getTranslations).mockResolvedValue([
+        {
+          code: "kjv",
+          language: "English",
+          short_name: "KJV",
+          full_name: "King James Version",
+        },
+      ]);
+      vi.mocked(api.streamMessage).mockImplementation(async function* () {
+        yield {
+          type: "metadata" as const,
+          message_id: "msg-detect2",
+          scripture_context: { query: "", verses: [], passages: [] },
+          provider: "test",
+          model: "test-model",
+          detected_translation: "kjv",
+        };
+        yield { type: "content" as const, content: "ok" };
+        yield { type: "completion" as const, verses_cited: [] };
+      });
+
+      const { container } = renderWithIntl(<Home />);
+      await screen.findByLabelText("Bible version");
+
+      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      await act(async () => {
+        fireEvent.change(input, { target: { value: "hello" } });
+      });
+      const submitButton = container.querySelector('button[type="submit"]');
+      await act(async () => {
+        fireEvent.click(submitButton!);
+      });
+
+      await waitFor(() =>
+        expect(screen.getByText("ok")).toBeInTheDocument(),
+      );
+
+      expect(localStorage.getItem("preferredTranslation")).toBeNull();
+      const call = vi.mocked(api.streamMessage).mock.calls[0];
+      expect(call[2]?.preferredTranslation).toBeUndefined();
+    });
+
+    it("BITB-029: select stays at placeholder when detected code is not in options list", async () => {
+      vi.mocked(api.getTranslations).mockResolvedValue([
+        {
+          code: "kjv",
+          language: "English",
+          short_name: "KJV",
+          full_name: "King James Version",
+        },
+      ]);
+      vi.mocked(api.streamMessage).mockImplementation(async function* () {
+        yield {
+          type: "metadata" as const,
+          message_id: "msg-unknown",
+          scripture_context: { query: "", verses: [], passages: [] },
+          provider: "test",
+          model: "test-model",
+          detected_translation: "esv",
+        };
+        yield { type: "content" as const, content: "ok" };
+        yield { type: "completion" as const, verses_cited: [] };
+      });
+
+      const { container } = renderWithIntl(<Home />);
+      await screen.findByLabelText("Bible version");
+
+      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      await act(async () => {
+        fireEvent.change(input, { target: { value: "hello" } });
+      });
+      const submitButton = container.querySelector('button[type="submit"]');
+      await act(async () => {
+        fireEvent.click(submitButton!);
+      });
+
+      await waitFor(() =>
+        expect(screen.getByText("ok")).toBeInTheDocument(),
+      );
+
+      const select = screen.getByLabelText<HTMLSelectElement>("Bible version");
+      expect(select.value).toBe("");
+    });
   });
 
   describe("responsive main container", () => {

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -262,7 +262,9 @@ describe("Home page responsive layout", () => {
       const { container } = renderWithIntl(<Home />);
       await screen.findByLabelText("Bible version");
 
-      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      const input = screen.getByPlaceholderText(
+        "Share what's on your heart...",
+      );
       await act(async () => {
         fireEvent.change(input, { target: { value: "hello" } });
       });
@@ -271,7 +273,8 @@ describe("Home page responsive layout", () => {
         fireEvent.click(submitButton!);
       });
 
-      const select = await screen.findByLabelText<HTMLSelectElement>("Bible version");
+      const select =
+        await screen.findByLabelText<HTMLSelectElement>("Bible version");
       await waitFor(() => expect(select.value).toBe("kjv"));
     });
 
@@ -300,7 +303,9 @@ describe("Home page responsive layout", () => {
       const { container } = renderWithIntl(<Home />);
       await screen.findByLabelText("Bible version");
 
-      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      const input = screen.getByPlaceholderText(
+        "Share what's on your heart...",
+      );
       await act(async () => {
         fireEvent.change(input, { target: { value: "hello" } });
       });
@@ -309,9 +314,7 @@ describe("Home page responsive layout", () => {
         fireEvent.click(submitButton!);
       });
 
-      await waitFor(() =>
-        expect(screen.getByText("ok")).toBeInTheDocument(),
-      );
+      await waitFor(() => expect(screen.getByText("ok")).toBeInTheDocument());
 
       expect(localStorage.getItem("preferredTranslation")).toBeNull();
       const call = vi.mocked(api.streamMessage).mock.calls[0];
@@ -343,7 +346,9 @@ describe("Home page responsive layout", () => {
       const { container } = renderWithIntl(<Home />);
       await screen.findByLabelText("Bible version");
 
-      const input = screen.getByPlaceholderText("Share what's on your heart...");
+      const input = screen.getByPlaceholderText(
+        "Share what's on your heart...",
+      );
       await act(async () => {
         fireEvent.change(input, { target: { value: "hello" } });
       });
@@ -352,9 +357,7 @@ describe("Home page responsive layout", () => {
         fireEvent.click(submitButton!);
       });
 
-      await waitFor(() =>
-        expect(screen.getByText("ok")).toBeInTheDocument(),
-      );
+      await waitFor(() => expect(screen.getByText("ok")).toBeInTheDocument());
 
       const select = screen.getByLabelText<HTMLSelectElement>("Bible version");
       expect(select.value).toBe("");


### PR DESCRIPTION
## Summary

- **BITB-029**: After the first AI response, the header translation selector was showing "Bible version" (placeholder) even though the backend had auto-detected and was using a specific translation (e.g. KJV). Users couldn't see which translation was active unless they had manually selected one.
- Fixed by binding the select `value` to `selectedTranslation || (detectedTranslation if valid option else "")` — display-only change, no write path touched.
- Backend guidance (`BIBLE_VERSION_GUIDANCE` in `prompts.py`) that instructs the AI to direct users to the header selector when asked "which Bible version?" was already in place.

## What changed

**`frontend/src/app/[locale]/ChatIsland.tsx`** (1 line):
```tsx
// Before
value={selectedTranslation}

// After
value={
  selectedTranslation ||
  (translations.some((t) => t.code === detectedTranslation)
    ? (detectedTranslation as string)
    : "")
}
```

The guard (`translations.some(...)`) prevents a React "value not in options" mismatch if the backend returns a translation code that isn't in the frontend's loaded options list.

## Invariants preserved

- `handleTranslationChange` (the only writer to `selectedTranslation` / `localStorage`) is untouched — user preferences are never overwritten by backend detection.
- `New Chat` resets `detectedTranslation` to `null` but leaves `selectedTranslation` intact — intended behavior.
- Before the first message (both states empty), select still shows the placeholder.

## Test plan

Three new regression tests in `page.test.tsx`:
- [x] `BITB-029: select reflects detected_translation after first message`
- [x] `BITB-029: detection does not write to localStorage or preferredTranslation`
- [x] `BITB-029: select stays at placeholder when detected code is not in options list`

All 624 frontend tests pass. TypeScript type-check clean.

https://claude.ai/code/session_01TKjCTazBnk8JtYVkFwFwD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKjCTazBnk8JtYVkFwFwD4)_