### PR TITLE
feat(android): submit sample question directly on tap

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -381,7 +381,17 @@ fun ChatScreen(
                     if (uiState.messages.isEmpty()) {
                         item {
                             WelcomeBanner(
-                                onPromptSelected = { prompt -> inputText = prompt },
+                                onPromptSelected = { prompt ->
+                                    // Tapping a sample question submits it directly.
+                                    // If Turnstile isn't ready yet, fall back to
+                                    // filling the input so the Send button still works.
+                                    if (uiState.isTurnstileReady) {
+                                        viewModel.sendMessage(prompt)
+                                        inputText = ""
+                                    } else {
+                                        inputText = prompt
+                                    }
+                                },
                                 modifier = Modifier.padding(24.dp),
                             )
                         }


### PR DESCRIPTION
Tapping a WelcomeBanner sample question now submits it immediately via
ChatViewModel.sendMessage instead of only filling the input field. Falls
back to filling the input when Turnstile isn't ready yet, preserving the
existing Send-button flow.

https://claude.ai/code/session_01ABNWqcyaZMkVa5NGe75gT4