### PR TITLE
feat(web): make Bible version selector a prominent badge pill (BITB-029)

### DIFF
--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -838,8 +838,15 @@ export default function ChatIsland({
               {/* Language Switcher */}
               <LanguageSwitcher />
 
-              {/* Translation Selector - always visible, disabled when loading */}
-              <div className="flex items-center gap-2">
+              {/* Translation Selector - badge-style pill, BookOpen icon, no truncation */}
+              <div
+                className={`flex items-center gap-1.5 rounded-full border pl-2.5 pr-1 py-1 transition-colors ${
+                  translations.length === 0
+                    ? "border-gray-200 bg-gray-100 text-gray-400"
+                    : "border-primary-200 bg-primary-50 text-primary-700"
+                }`}
+              >
+                <BookOpen className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
                 <select
                   value={
                     selectedTranslation ||
@@ -850,16 +857,16 @@ export default function ChatIsland({
                   onChange={(e) => handleTranslationChange(e.target.value)}
                   disabled={translations.length === 0}
                   aria-label={tHeader("bibleVersion")}
-                  className={`text-sm border border-gray-200 rounded-lg px-2 py-1.5 max-w-[8rem] sm:max-w-none truncate focus:outline-none focus:ring-2 focus:ring-primary-500 ${
+                  className={`bg-transparent text-sm font-semibold border-0 pr-1 py-0.5 cursor-pointer focus:outline-none focus:ring-0 ${
                     translations.length === 0
-                      ? "bg-gray-100 text-gray-400 cursor-not-allowed"
-                      : "bg-white text-gray-600"
+                      ? "text-gray-400 cursor-not-allowed"
+                      : "text-primary-700"
                   }`}
                 >
                   <option value="">{tHeader("bibleVersion")}</option>
                   {translations.map((t) => (
                     <option key={t.code} value={t.code}>
-                      {t.language} - {t.short_name}
+                      {t.short_name} · {t.language}
                     </option>
                   ))}
                 </select>

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -846,7 +846,10 @@ export default function ChatIsland({
                     : "border-primary-200 bg-primary-50 text-primary-700"
                 }`}
               >
-                <BookOpen className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+                <BookOpen
+                  className="w-4 h-4 flex-shrink-0"
+                  aria-hidden="true"
+                />
                 <select
                   value={
                     selectedTranslation ||


### PR DESCRIPTION
## Summary

Closes BITB-029: Surface Bible Version Information More Clearly (web).

The Bible version `<select>` in the chat header was a small, truncated plain form control that was easy to miss — especially on mobile where `max-w-[8rem]` cut off the version name. Users reported needing to ask in chat "which Bible version is this?" because the version source wasn't obvious.

**Changes:**
- Wraps the existing `<select>` in a badge-pill container: `BookOpen` icon (already imported) + tinted `bg-primary-50 / border-primary-200 / text-primary-700` so the active version reads as a deliberate label, not a stray form control
- Removes `max-w-[8rem] truncate` — version is fully readable on mobile without truncation
- Reorders option text: `{short_name} · {language}` (e.g. "KJV · English") so the recognizable translation code leads
- Greys out gracefully in the disabled/loading state (same logic as before)
- **Zero behavior change**: `onChange`, `value`, disabled state, and `localStorage` persistence are untouched

**Android** already has a prominent suggestion chip — unchanged.  
**API guidance** (`BIBLE_VERSION_GUIDANCE`) already directs users to the version selector — unchanged.

## Acceptance criteria

- [x] Active Bible version is visibly displayed in the primary chat experience on web (badge-pill with BookOpen icon, no truncation)
- [x] Active Bible version is visibly displayed in the primary chat experience on Android (unchanged — suggestion chip already prominent)
- [x] Version indicator opens/navigates to the existing Bible version selection surface (select opens the native picker; Android chip opens the bottom sheet)
- [x] If user asks about Bible version in chat, assistant points to Bible version information instead of improvising version details (BIBLE_VERSION_GUIDANCE already in system prompt — unchanged)
- [x] Behavior works in all 11 supported UI locales — `Header.bibleVersion` key verified present in all `messages/*.json`
- [x] Existing translation selection/persistence behavior remains unchanged

## Test plan

- [x] `npx vitest run` — 628 tests pass, 0 failures
- [ ] Visual smoke test: open web app, confirm Bible version badge is visible and clickable in the header
- [ ] Verify version name is not truncated on mobile viewport (375px)
- [ ] Verify disabled/loading state renders correctly (grey pill) before translations load

https://claude.ai/code/session_01WLwFpyXWTicnurNzoc2PgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLwFpyXWTicnurNzoc2PgV)_