### PR TITLE
fix: make 10-interaction session limit durable on Android and backend

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/preferences/SessionPreferences.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/preferences/SessionPreferences.kt
@@ -3,6 +3,7 @@ package org.voxquieta.app.data.preferences
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import java.util.UUID
@@ -23,6 +24,21 @@ class SessionPreferences @Inject constructor(
 ) {
     companion object {
         private val SESSION_ID_KEY = stringPreferencesKey("session_id")
+        private val INTERACTION_COUNT_KEY = intPreferencesKey("interaction_count")
+    }
+
+    /**
+     * Reads the persisted interaction count (0 if never written).
+     *
+     * Persisted so the 10-message limit survives app restarts and conversation
+     * loads. Keyed to the session lifetime: reset to 0 by [resetSessionId].
+     */
+    suspend fun getInteractionCount(): Int =
+        dataStore.data.first()[INTERACTION_COUNT_KEY] ?: 0
+
+    /** Persists the interaction count for the current session. */
+    suspend fun setInteractionCount(count: Int) {
+        dataStore.edit { prefs -> prefs[INTERACTION_COUNT_KEY] = count }
     }
 
     /**
@@ -41,13 +57,17 @@ class SessionPreferences @Inject constructor(
     }
 
     /**
-     * Generates and persists a new session ID, replacing the existing one.
-     * Call this when starting a new session so the backend resets its
-     * per-session message counter.
+     * Generates and persists a new session ID, replacing the existing one, and
+     * resets the persisted interaction count to 0 in the same atomic edit. Call
+     * this when starting a new session so both the backend and the local
+     * 10-message limit reset together.
      */
     suspend fun resetSessionId(): String {
         val newId = UUID.randomUUID().toString()
-        dataStore.edit { prefs -> prefs[SESSION_ID_KEY] = newId }
+        dataStore.edit { prefs ->
+            prefs[SESSION_ID_KEY] = newId
+            prefs[INTERACTION_COUNT_KEY] = 0
+        }
         return newId
     }
 }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -268,6 +268,21 @@ class ChatViewModel @Inject constructor(
                 _uiState.update { it.copy(themeMode = mode) }
             }
         }
+        // Restore the persisted per-session interaction count so the 10-message
+        // limit survives app restarts and conversation loads. The count is keyed
+        // to the session lifetime (reset by startNewConversation), so we seed both
+        // the counter and the limit flag from DataStore on cold start. We do NOT
+        // restore the church-finder banner/inline flags: those use one-shot
+        // triggers (== 3 / >= 5) and must not re-nag after a restart.
+        viewModelScope.launch {
+            val restoredCount = sessionPreferences.getInteractionCount()
+            _uiState.update {
+                it.copy(
+                    interactionCount = restoredCount,
+                    isSessionLimitReached = restoredCount >= MAX_INTERACTIONS,
+                )
+            }
+        }
         // Fetch available translations from the backend with retry.
         viewModelScope.launch { fetchTranslationsWithRetry() }
         // Fetch book name mappings from the backend with retry.
@@ -528,6 +543,10 @@ class ChatViewModel @Inject constructor(
                                     allVerses = state.allVerses + dedupedNew,
                                 )
                             }
+                            // Persist the new count so the 10-message limit survives
+                            // app restarts and conversation loads. state is the
+                            // in-memory mirror of the persisted value; write it back.
+                            sessionPreferences.setInteractionCount(_uiState.value.interactionCount)
                         }
                     }
                 }
@@ -625,6 +644,13 @@ class ChatViewModel @Inject constructor(
                     .filter { it.role == Message.Role.ASSISTANT }
                     .flatMap { it.verses }
                     .distinctBy { "${it.book}${it.chapter}:${it.verse}" }
+                // Intentionally do NOT recompute interactionCount / isSessionLimitReached
+                // from these messages. The limit is per session_id (shared across all
+                // conversations and matching the backend), not per conversation thread —
+                // an old thread's historical messages belong to past sessions. The current
+                // session count is restored from DataStore on init and must be preserved
+                // here. Deriving it from the loaded thread would reintroduce
+                // per-conversation behaviour and diverge from the backend's 429.
                 _uiState.update { it.copy(messages = messages, currentConversationId = conversationId, allVerses = allVerses) }
             }
         }

--- a/android/app/src/test/kotlin/org/voxquieta/app/preferences/SessionPreferencesTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/preferences/SessionPreferencesTest.kt
@@ -96,4 +96,42 @@ class SessionPreferencesTest {
                 id2,
             )
         }
+
+    /** The interaction count defaults to 0 before anything is written. */
+    @Test
+    fun `getInteractionCount defaults to zero`() = runTest(testDispatcher) {
+        assertEquals(0, sessionPreferences.getInteractionCount())
+    }
+
+    /** [SessionPreferences.setInteractionCount] persists the value for later reads. */
+    @Test
+    fun `setInteractionCount persists the value`() = runTest(testDispatcher) {
+        sessionPreferences.setInteractionCount(7)
+        assertEquals(7, sessionPreferences.getInteractionCount())
+    }
+
+    /**
+     * The persisted interaction count survives re-instantiation (process restart),
+     * so the 10-message limit is restored on cold start.
+     */
+    @Test
+    fun `interaction count persists across fresh SessionPreferences instances`() =
+        runTest(testDispatcher) {
+            sessionPreferences.setInteractionCount(9)
+
+            val anotherInstance = SessionPreferences(dataStore)
+            assertEquals(9, anotherInstance.getInteractionCount())
+        }
+
+    /** Starting a new session via [resetSessionId] zeroes the interaction count. */
+    @Test
+    fun `resetSessionId resets interaction count to zero`() = runTest(testDispatcher) {
+        sessionPreferences.setInteractionCount(10)
+        val oldId = sessionPreferences.getOrCreateSessionId()
+
+        val newId = sessionPreferences.resetSessionId()
+
+        assertEquals(0, sessionPreferences.getInteractionCount())
+        assertTrue("resetSessionId must issue a new session id", newId != oldId)
+    }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -1985,4 +1985,97 @@ class ChatViewModelTest {
         assertNull(result)
         coVerify { lastConversationPreferences.setLastConversationId(null) }
     }
+
+    // ── Interaction-count persistence (per-session limit durability) ──────────
+
+    @Test
+    fun `restores persisted interaction count and limit flag on init`() = runTest {
+        coEvery { sessionPreferences.getInteractionCount() } returns ChatViewModel.MAX_INTERACTIONS
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The limit must survive an app restart: the count is restored from
+        // DataStore and the limit flag is derived from it.
+        assertEquals(ChatViewModel.MAX_INTERACTIONS, vm.uiState.value.interactionCount)
+        assertTrue(vm.uiState.value.isSessionLimitReached)
+    }
+
+    @Test
+    fun `restores sub-limit count without tripping the limit on init`() = runTest {
+        coEvery { sessionPreferences.getInteractionCount() } returns 5
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(5, vm.uiState.value.interactionCount)
+        assertFalse(vm.uiState.value.isSessionLimitReached)
+    }
+
+    @Test
+    fun `persists interaction count after a completed stream`() = runTest {
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(content = "Reply", done = true),
+        )
+
+        viewModel.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { sessionPreferences.setInteractionCount(1) }
+    }
+
+    @Test
+    fun `loadConversation does not recompute interaction count from thread messages`() = runTest {
+        // A saved thread longer than the limit. Under per-session semantics these
+        // historical messages belong to past sessions and must NOT be counted.
+        val longThread = (1..12).map { i ->
+            Message(id = "m$i", role = Message.Role.ASSISTANT, content = "Reply $i")
+        }
+        every { repository.observeMessages("conv-1") } returns flowOf(longThread)
+
+        viewModel.loadConversation("conv-1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(longThread.size, viewModel.uiState.value.messages.size)
+        assertEquals(0, viewModel.uiState.value.interactionCount)
+        assertFalse(viewModel.uiState.value.isSessionLimitReached)
+    }
+
+    @Test
+    fun `startNewConversation resets the persisted interaction count`() = runTest {
+        viewModel.startNewConversation()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(0, viewModel.uiState.value.interactionCount)
+        // resetSessionId() zeroes the persisted count and issues a fresh session_id.
+        coVerify { sessionPreferences.resetSessionId() }
+    }
 }

--- a/api/config.py
+++ b/api/config.py
@@ -118,6 +118,9 @@ class Settings(BaseSettings):
     rate_limit_requests_per_minute: int = 20  # Per IP address
     rate_limit_requests_per_session_minute: int = 10  # Per session per minute
     rate_limit_session_max_requests: int = 10  # Lifetime max per session (encourages breaks)
+    rate_limit_session_ttl_seconds: int = (
+        3600  # Retain a session's lifetime counter for this long after its last request
+    )
     content_filter_enabled: bool = True
     content_filter_block_profanity: bool = True
     content_filter_block_spam: bool = True

--- a/api/tests/test_utils_coverage.py
+++ b/api/tests/test_utils_coverage.py
@@ -814,6 +814,64 @@ class TestRateLimiter:
         # Maxed session should be kept (lifetime limit reached)
         assert "maxed-session" in limiter._session_limits
 
+    @pytest.mark.asyncio
+    async def test_cleanup_keeps_idle_sub_limit_session_within_ttl(self):
+        """A session below the lifetime limit must NOT be reset on brief idle gaps.
+
+        Regression test: cleanup used to delete sessions whose total_requests was
+        under the lifetime limit once their timestamps fell outside the 60s rate
+        window, silently resetting the "lifetime" counter. Sessions within the TTL
+        must now be retained with their count intact.
+        """
+        limiter = RateLimiter(
+            requests_per_minute=100,
+            session_requests_per_minute=100,
+            session_max_requests=10,
+            window_seconds=1,
+            cleanup_interval_seconds=0,
+            session_ttl_seconds=3600,
+        )
+
+        # Send a few requests, staying below the lifetime limit of 10.
+        for _ in range(4):
+            await limiter.check_rate_limit("1.2.3.4", session_id="idle-session")
+
+        # Idle past the 1s rate window but well within the 1h TTL.
+        limiter._last_cleanup = 0
+        limiter._session_limits["idle-session"].timestamps = [time.time() - 100]
+
+        # Trigger cleanup via another request.
+        await limiter.check_rate_limit("5.5.5.5")
+
+        # Session retained with its lifetime count intact.
+        assert "idle-session" in limiter._session_limits
+        assert limiter._session_limits["idle-session"].total_requests == 4
+
+    @pytest.mark.asyncio
+    async def test_cleanup_evicts_session_after_ttl(self):
+        """Sessions idle beyond the TTL are evicted to bound memory growth."""
+        limiter = RateLimiter(
+            requests_per_minute=100,
+            session_requests_per_minute=100,
+            session_max_requests=10,
+            window_seconds=1,
+            cleanup_interval_seconds=0,
+            session_ttl_seconds=60,
+        )
+
+        await limiter.check_rate_limit("1.2.3.4", session_id="old-session")
+
+        # Force last activity older than the TTL.
+        limiter._last_cleanup = 0
+        entry = limiter._session_limits["old-session"]
+        entry.last_seen = time.time() - 120
+        entry.timestamps = [time.time() - 120]
+
+        # Trigger cleanup via another request.
+        await limiter.check_rate_limit("5.5.5.5")
+
+        assert "old-session" not in limiter._session_limits
+
     def test_get_stats(self):
         """get_stats should return current statistics."""
         limiter = RateLimiter(

--- a/api/utils/rate_limiter.py
+++ b/api/utils/rate_limiter.py
@@ -16,6 +16,7 @@ class RateLimitEntry:
 
     timestamps: list[float] = field(default_factory=list)
     total_requests: int = 0  # Lifetime counter (for session limits)
+    last_seen: float = 0.0  # Timestamp of the most recent request (for session TTL)
 
 
 class RateLimiter:
@@ -37,12 +38,17 @@ class RateLimiter:
         session_max_requests: int = 100,
         window_seconds: int = 60,
         cleanup_interval_seconds: int = 300,
+        session_ttl_seconds: int = 3600,
     ):
         self.requests_per_minute = requests_per_minute
         self.session_requests_per_minute = session_requests_per_minute
         self.session_max_requests = session_max_requests
         self.window_seconds = window_seconds
         self.cleanup_interval = cleanup_interval_seconds
+        # How long a session's lifetime counter is retained after its last
+        # request. Decoupled from window_seconds so the lifetime session limit
+        # survives normal idle gaps instead of resetting every minute.
+        self.session_ttl_seconds = session_ttl_seconds
 
         # Storage
         self._ip_limits: dict[str, RateLimitEntry] = defaultdict(RateLimitEntry)
