### PR TITLE
feat(android): language-mismatch switch suggestion banner (BITB-040 slice 3)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
@@ -53,4 +53,5 @@ fun StreamChunkDto.toDomain(): StreamChunk = StreamChunk(
     type = type,
     versesCited = versesCited,
     resolvedVerses = resolvedVerses.map { it.toDomain() },
+    languageSuggestion = languageSuggestion,
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatResponseDto.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatResponseDto.kt
@@ -36,6 +36,11 @@ data class StreamChunkDto(
     @SerialName("verses_cited") val versesCited: List<String> = emptyList(),
     /** Backend-resolved cited verses (with text) from the completion event. */
     @SerialName("resolved_verses") val resolvedVerses: List<VerseDto> = emptyList(),
+    /**
+     * Suggested language switch when the user typed in a language different from their
+     * selected UI language. Populated in the metadata event. Null when no mismatch.
+     */
+    @SerialName("language_suggestion") val languageSuggestion: String? = null,
 )
 
 /**

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
@@ -55,6 +55,7 @@ fun ResponseBody.toChunkFlow(): Flow<StreamChunkDto> = flow {
                         val messageId = jsonObj["message_id"]?.jsonPrimitive?.contentOrNull ?: ""
                         val model = jsonObj["model"]?.jsonPrimitive?.contentOrNull ?: ""
                         val detectedTranslation = jsonObj["detected_translation"]?.jsonPrimitive?.contentOrNull ?: ""
+                        val languageSuggestion = jsonObj["language_suggestion"]?.jsonPrimitive?.contentOrNull
                         // Extract verses from scripture_context.verses (the primary source for verse data).
                         val verses: List<VerseDto> = try {
                             val ctxEl = jsonObj["scripture_context"]
@@ -76,6 +77,7 @@ fun ResponseBody.toChunkFlow(): Flow<StreamChunkDto> = flow {
                                 messageId = messageId,
                                 model = model,
                                 detectedTranslation = detectedTranslation,
+                                languageSuggestion = languageSuggestion,
                             ),
                         )
                     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatResponse.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatResponse.kt
@@ -19,6 +19,7 @@ data class ChatResponse(
  * @param type Event type: "metadata", "content", "completion", or "" for legacy chunks.
  * @param versesCited Server-extracted verse citations from the completion event.
  * @param resolvedVerses Backend-resolved cited verses (with text) from the completion event.
+ * @param languageSuggestion ISO 639-1 code suggested for UI locale switch (null when no mismatch).
  */
 data class StreamChunk(
     val content: String = "",
@@ -30,4 +31,5 @@ data class StreamChunk(
     val type: String = "",
     val versesCited: List<String> = emptyList(),
     val resolvedVerses: List<Verse> = emptyList(),
+    val languageSuggestion: String? = null,
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/LanguageSwitchBanner.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/LanguageSwitchBanner.kt
@@ -1,0 +1,106 @@
+package org.voxquieta.app.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.voxquieta.app.R
+import java.util.Locale
+
+/**
+ * A dismissible banner shown above the input field when the backend detects
+ * the user is typing in a language different from their selected UI locale.
+ *
+ * @param suggestedLocale  ISO 639-1 code of the detected language (e.g. "de", "it").
+ * @param onSwitch         Called when the user taps "Switch" — caller should invoke
+ *                         [ChatViewModel.setLocale] with [suggestedLocale].
+ * @param onDismiss        Called when the user taps "✕" to dismiss without switching.
+ */
+@Composable
+fun LanguageSwitchBanner(
+    suggestedLocale: String,
+    onSwitch: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val languageName = Locale.forLanguageTag(suggestedLocale).displayLanguage
+        .replaceFirstChar { it.uppercaseChar() }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Language,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.size(20.dp),
+            )
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.language_switch_banner_text, languageName),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+                TextButton(
+                    onClick = onSwitch,
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.language_switch_banner_switch),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.tertiary,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(4.dp))
+
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.size(28.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.language_switch_banner_dismiss),
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -72,6 +72,7 @@ import org.voxquieta.app.domain.models.Message
 import org.voxquieta.app.presentation.components.ChatInputField
 import org.voxquieta.app.presentation.components.ChatMessageItem
 import org.voxquieta.app.presentation.components.ChurchFinderBanner
+import org.voxquieta.app.presentation.components.LanguageSwitchBanner
 import org.voxquieta.app.presentation.components.ChurchFinderBottomSheet
 import org.voxquieta.app.presentation.components.TranslationPickerBottomSheet
 import org.voxquieta.app.presentation.components.VersesPanel
@@ -507,6 +508,16 @@ fun ChatScreen(
                 ) {
                     Text(stringResource(R.string.action_start_new_session))
                 }
+            }
+
+            // Language-switch suggestion banner — shown when the backend detects typing
+            // in a different language than the user's selected UI locale.
+            uiState.languageSuggestion?.let { suggestedLocale ->
+                LanguageSwitchBanner(
+                    suggestedLocale = suggestedLocale,
+                    onSwitch = { viewModel.setLocale(suggestedLocale) },
+                    onDismiss = viewModel::dismissLanguageSuggestion,
+                )
             }
 
             // Church-finder banner — shown above the input field after 3 interactions.

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -130,6 +130,12 @@ data class ChatUiState(
     val detectedTranslation: String = "",
     /** True when the device has no active internet connection. */
     val isOffline: Boolean = false,
+    /**
+     * ISO 639-1 code of the language the backend detected the user typing in, when
+     * it differs from the explicitly-selected UI locale. Non-null means show the
+     * language-switch suggestion banner. Null means no banner.
+     */
+    val languageSuggestion: String? = null,
 )
 
 @HiltViewModel
@@ -392,6 +398,7 @@ class ChatViewModel @Inject constructor(
                 messages = it.messages + userMessage + assistantPlaceholder,
                 isLoading = true,
                 error = null,
+                languageSuggestion = null,
             )
         }
 
@@ -582,6 +589,12 @@ class ChatViewModel @Inject constructor(
                                     } else msg
                                 },
                                 detectedTranslation = chunk.detectedTranslation.ifBlank { state.detectedTranslation },
+                                // Show the language-switch banner only when the backend is
+                                // confident the message was typed in a different language than
+                                // the user's explicitly-selected UI locale.
+                                languageSuggestion = chunk.languageSuggestion?.takeIf {
+                                    it.isNotBlank() && it != state.currentLocale
+                                },
                             )
                         }
                         return@collect
@@ -701,6 +714,7 @@ class ChatViewModel @Inject constructor(
                 showChurchFinderBanner = false,
                 showChurchFinderInlineCard = false,
                 allVerses = emptyList(),
+                languageSuggestion = null,
             )
         }
         _churchFinderSheetState.value = ChurchFinderSheetState.Idle
@@ -901,6 +915,11 @@ class ChatViewModel @Inject constructor(
                 showChurchFinderInlineCard = false,
             )
         }
+    }
+
+    /** Dismisses the language-switch suggestion banner without switching locale. */
+    fun dismissLanguageSuggestion() {
+        _uiState.update { it.copy(languageSuggestion = null) }
     }
 
     /**

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -230,6 +230,11 @@
     <string name="church_finder_website">الموقع الإلكتروني</string>
     <string name="church_finder_email">البريد الإلكتروني</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">يبدو أنك تكتب بالـ%s. هل تريد تغيير لغة التطبيق؟</string>
+    <string name="language_switch_banner_switch">تغيير</string>
+    <string name="language_switch_banner_dismiss">رفض اقتراح اللغة</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">تواصل</string>
     <string name="contact_open_button">تواصل معنا</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -226,6 +226,11 @@
     <string name="church_finder_website">Website</string>
     <string name="church_finder_email">E-Mail</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">Es sieht aus, als würden Sie auf %s tippen. App-Sprache wechseln?</string>
+    <string name="language_switch_banner_switch">Wechseln</string>
+    <string name="language_switch_banner_dismiss">Sprachvorschlag verwerfen</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Kontakt</string>
     <string name="contact_open_button">Kontakt aufnehmen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -227,6 +227,11 @@
     <string name="church_finder_website">Sitio web</string>
     <string name="church_finder_email">Correo electrónico</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">Parece que estás escribiendo en %s. ¿Cambiar el idioma de la app?</string>
+    <string name="language_switch_banner_switch">Cambiar</string>
+    <string name="language_switch_banner_dismiss">Descartar sugerencia de idioma</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Contacto</string>
     <string name="contact_open_button">Contactar</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -227,6 +227,11 @@
     <string name="church_finder_website">Site web</string>
     <string name="church_finder_email">E-mail</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">Il semble que vous écrivez en %s. Changer la langue de l\'appli ?</string>
+    <string name="language_switch_banner_switch">Changer</string>
+    <string name="language_switch_banner_dismiss">Ignorer la suggestion de langue</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Contact</string>
     <string name="contact_open_button">Nous contacter</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -226,6 +226,11 @@
     <string name="church_finder_website">वेबसाइट</string>
     <string name="church_finder_email">ईमेल</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">लगता है आप %s में टाइप कर रहे हैं। ऐप की भाषा बदलें?</string>
+    <string name="language_switch_banner_switch">बदलें</string>
+    <string name="language_switch_banner_dismiss">भाषा सुझाव खारिज करें</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">संपर्क</string>
     <string name="contact_open_button">हमसे संपर्क करें</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -227,6 +227,11 @@
     <string name="church_finder_website">Sito web</string>
     <string name="church_finder_email">E-mail</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">Sembra che tu stia scrivendo in %s. Cambiare la lingua dell\'app?</string>
+    <string name="language_switch_banner_switch">Cambia</string>
+    <string name="language_switch_banner_dismiss">Ignora suggerimento lingua</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Contatto</string>
     <string name="contact_open_button">Contattaci</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -225,6 +225,11 @@
     <string name="church_finder_website">웹사이트</string>
     <string name="church_finder_email">이메일</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">%s로 입력 중인 것 같습니다. 앱 언어를 변경할까요?</string>
+    <string name="language_switch_banner_switch">변경</string>
+    <string name="language_switch_banner_dismiss">언어 제안 무시</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">문의</string>
     <string name="contact_open_button">문의하기</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -227,6 +227,11 @@
     <string name="church_finder_website">Site</string>
     <string name="church_finder_email">E-mail</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">Parece que você está digitando em %s. Mudar o idioma do aplicativo?</string>
+    <string name="language_switch_banner_switch">Mudar</string>
+    <string name="language_switch_banner_dismiss">Ignorar sugestão de idioma</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Contato</string>
     <string name="contact_open_button">Entre em contato</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -228,6 +228,11 @@
     <string name="church_finder_website">Веб-сайт</string>
     <string name="church_finder_email">Эл. почта</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">Похоже, вы пишете на %s. Изменить язык приложения?</string>
+    <string name="language_switch_banner_switch">Изменить</string>
+    <string name="language_switch_banner_dismiss">Отклонить предложение языка</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Контакт</string>
     <string name="contact_open_button">Связаться с нами</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -225,6 +225,11 @@
     <string name="church_finder_website">网站</string>
     <string name="church_finder_email">电子邮件</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">看起来您在用%s输入。是否切换应用语言？</string>
+    <string name="language_switch_banner_switch">切换</string>
+    <string name="language_switch_banner_dismiss">忽略语言建议</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">联系</string>
     <string name="contact_open_button">联系我们</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -235,6 +235,11 @@
     <string name="church_finder_website">Website</string>
     <string name="church_finder_email">Email</string>
 
+    <!-- Language Switch Banner -->
+    <string name="language_switch_banner_text">It looks like you\'re typing in %s. Switch the app language?</string>
+    <string name="language_switch_banner_switch">Switch</string>
+    <string name="language_switch_banner_dismiss">Dismiss language suggestion</string>
+
     <!-- Contact Form -->
     <string name="contact_section_title">Contact</string>
     <string name="contact_open_button">Get in Touch</string>

--- a/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
@@ -277,7 +277,41 @@ class EventSourceParserTest {
     }
 
     /**
-     * 14. Completion event with resolved_verses — both the string citations and the
+     * 14. Metadata event with language_suggestion — the field is extracted and populated
+     *     on the emitted StreamChunkDto.
+     */
+    @Test
+    fun `metadata event with language_suggestion populates languageSuggestion field`() = runTest {
+        val body = bodyOf(
+            """data: {"type":"metadata","message_id":"abc","model":"llama3","language_suggestion":"de"}""" + "\n",
+        )
+
+        val chunks = mutableListOf<org.voxquieta.app.data.remote.models.StreamChunkDto>()
+        body.toChunkFlow().collect { chunks.add(it) }
+
+        assertEquals(1, chunks.size)
+        assertEquals("metadata", chunks[0].type)
+        assertEquals("de", chunks[0].languageSuggestion)
+    }
+
+    /**
+     * 15. Metadata event without language_suggestion — the field is null on the emitted chunk.
+     */
+    @Test
+    fun `metadata event without language_suggestion yields null languageSuggestion`() = runTest {
+        val body = bodyOf(
+            """data: {"type":"metadata","message_id":"abc","model":"llama3"}""" + "\n",
+        )
+
+        val chunks = mutableListOf<org.voxquieta.app.data.remote.models.StreamChunkDto>()
+        body.toChunkFlow().collect { chunks.add(it) }
+
+        assertEquals(1, chunks.size)
+        assertNull(chunks[0].languageSuggestion)
+    }
+
+    /**
+     * 16. Completion event with resolved_verses — both the string citations and the
      *     resolved verse objects (with text) are parsed onto the chunk.
      */
     @Test

--- a/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
@@ -7,6 +7,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -2097,4 +2097,88 @@ class ChatViewModelTest {
         // resetSessionId() zeroes the persisted count and issues a fresh session_id.
         coVerify { sessionPreferences.resetSessionId() }
     }
+
+    // ── Language switch suggestion (language-mismatch banner) ─────────────────
+
+    @Test
+    fun `metadata chunk with languageSuggestion sets uiState languageSuggestion`() = runTest {
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(type = "metadata", content = "", messageId = "m1", languageSuggestion = "de", done = false),
+            StreamChunk(content = "Guten Tag!", done = true),
+        )
+
+        viewModel.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("de", viewModel.uiState.value.languageSuggestion)
+    }
+
+    @Test
+    fun `dismissLanguageSuggestion clears languageSuggestion from state`() = runTest {
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(type = "metadata", content = "", messageId = "m1", languageSuggestion = "fr", done = false),
+            StreamChunk(content = "Bonjour!", done = true),
+        )
+
+        viewModel.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("fr", viewModel.uiState.value.languageSuggestion)
+
+        viewModel.dismissLanguageSuggestion()
+
+        assertNull(viewModel.uiState.value.languageSuggestion)
+    }
+
+    @Test
+    fun `sendMessage clears any previous languageSuggestion`() = runTest {
+        every { repository.chatStream(any()) } returnsMany listOf(
+            flowOf(
+                StreamChunk(type = "metadata", content = "", messageId = "m1", languageSuggestion = "it", done = false),
+                StreamChunk(content = "Ciao!", done = true),
+            ),
+            flowOf(
+                StreamChunk(content = "Hello again!", done = true),
+            ),
+        )
+
+        viewModel.sendMessage("First question")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("it", viewModel.uiState.value.languageSuggestion)
+
+        viewModel.sendMessage("Second question")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.languageSuggestion)
+    }
+
+    @Test
+    fun `startNewConversation clears languageSuggestion`() = runTest {
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(type = "metadata", content = "", messageId = "m1", languageSuggestion = "de", done = false),
+            StreamChunk(content = "Guten Tag!", done = true),
+        )
+
+        viewModel.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("de", viewModel.uiState.value.languageSuggestion)
+
+        viewModel.startNewConversation()
+
+        assertNull(viewModel.uiState.value.languageSuggestion)
+    }
+
+    @Test
+    fun `languageSuggestion is null when suggestion matches current locale`() = runTest {
+        // If the backend suggests "en" but the user is already on "en", the ViewModel should suppress it.
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(type = "metadata", content = "", messageId = "m1", languageSuggestion = "en", done = false),
+            StreamChunk(content = "Hello!", done = true),
+        )
+
+        viewModel.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // currentLocale is "en" (set by setUp via languagePreferences.readInitial = "en")
+        assertNull(viewModel.uiState.value.languageSuggestion)
+    }
 }


### PR DESCRIPTION
## Summary

Completes the Android slice (Slice 3) of the language-mismatch switch suggestion feature (BITB-040). The backend (Slice 1) and web frontend (Slice 2) were already shipped. This PR wires up the full Android pipeline so a dismissible `LanguageSwitchBanner` appears above the input field when the backend detects the user is typing in a language different from their selected UI locale.

### Changes

- **`EventSourceParser.kt`** — the load-bearing fix: manually extract `language_suggestion` from the metadata `JsonObject` and pass it into the emitted `StreamChunkDto`. The `@SerialName` annotation alone is not sufficient for the hand-built metadata branch.
- **`StreamChunkDto` / `StreamChunk` / `ChatMapper`** — propagate `languageSuggestion` through the data → domain layers.
- **`ChatViewModel` / `ChatUiState`** — expose `languageSuggestion`; suppress when it already matches `currentLocale`; clear on `sendMessage` and `startNewConversation`; add `dismissLanguageSuggestion()`.
- **`LanguageSwitchBanner.kt`** — new `@Composable` following the `ChurchFinderBanner` pattern, using `tertiaryContainer` to visually distinguish it; tapping "Switch" calls `setLocale()`.
- **`ChatScreen.kt`** — render the banner above `ChurchFinderBanner` when `languageSuggestion` is non-null.
- **`strings.xml` (all locales)** — add `language_switch_banner_text`, `language_switch_banner_switch`, `language_switch_banner_dismiss` to all 11 resource directories (en + ar/de/es/fr/hi/it/ko/pt/ru/zh).
- **Tests** — 2 new `EventSourceParserTest` cases (field present / absent) and 5 new `ChatViewModelTest` cases (set, dismiss, clear on send, clear on new conversation, suppress when locale already matches).

## Test plan

- [ ] Build passes with `./gradlew :app:assembleDebug`
- [ ] Unit tests pass with `./gradlew :app:testDebugUnitTest`
- [ ] On device/emulator: set app locale to English, type a German sentence → banner appears with "Switch" and dismiss controls
- [ ] Tapping "Switch" switches the app to German locale and hides the banner
- [ ] Tapping "✕" dismisses the banner without switching locale
- [ ] Sending a new message clears the banner
- [ ] Starting a new conversation clears the banner
- [ ] If app locale is already German and backend suggests German → banner does NOT appear

## Notes

- The esbuild HIGH severity vulnerability (`@vitejs/plugin-react ^4.3.4`) affects the Security & Dependency Check CI job on other branches. Dependabot PR #736 is the path forward for that issue — it does not block this Android-only PR.

https://claude.ai/code/session_01FBiAMiWRyW1bBibjhM3jiz

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBiAMiWRyW1bBibjhM3jiz)_