@@ -69,7 +75,7 @@ class RateLimiter:
 
             # Periodic cleanup
             if now - self._last_cleanup > self.cleanup_interval:
-                await self._cleanup(cutoff)
+                await self._cleanup(now, cutoff)
                 self._last_cleanup = now
 
             # Check IP rate limit
@@ -100,12 +106,13 @@ class RateLimiter:
                 session_entry = self._session_limits[session_id]
                 session_entry.timestamps.append(now)
                 session_entry.total_requests += 1
+                session_entry.last_seen = now
 
             return True, None
 
-    async def _cleanup(self, cutoff: float) -> None:
+    async def _cleanup(self, now: float, cutoff: float) -> None:
         """Remove expired entries to prevent memory growth."""
-        # Clean IP entries
+        # Clean IP entries (purely rate-window based)
         expired_ips = [
             ip
             for ip, entry in self._ip_limits.items()
@@ -114,12 +121,16 @@ class RateLimiter:
         for ip in expired_ips:
             del self._ip_limits[ip]
 
-        # Clean session entries (keep those with lifetime limits still active)
+        # Clean session entries by inactivity TTL only. Previously sessions under
+        # the lifetime limit were deleted once idle past the 60s rate window,
+        # which silently reset the "lifetime" counter on brief idle gaps. Evicting
+        # by last_seen keeps the count alive for the session's real lifetime while
+        # still bounding memory.
+        session_cutoff = now - self.session_ttl_seconds
         expired_sessions = [
             sid
             for sid, entry in self._session_limits.items()
-            if (not entry.timestamps or all(t <= cutoff for t in entry.timestamps))
-            and entry.total_requests < self.session_max_requests
+            if entry.last_seen <= session_cutoff
         ]
         for sid in expired_sessions:
             del self._session_limits[sid]
@@ -152,5 +163,6 @@ def get_rate_limiter() -> RateLimiter:
             requests_per_minute=settings.rate_limit_requests_per_minute,
             session_requests_per_minute=settings.rate_limit_requests_per_session_minute,
             session_max_requests=settings.rate_limit_session_max_requests,
+            session_ttl_seconds=settings.rate_limit_session_ttl_seconds,
         )
     return _rate_limiter

--- a/api/utils/rate_limiter.py
+++ b/api/utils/rate_limiter.py
@@ -128,9 +128,7 @@ class RateLimiter:
         # still bounding memory.
         session_cutoff = now - self.session_ttl_seconds
         expired_sessions = [
-            sid
-            for sid, entry in self._session_limits.items()
-            if entry.last_seen <= session_cutoff
+            sid for sid, entry in self._session_limits.items() if entry.last_seen <= session_cutoff
         ]
         for sid in expired_sessions:
             del self._session_limits[sid]


### PR DESCRIPTION
The 10-message session limit did not fire reliably on Android because the
client interaction count lived only in ViewModel memory: it was never
persisted nor restored, and loadConversation never recomputed it. A cold
start, process death, or loading a saved chat reset the client to 0 while the
persisted session_id and the backend kept counting, so the take-a-break nudge
fired too early (surprise 429) or not at all.

Server-side, the per-session lifetime counter was also unreliable: _cleanup
deleted any session under the limit once idle past the 60s rate window,
silently resetting the "lifetime" count on brief idle gaps.

Counting model is per session_id (shared across conversations, reset only on
Start New Session), matching the backend.

Android:
- SessionPreferences: persist interaction_count in DataStore; get/set helpers;
  resetSessionId() zeroes the count atomically with the new session_id.
- ChatViewModel: restore count + isSessionLimitReached on init; persist the
  count after each completed stream; loadConversation intentionally does not
  recompute it (per-session, not per-conversation).

Backend:
- rate_limiter: track last_seen per session and evict sessions by an
  inactivity TTL instead of deleting sub-limit sessions every 60s, so the
  lifetime count survives normal idle gaps while still bounding memory.
- config: add rate_limit_session_ttl_seconds (default 3600).

Tests: SessionPreferences persistence/reset, ChatViewModel restore/persist/
loadConversation/reset, and rate limiter TTL retention + eviction.

Refs #718

https://claude.ai/code/session_017M6i3aPJFrf6PEjwGPwWGr