### PR TITLE
fix(chat): ground inline verse quotes against the real Bible text

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/mappers/ChatMapper.kt
@@ -53,5 +53,6 @@ fun StreamChunkDto.toDomain(): StreamChunk = StreamChunk(
     type = type,
     versesCited = versesCited,
     resolvedVerses = resolvedVerses.map { it.toDomain() },
+    correctedMessage = correctedMessage,
     languageSuggestion = languageSuggestion,
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatResponseDto.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ChatResponseDto.kt
@@ -37,10 +37,25 @@ data class StreamChunkDto(
     /** Backend-resolved cited verses (with text) from the completion event. */
     @SerialName("resolved_verses") val resolvedVerses: List<VerseDto> = emptyList(),
     /**
+     * Authoritative message body, set only when post-generation grounding rewrote a
+     * fabricated/mismatched inline verse quote to the canonical scripture text.
+     * When present it replaces the streamed content. Null when nothing was corrected.
+     */
+    @SerialName("corrected_message") val correctedMessage: String? = null,
+    /** References that were corrected, with the reason (completion event). */
+    @SerialName("corrections") val corrections: List<CorrectionDto> = emptyList(),
+    /**
      * Suggested language switch when the user typed in a language different from their
      * selected UI language. Populated in the metadata event. Null when no mismatch.
      */
     @SerialName("language_suggestion") val languageSuggestion: String? = null,
+)
+
+/** A single scripture-fidelity correction reported in the completion event. */
+@Serializable
+data class CorrectionDto(
+    @SerialName("reference") val reference: String = "",
+    @SerialName("reason") val reason: String = "",
 )
 
 /**

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/streaming/EventSourceParser.kt
@@ -1,5 +1,6 @@
 package org.voxquieta.app.data.streaming
 
+import org.voxquieta.app.data.remote.models.CorrectionDto
 import org.voxquieta.app.data.remote.models.StreamChunkDto
 import org.voxquieta.app.data.remote.models.VerseDto
 import kotlinx.coroutines.CancellationException
@@ -101,11 +102,28 @@ fun ResponseBody.toChunkFlow(): Flow<StreamChunkDto> = flow {
                             Timber.w(e, "SSE: failed to parse resolved_verses")
                             emptyList()
                         }
+                        // Authoritative corrected body, present only when grounding
+                        // rewrote a fabricated/mismatched verse quote.
+                        val correctedMessage: String? =
+                            jsonObj["corrected_message"]?.jsonPrimitive?.contentOrNull
+                        val corrections: List<CorrectionDto> = try {
+                            val correctionsEl = jsonObj["corrections"]
+                            if (correctionsEl != null) {
+                                json.decodeFromJsonElement<List<CorrectionDto>>(correctionsEl)
+                            } else {
+                                emptyList()
+                            }
+                        } catch (e: Exception) {
+                            Timber.w(e, "SSE: failed to parse corrections")
+                            emptyList()
+                        }
                         emit(
                             StreamChunkDto(
                                 type = "completion",
                                 versesCited = versesCited,
                                 resolvedVerses = resolvedVerses,
+                                correctedMessage = correctedMessage,
+                                corrections = corrections,
                             ),
                         )
                     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatResponse.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/domain/models/ChatResponse.kt
@@ -19,6 +19,8 @@ data class ChatResponse(
  * @param type Event type: "metadata", "content", "completion", or "" for legacy chunks.
  * @param versesCited Server-extracted verse citations from the completion event.
  * @param resolvedVerses Backend-resolved cited verses (with text) from the completion event.
+ * @param correctedMessage Authoritative message body when grounding rewrote a fabricated/
+ *   mismatched inline verse quote; null when nothing was corrected.
  * @param languageSuggestion ISO 639-1 code suggested for UI locale switch (null when no mismatch).
  */
 data class StreamChunk(
@@ -31,5 +33,6 @@ data class StreamChunk(
     val type: String = "",
     val versesCited: List<String> = emptyList(),
     val resolvedVerses: List<Verse> = emptyList(),
+    val correctedMessage: String? = null,
     val languageSuggestion: String? = null,
 )

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -613,6 +613,21 @@ class ChatViewModel @Inject constructor(
                         if (chunk.resolvedVerses.isNotEmpty()) {
                             finalResolvedVerses = chunk.resolvedVerses
                         }
+                        // Grounding rewrote a fabricated/mismatched verse quote: the
+                        // streamed text is already on screen, so replace it with the
+                        // authoritative corrected body.
+                        chunk.correctedMessage?.let { corrected ->
+                            accumulatedContent = corrected
+                            _uiState.update { state ->
+                                state.copy(
+                                    messages = state.messages.map { msg ->
+                                        if (msg.id == assistantId) {
+                                            msg.copy(content = accumulatedContent)
+                                        } else msg
+                                    },
+                                )
+                            }
+                        }
                         return@collect
                     }
 

--- a/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/streaming/EventSourceParserTest.kt
@@ -331,4 +331,44 @@ class EventSourceParserTest {
         assertEquals("John", chunks[0].resolvedVerses[0].book)
         assertEquals(27, chunks[0].resolvedVerses[0].verse)
     }
+
+    /**
+     * 17. Completion event with corrected_message — the authoritative corrected body
+     *     and the corrections list are parsed onto the chunk.
+     */
+    @Test
+    fun `completion event parses corrected_message and corrections`() = runTest {
+        val body = bodyOf(
+            """data: {"type":"completion","verses_cited":["Isaiah 41:10"],""" +
+                """"corrected_message":"Do not fear, for I am with you.",""" +
+                """"corrections":[{"reference":"Isaiah 41:10","reason":"fabricated"}]}""" + "\n",
+        )
+
+        val chunks = mutableListOf<org.voxquieta.app.data.remote.models.StreamChunkDto>()
+        body.toChunkFlow().collect { chunks.add(it) }
+
+        assertEquals(1, chunks.size)
+        assertEquals("Do not fear, for I am with you.", chunks[0].correctedMessage)
+        assertEquals(1, chunks[0].corrections.size)
+        assertEquals("Isaiah 41:10", chunks[0].corrections[0].reference)
+        assertEquals("fabricated", chunks[0].corrections[0].reason)
+    }
+
+    /**
+     * 18. Completion event without corrected_message — the field stays null so the
+     *     streamed text is left untouched.
+     */
+    @Test
+    fun `completion event without corrected_message leaves it null`() = runTest {
+        val body = bodyOf(
+            """data: {"type":"completion","verses_cited":["John 3:16"]}""" + "\n",
+        )
+
+        val chunks = mutableListOf<org.voxquieta.app.data.remote.models.StreamChunkDto>()
+        body.toChunkFlow().collect { chunks.add(it) }
+
+        assertEquals(1, chunks.size)
+        assertNull(chunks[0].correctedMessage)
+        assertTrue(chunks[0].corrections.isEmpty())
+    }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -193,6 +193,25 @@ class ChatViewModelTest {
     }
 
     @Test
+    fun `completion correctedMessage replaces streamed content`() = runTest {
+        every { repository.chatStream(any()) } returns flowOf(
+            StreamChunk(content = "A fabricated verse quote (Isaiah 41:10)."),
+            StreamChunk(
+                type = "completion",
+                correctedMessage = "Do not fear, for I am with you (Isaiah 41:10).",
+            ),
+            StreamChunk(content = "", done = true),
+        )
+
+        viewModel.sendMessage("comfort me")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val assistant = viewModel.uiState.value.messages
+            .last { it.role == Message.Role.ASSISTANT }
+        assertEquals("Do not fear, for I am with you (Isaiah 41:10).", assistant.content)
+    }
+
+    @Test
     fun `sendMessage populates verses on done chunk`() = runTest {
         val verse = Verse(book = "John", chapter = 3, verse = 16, text = "For God so loved...")
         every { repository.chatStream(any()) } returns flowOf(

--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -505,7 +505,7 @@ def build_search_context_prompt(search_results: dict) -> str:
     if verses:
         context_parts.append("## Relevant Bible Verses")
         for v in verses:
-            context_parts.append(f"**{v['reference']}**: \"{v['text']}\"")
+            context_parts.append(f'**{v["reference"]}**: "{v["text"]}"')
 
     if passages:
         context_parts.append("\n## Relevant Passages")

--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -354,6 +354,13 @@ restriction applies ONLY to the quoted verse text itself, which must be exact.
 - If no verse text is provided in the Scripture Context, do not invent or \
 reconstruct one from memory — speak without quoting rather than risk an \
 inexact quotation.
+- **Never quote or cite a verse that is not in the Scripture Context.** If a \
+verse you have in mind does not appear in the Scripture Context block above, do \
+NOT attach a chapter:verse reference to it and do NOT put any words in quotation \
+marks as if they were that verse. You may speak about the idea in your own \
+words, or invite the user to look the passage up — but never reconstruct a \
+verse's wording from memory. Quoting a verse means its exact text is present in \
+the Scripture Context; if it isn't there, there is no verse to quote.
 """
 
 

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -27,8 +27,14 @@ from utils.language import (
     resolve_translation,
 )
 from utils.logging_config import get_logger
+from utils.metrics import (
+    verse_grounding_corrections_counter,
+    verse_grounding_duration_histogram,
+    verse_grounding_quotes_checked_counter,
+)
 from utils.verse_parser import (
     extract_all_references,
+    extract_inline_quotes,
     extract_references,
     is_verse_lookup_request,
     parse_structured_citations,
@@ -45,6 +51,7 @@ from .prompts import (
     get_verse_lookup_prompt,
 )
 from .topics import detect_topics
+from .verse_grounding import ground_response
 
 logger = get_logger(__name__)
 
@@ -464,9 +471,15 @@ Keep it under 100 words."""
                 extra={"response_preview": response.content[:200]},
             )
 
+        # Ground the response: rewrite any fabricated/mismatched inline verse
+        # quote to the canonical DB text before returning it to the client.
+        message, _ = await self._apply_verse_grounding(
+            response.content, scripture_context, translation, effective_language
+        )
+
         return ChatResponse(
             message_id=message_id,
-            message=response.content,
+            message=message,
             scripture_context=scripture_context,
             provider=response.provider,
             model=response.model,
@@ -788,6 +801,71 @@ Keep it under 100 words."""
                 logger.warning(f"Failed to resolve cited verse {ref}: {e}")
         return list(resolved.values())
 
+    async def _apply_verse_grounding(
+        self,
+        text: str,
+        scripture_context: SearchResults | None,
+        translation: str | None,
+        language: str,
+        resolved_verses: list | None = None,
+    ) -> tuple[str, list]:
+        """Rewrite fabricated/mismatched inline verse quotes to canonical DB text.
+
+        Returns (possibly-corrected text, list[Correction]). Reuses pre-resolved
+        cited verses when the caller already has them (streaming path) to avoid a
+        second DB pass; otherwise resolves the references it finds in ``text``.
+        Never raises — grounding must never break a response.
+        """
+        if not settings.verse_grounding_enabled:
+            return text, []
+        start = time.perf_counter()
+        try:
+            if resolved_verses is None:
+                resolved_verses = await self._resolve_cited_verses(
+                    extract_all_references(text), translation
+                )
+            context_refs = {
+                (v.book.lower(), v.chapter, v.verse)
+                for v in (scripture_context.verses if scripture_context else [])
+            }
+            quotes_checked = len(extract_inline_quotes(text))
+            corrected, corrections = ground_response(
+                text,
+                resolved_verses,
+                context_refs,
+                strip_unresolved=settings.grounding_strip_unresolved,
+            )
+        except Exception as e:
+            logger.warning(f"Verse grounding skipped due to error: {e}")
+            return text, []
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        attrs = {"language": language, "corrected": bool(corrections)}
+        verse_grounding_duration_histogram.record(duration_ms, attrs)
+        if quotes_checked:
+            verse_grounding_quotes_checked_counter.add(quotes_checked, {"language": language})
+        for c in corrections:
+            verse_grounding_corrections_counter.add(
+                1,
+                {
+                    "language": language,
+                    "reason": c.reason,
+                    "corrected": c.corrected_quote is not None,
+                    "book": c.reference.rsplit(" ", 1)[0],
+                },
+            )
+            logger.warning(
+                "Scripture fidelity issue corrected",
+                extra={
+                    "reference": c.reference,
+                    "reason": c.reason,
+                    "original_quote": c.original_quote[:160],
+                    "corrected_quote": (c.corrected_quote or "")[:160],
+                    "language": language,
+                },
+            )
+        return corrected, corrections
+
     def _merge_direct_verses(self, scripture_context: SearchResults, direct_verses: list) -> None:
         """Merge direct lookup verses into scripture context (at beginning)."""
         if not direct_verses or not scripture_context:
@@ -955,6 +1033,19 @@ Keep it under 100 words."""
         # appears in the "Cited" tab.
         resolved_verses = await self._resolve_cited_verses(list(merged_refs.values()), translation)
 
+        # Ground the streamed answer: detect fabricated/mismatched inline verse
+        # quotes and rewrite them to canonical text. Reuses resolved_verses (no
+        # extra DB calls). The tokens are already on the client's screen, so the
+        # correction is delivered as an authoritative `corrected_message` the
+        # client swaps in — only when something actually changed.
+        corrected_message, corrections = await self._apply_verse_grounding(
+            full_response,
+            scripture_context,
+            translation,
+            effective_language,
+            resolved_verses=resolved_verses,
+        )
+
         # Track LLM structured output compliance — helps decide whether to
         # invest in tool/function calling as a more reliable mechanism.
         has_structured = len(structured) > 0
@@ -982,11 +1073,19 @@ Keep it under 100 words."""
         #                    merges these into its verse pool so the filter has
         #                    cards to match even for verses outside the semantic
         #                    search results.
-        yield {
+        completion: dict = {
             "type": "completion",
             "verses_cited": verses_cited,
             "resolved_verses": [v.model_dump() for v in resolved_verses],
         }
+        # Only sent when a quote was rewritten; older clients ignore unknown
+        # fields, so this is backward compatible.
+        if corrections:
+            completion["corrected_message"] = corrected_message
+            completion["corrections"] = [
+                {"reference": c.reference, "reason": c.reason} for c in corrections
+            ]
+        yield completion
 
     def _determine_prompt_type(self, is_verse_lookup: bool, prayer_ref) -> str:
         """Determine the appropriate prompt type based on request characteristics."""

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -840,20 +840,18 @@ Keep it under 100 words."""
             return text, []
 
         duration_ms = (time.perf_counter() - start) * 1000
-        attrs = {"language": language, "corrected": bool(corrections)}
+        attrs: dict[str, str | bool] = {"language": language, "corrected": bool(corrections)}
         verse_grounding_duration_histogram.record(duration_ms, attrs)
         if quotes_checked:
             verse_grounding_quotes_checked_counter.add(quotes_checked, {"language": language})
         for c in corrections:
-            verse_grounding_corrections_counter.add(
-                1,
-                {
-                    "language": language,
-                    "reason": c.reason,
-                    "corrected": c.corrected_quote is not None,
-                    "book": c.reference.rsplit(" ", 1)[0],
-                },
-            )
+            correction_attrs: dict[str, str | bool] = {
+                "language": language,
+                "reason": c.reason,
+                "corrected": c.corrected_quote is not None,
+                "book": c.reference.rsplit(" ", 1)[0],
+            }
+            verse_grounding_corrections_counter.add(1, correction_attrs)
             logger.warning(
                 "Scripture fidelity issue corrected",
                 extra={

--- a/api/chat/verse_grounding.py
+++ b/api/chat/verse_grounding.py
@@ -1,0 +1,173 @@
+"""Post-generation scripture grounding.
+
+The LLM is given verified verse text in the "Scripture Context" block, but it
+sometimes volunteers a verse that was never retrieved and reconstructs its
+wording from memory — producing a citation whose quoted text does not match the
+real verse (e.g. Italian Isaiah 41:10 rendered with the non-word "io ti
+fortirò"). Prompt rules alone (BITB-038) don't fully prevent this.
+
+This module adds a mechanical safety net: after generation, every inline-quoted
+verse is compared against the canonical text already resolved from the database,
+and a fabricated or mismatched quote is rewritten to the canonical wording (the
+reference and surrounding prose are preserved). It is a pure function — all DB
+access happens upstream in the caller — so it is fast and trivially testable.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import unicodedata
+from dataclasses import dataclass
+
+from utils.verse_parser import InlineQuote, VerseReference, extract_inline_quotes
+
+# Quotes scoring at or above this normalized similarity to the canonical verse
+# are treated as faithful. A verbatim quote with only punctuation/casing noise
+# scores ~0.95+; reconstructed-from-memory text scores well below 0.6, so 0.90
+# catches fabrications while leaving margin for diacritic/whitespace artifacts.
+GROUNDING_SIMILARITY_THRESHOLD = 0.90
+# Below this normalized length a quote is too short to judge reliably (high
+# false-positive risk), so it is left untouched.
+MIN_QUOTE_LEN = 12
+
+_PUNCT_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
+_WS_RE = re.compile(r"\s+")
+_ELLIPSIS_RE = re.compile(r"(\.{3,}|…)")
+
+
+def _normalize_for_compare(s: str) -> str:
+    """Normalize verse text for similarity comparison.
+
+    Unicode-normalize (NFKC), casefold, drop ellipsis truncation markers, strip
+    punctuation/quote marks, and collapse all whitespace (including newlines, so
+    flattened poetry doesn't read as a mismatch).
+    """
+    s = unicodedata.normalize("NFKC", s)
+    s = _ELLIPSIS_RE.sub(" ", s)
+    s = _PUNCT_RE.sub(" ", s)
+    s = _WS_RE.sub(" ", s)
+    return s.casefold().strip()
+
+
+@dataclass
+class Correction:
+    """A detected scripture-fidelity issue and what was done about it."""
+
+    reference: str
+    reason: str  # "fabricated" | "mismatched" | "unresolved"
+    original_quote: str
+    corrected_quote: str | None  # None when no canonical text was available
+
+
+def _ref_keys(ref: VerseReference) -> list[tuple[str, int, int]]:
+    """Canonical (book, chapter, verse) keys a reference covers, expanding ranges."""
+    if ref.verse_end and ref.verse_end > ref.verse_start:
+        return [
+            (ref.book.lower(), ref.chapter, v)
+            for v in range(ref.verse_start, ref.verse_end + 1)
+        ]
+    return [(ref.book.lower(), ref.chapter, ref.verse_start)]
+
+
+def _canonical_text(ref: VerseReference, canonical_by_key: dict[tuple[str, int, int], str]) -> str:
+    """Concatenate the canonical text for a reference (joined for ranges)."""
+    parts = [canonical_by_key[k] for k in _ref_keys(ref) if k in canonical_by_key]
+    return " ".join(p for p in parts if p).strip()
+
+
+def _classify(quoted: str, canonical: str, in_context: bool) -> str | None:
+    """Return a correction reason, or None when the quote is acceptable.
+
+    A partial quote that is a substring of the canonical text is always
+    acceptable — the model may legitimately quote only part of a verse.
+    """
+    if not canonical:
+        return "unresolved"
+    nq = _normalize_for_compare(quoted)
+    if len(nq) < MIN_QUOTE_LEN:
+        return None
+    nc = _normalize_for_compare(canonical)
+    if nq in nc:
+        return None
+    if difflib.SequenceMatcher(None, nq, nc).ratio() >= GROUNDING_SIMILARITY_THRESHOLD:
+        return None
+    return "mismatched" if in_context else "fabricated"
+
+
+def ground_response(
+    text: str,
+    resolved_verses: list,
+    context_refs: set[tuple[str, int, int]],
+    *,
+    strip_unresolved: bool = False,
+) -> tuple[str, list[Correction]]:
+    """Correct fabricated/mismatched inline verse quotes in ``text``.
+
+    Args:
+        text: The full LLM response.
+        resolved_verses: VerseResult objects already resolved from the DB for the
+            cited references (reused — this function makes no DB calls).
+        context_refs: (book, chapter, verse) keys that were in the Scripture
+            Context, used to label a low-similarity quote ``fabricated`` (not
+            provided) vs ``mismatched`` (provided but re-worded).
+        strip_unresolved: When a reference resolves to no DB text, remove the
+            invented quotation instead of only reporting it.
+
+    Returns:
+        (corrected_text, corrections). ``corrected_text`` is ``text`` unchanged
+        when nothing needed fixing.
+    """
+    quotes = extract_inline_quotes(text)
+    if not quotes:
+        return text, []
+
+    canonical_by_key: dict[tuple[str, int, int], str] = {}
+    for v in resolved_verses:
+        canonical_by_key[(v.book.lower(), v.chapter, v.verse)] = v.text
+
+    corrections: list[Correction] = []
+    # (start, end, replacement) edits, applied right-to-left so offsets stay valid.
+    edits: list[tuple[int, int, str]] = []
+    for q in quotes:
+        canonical = _canonical_text(q.reference, canonical_by_key)
+        in_context = any(k in context_refs for k in _ref_keys(q.reference))
+        reason = _classify(q.quoted_text, canonical, in_context)
+        if reason is None:
+            continue
+        if reason == "unresolved":
+            corrected = None
+            if strip_unresolved:
+                edits.append(_strip_edit(text, q))
+        else:
+            corrected = canonical
+            edits.append((q.span[0], q.span[1], canonical))
+        corrections.append(
+            Correction(
+                reference=str(q.reference),
+                reason=reason,
+                original_quote=q.quoted_text,
+                corrected_quote=corrected,
+            )
+        )
+
+    if not edits:
+        return text, corrections
+
+    corrected_text = text
+    for start, end, replacement in sorted(edits, key=lambda e: e[0], reverse=True):
+        corrected_text = corrected_text[:start] + replacement + corrected_text[end:]
+    return corrected_text, corrections
+
+
+def _strip_edit(text: str, quote: InlineQuote) -> tuple[int, int, str]:
+    """Edit that removes an invented quotation along with its surrounding marks,
+    leaving the reference and prose intact."""
+    start = quote.span[0]
+    end = quote.span[1]
+    # Drop the opening/closing quotation marks that bracket the span.
+    if start > 0:
+        start -= 1
+    if end < len(text):
+        end += 1
+    return start, end, ""

--- a/api/chat/verse_grounding.py
+++ b/api/chat/verse_grounding.py
@@ -64,8 +64,7 @@ def _ref_keys(ref: VerseReference) -> list[tuple[str, int, int]]:
     """Canonical (book, chapter, verse) keys a reference covers, expanding ranges."""
     if ref.verse_end and ref.verse_end > ref.verse_start:
         return [
-            (ref.book.lower(), ref.chapter, v)
-            for v in range(ref.verse_start, ref.verse_end + 1)
+            (ref.book.lower(), ref.chapter, v) for v in range(ref.verse_start, ref.verse_end + 1)
         ]
     return [(ref.book.lower(), ref.chapter, ref.verse_start)]
 

--- a/api/config.py
+++ b/api/config.py
@@ -131,6 +131,13 @@ class Settings(BaseSettings):
     content_filter_intent_detection: bool = True  # Pre-LLM intent classification
     security_log_violations: bool = True  # Log security violations
 
+    # Verse grounding (post-generation scripture fidelity)
+    verse_grounding_enabled: bool = True  # Correct fabricated/mismatched inline verse quotes
+    # When a cited verse cannot be resolved in the DB at all, strip the invented
+    # quotation rather than only logging it. Off by default — grammar-safe
+    # stripping across 11 languages is risky, so detect-and-log first.
+    grounding_strip_unresolved: bool = False
+
     # Performance Monitoring
     slow_query_threshold_ms: int = 100  # Log queries slower than this (milliseconds)
     verse_query_timeout_s: float = 10.0  # Max seconds for a verse/chapter DB query before 504

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -523,6 +523,19 @@ class TestScriptureFidelityGuidance:
         text = SCRIPTURE_FIDELITY_GUIDANCE.lower()
         assert "invent" in text or "reconstruct" in text
 
+    def test_guidance_forbids_citing_unprovided_verse(self):
+        # Distinct from re-wording a provided verse: the LLM must not cite or
+        # quote a verse that was never in the Scripture Context at all.
+        text = SCRIPTURE_FIDELITY_GUIDANCE.lower()
+        assert "not in the scripture context" in text
+        assert "there is no verse to quote" in text
+
+    def test_unprovided_verse_rule_in_all_builders(self):
+        for builder in (get_system_prompt, get_verse_lookup_prompt, get_prayer_lookup_prompt):
+            assert "Never quote or cite a verse that is not in the Scripture Context" in builder(
+                "en"
+            )
+
 
 class TestResponseDepthGuidance:
     """BITB-050: the conversational reply must have enough depth to genuinely
@@ -1074,6 +1087,85 @@ class TestChatServiceChatStream:
         completion = next(c for c in chunks if c["type"] == "completion")
         assert completion["resolved_verses"] == []
         assert "verses_cited" in completion
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_stream_corrects_fabricated_quote(
+        self, mock_extract, mock_is_verse, mock_resolve, mock_detect
+    ):
+        """A fabricated inline quote is rewritten and the completion event carries
+        an authoritative corrected_message + corrections list."""
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+        canonical = "For God so loved the world, that he gave his only begotten Son."
+        service.search_service.get_verse = AsyncMock(
+            return_value=VerseResult(
+                reference="John 3:16",
+                text=canonical,
+                book="John",
+                chapter=3,
+                verse=16,
+                translation="kjv",
+            )
+        )
+        service.search_service.get_verse_range = AsyncMock(return_value=[])
+
+        async def mock_stream(*args, **kwargs):
+            yield (
+                'John 3:16 reminds us: "God adored the whole planet so much he '
+                'sent his one and only child down." Take heart.'
+                "\n<!-- VERSES: John 3:16 -->"
+            )
+
+        llm.chat_stream = mock_stream
+
+        chunks = []
+        async for chunk in service.chat_stream(ChatRequest(message="comfort me")):
+            chunks.append(chunk)
+
+        completion = next(c for c in chunks if c["type"] == "completion")
+        assert "corrected_message" in completion
+        assert canonical in completion["corrected_message"]
+        assert "God adored the whole planet" not in completion["corrected_message"]
+        assert completion["corrections"] == [
+            {"reference": "John 3:16", "reason": "fabricated"}
+        ]
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_stream_no_correction_omits_fields(
+        self, mock_extract, mock_is_verse, mock_resolve, mock_detect
+    ):
+        """When nothing is rewritten, corrected_message/corrections are absent."""
+        service, llm, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search = AsyncMock(
+            return_value=SearchResults(query="test", verses=[], passages=[])
+        )
+        service.search_service.get_verse = AsyncMock(return_value=None)
+        service.search_service.get_verse_range = AsyncMock(return_value=[])
+
+        async def mock_stream(*args, **kwargs):
+            yield "Take heart and be encouraged today."
+
+        llm.chat_stream = mock_stream
+
+        chunks = []
+        async for chunk in service.chat_stream(ChatRequest(message="hi")):
+            chunks.append(chunk)
+
+        completion = next(c for c in chunks if c["type"] == "completion")
+        assert "corrected_message" not in completion
+        assert "corrections" not in completion
 
 
 def _make_ref(book, chapter, verse_start, verse_end=None):

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -122,9 +122,9 @@ class TestGetSystemPrompt:
         """Non-English prompts should not contain the hardcoded English attribution phrase."""
         for lang in ("es", "fr", "it", "de", "pt"):
             result = get_system_prompt(lang)
-            assert (
-                "This is from the Bible, specifically" not in result
-            ), f"Hardcoded English attribution still present for lang={lang}"
+            assert "This is from the Bible, specifically" not in result, (
+                f"Hardcoded English attribution still present for lang={lang}"
+            )
 
 
 class TestOpeningPhrase:
@@ -1052,9 +1052,9 @@ class TestChatServiceChatStream:
         cited = completion["resolved_verses"]
         assert isinstance(cited, list)
         # At least one verse resolved (John 3:16)
-        assert any(
-            v["book"] == "John" and v["chapter"] == 3 and v["verse"] == 16 for v in cited
-        ), f"Expected John 3:16 in resolved_verses, got: {cited}"
+        assert any(v["book"] == "John" and v["chapter"] == 3 and v["verse"] == 16 for v in cited), (
+            f"Expected John 3:16 in resolved_verses, got: {cited}"
+        )
 
     @pytest.mark.asyncio
     @patch("chat.service.detect_language", return_value="en")
@@ -1133,9 +1133,7 @@ class TestChatServiceChatStream:
         assert "corrected_message" in completion
         assert canonical in completion["corrected_message"]
         assert "God adored the whole planet" not in completion["corrected_message"]
-        assert completion["corrections"] == [
-            {"reference": "John 3:16", "reason": "fabricated"}
-        ]
+        assert completion["corrections"] == [{"reference": "John 3:16", "reason": "fabricated"}]
 
     @pytest.mark.asyncio
     @patch("chat.service.detect_language", return_value="en")

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -122,9 +122,9 @@ class TestGetSystemPrompt:
         """Non-English prompts should not contain the hardcoded English attribution phrase."""
         for lang in ("es", "fr", "it", "de", "pt"):
             result = get_system_prompt(lang)
-            assert "This is from the Bible, specifically" not in result, (
-                f"Hardcoded English attribution still present for lang={lang}"
-            )
+            assert (
+                "This is from the Bible, specifically" not in result
+            ), f"Hardcoded English attribution still present for lang={lang}"
 
 
 class TestOpeningPhrase:
@@ -1052,9 +1052,9 @@ class TestChatServiceChatStream:
         cited = completion["resolved_verses"]
         assert isinstance(cited, list)
         # At least one verse resolved (John 3:16)
-        assert any(v["book"] == "John" and v["chapter"] == 3 and v["verse"] == 16 for v in cited), (
-            f"Expected John 3:16 in resolved_verses, got: {cited}"
-        )
+        assert any(
+            v["book"] == "John" and v["chapter"] == 3 and v["verse"] == 16 for v in cited
+        ), f"Expected John 3:16 in resolved_verses, got: {cited}"
 
     @pytest.mark.asyncio
     @patch("chat.service.detect_language", return_value="en")

--- a/api/tests/test_verse_grounding.py
+++ b/api/tests/test_verse_grounding.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 
 from chat.verse_grounding import (
     GROUNDING_SIMILARITY_THRESHOLD,
-    Correction,
     _normalize_for_compare,
     ground_response,
 )

--- a/api/tests/test_verse_grounding.py
+++ b/api/tests/test_verse_grounding.py
@@ -111,9 +111,7 @@ class TestGroundResponse:
     def test_mismatch_when_verse_was_in_context(self):
         text = 'John 3:16 says: "God really loved the entire planet a whole lot."'
         jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
-        corrected, corrections = ground_response(
-            text, [jn], context_refs={("john", 3, 16)}
-        )
+        corrected, corrections = ground_response(text, [jn], context_refs={("john", 3, 16)})
         assert len(corrections) == 1
         assert corrections[0].reason == "mismatched"
         assert JOHN_3_16_EN in corrected
@@ -121,18 +119,14 @@ class TestGroundResponse:
     def test_faithful_quote_unchanged(self):
         text = f'As John 3:16 says: "{JOHN_3_16_EN}"'
         jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
-        corrected, corrections = ground_response(
-            text, [jn], context_refs={("john", 3, 16)}
-        )
+        corrected, corrections = ground_response(text, [jn], context_refs={("john", 3, 16)})
         assert corrections == []
         assert corrected == text
 
     def test_partial_quote_not_flagged(self):
         text = 'John 3:16 reminds us: "For God so loved the world".'
         jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
-        corrected, corrections = ground_response(
-            text, [jn], context_refs={("john", 3, 16)}
-        )
+        corrected, corrections = ground_response(text, [jn], context_refs={("john", 3, 16)})
         assert corrections == []
         assert corrected == text
 
@@ -145,7 +139,9 @@ class TestGroundResponse:
     def test_range_concatenation_partial_accepted(self):
         # An LLM quoting only verse 23 of a 5:22-23 range must not be flagged.
         v22 = FakeVerse("Galatians", 5, 22, "But the fruit of the Spirit is love, joy, peace,")
-        v23 = FakeVerse("Galatians", 5, 23, "gentleness, self-control: against such there is no law.")
+        v23 = FakeVerse(
+            "Galatians", 5, 23, "gentleness, self-control: against such there is no law."
+        )
         text = 'Galatians 5:22-23 lists "gentleness, self-control: against such there is no law."'
         _, corrections = ground_response(
             text, [v22, v23], context_refs={("galatians", 5, 22), ("galatians", 5, 23)}

--- a/api/tests/test_verse_grounding.py
+++ b/api/tests/test_verse_grounding.py
@@ -1,0 +1,180 @@
+"""Tests for post-generation verse grounding.
+
+Covers inline-quote extraction across languages, the fabricated/mismatched/partial
+classification, canonical-text substitution, and the metric/contract behavior that
+rewrites a hallucinated verse quote to the real DB text.
+"""
+
+from dataclasses import dataclass
+
+from chat.verse_grounding import (
+    GROUNDING_SIMILARITY_THRESHOLD,
+    Correction,
+    _normalize_for_compare,
+    ground_response,
+)
+from utils.verse_parser import extract_inline_quotes
+
+
+@dataclass
+class FakeVerse:
+    """Stand-in for scripture.search.VerseResult (only the fields grounding uses)."""
+
+    book: str
+    chapter: int
+    verse: int
+    text: str
+
+
+# Canonical reference texts used across the tests.
+ISAIAH_41_10_IT = (
+    "Non temere, perché io sono con te; non smarrirti, perché io sono il tuo Dio. "
+    "Ti rendo forte e ti vengo in aiuto e ti sostengo con la destra vittoriosa "
+    "della mia giustizia."
+)
+JOHN_3_16_EN = "For God so loved the world, that he gave his only begotten Son."
+
+
+class TestExtractInlineQuotes:
+    def test_quote_then_parenthetical_reference(self):
+        text = 'He wrote "For God so loved the world." (John 3:16) today.'
+        quotes = extract_inline_quotes(text)
+        assert len(quotes) == 1
+        assert str(quotes[0].reference) == "John 3:16"
+        assert quotes[0].quoted_text == "For God so loved the world."
+
+    def test_reference_then_quote_with_connector(self):
+        text = 'As John 3:16 says: "For God so loved the world."'
+        quotes = extract_inline_quotes(text)
+        assert len(quotes) == 1
+        assert str(quotes[0].reference) == "John 3:16"
+
+    def test_italian_guillemets(self):
+        text = "La verità «Dio è amore eterno e infinito» (1 Giovanni 4:8) consola."
+        quotes = extract_inline_quotes(text)
+        assert len(quotes) == 1
+        assert str(quotes[0].reference) == "1 John 4:8"
+
+    def test_german_low_high_quotes(self):
+        text = "Er sagte „Selig sind die Barmherzigen“ (Matthäus 5:7) heute."
+        quotes = extract_inline_quotes(text)
+        assert len(quotes) == 1
+        assert str(quotes[0].reference) == "Matthew 5:7"
+
+    def test_quote_without_reference_is_ignored(self):
+        text = 'She said "what a lovely day" while walking.'
+        assert extract_inline_quotes(text) == []
+
+    def test_reference_without_quote_is_ignored(self):
+        text = "Romans 8:28 is a comforting passage to remember."
+        assert extract_inline_quotes(text) == []
+
+    def test_narrative_gap_not_misattributed(self):
+        # A nearby quote that is not introduced by the reference must not bind.
+        text = 'John 3:16 and also "my dog is very cute" today.'
+        assert extract_inline_quotes(text) == []
+
+    def test_offsets_point_at_quoted_text(self):
+        text = '"For God so loved the world." (John 3:16)'
+        q = extract_inline_quotes(text)[0]
+        assert text[q.span[0] : q.span[1]] == q.quoted_text
+
+
+class TestNormalize:
+    def test_strips_punctuation_and_case(self):
+        assert _normalize_for_compare('  "Hello, WORLD!" ') == "hello world"
+
+    def test_collapses_newlines(self):
+        assert _normalize_for_compare("line one\nline two") == "line one line two"
+
+    def test_drops_ellipsis(self):
+        assert _normalize_for_compare("the world... and more") == "the world and more"
+
+
+class TestGroundResponse:
+    def test_italian_fabrication_is_corrected(self):
+        # The reported bug: a reconstructed-from-memory Isaiah 41:10.
+        text = (
+            'Un altro passaggio utile è: "Non temere, perché io sono con te; non '
+            "smarrirti, perché io sono il tuo Dio; io ti fortirò, io ti aiuterò, io ti "
+            'sosterrò con la mia destra fedele" (Isaia 41:10). Spero ti aiuti.'
+        )
+        isa = FakeVerse("Isaiah", 41, 10, ISAIAH_41_10_IT)
+        corrected, corrections = ground_response(text, [isa], context_refs=set())
+        assert len(corrections) == 1
+        assert corrections[0].reason == "fabricated"  # was not in Scripture Context
+        assert ISAIAH_41_10_IT in corrected
+        assert "io ti fortirò" not in corrected
+        # Reference and surrounding prose are preserved.
+        assert "(Isaia 41:10)" in corrected
+        assert corrected.startswith("Un altro passaggio utile è:")
+
+    def test_mismatch_when_verse_was_in_context(self):
+        text = 'John 3:16 says: "God really loved the entire planet a whole lot."'
+        jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
+        corrected, corrections = ground_response(
+            text, [jn], context_refs={("john", 3, 16)}
+        )
+        assert len(corrections) == 1
+        assert corrections[0].reason == "mismatched"
+        assert JOHN_3_16_EN in corrected
+
+    def test_faithful_quote_unchanged(self):
+        text = f'As John 3:16 says: "{JOHN_3_16_EN}"'
+        jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
+        corrected, corrections = ground_response(
+            text, [jn], context_refs={("john", 3, 16)}
+        )
+        assert corrections == []
+        assert corrected == text
+
+    def test_partial_quote_not_flagged(self):
+        text = 'John 3:16 reminds us: "For God so loved the world".'
+        jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
+        corrected, corrections = ground_response(
+            text, [jn], context_refs={("john", 3, 16)}
+        )
+        assert corrections == []
+        assert corrected == text
+
+    def test_very_short_quote_skipped(self):
+        text = 'John 3:16 says: "He gave."'
+        jn = FakeVerse("John", 3, 16, JOHN_3_16_EN)
+        _, corrections = ground_response(text, [jn], context_refs={("john", 3, 16)})
+        assert corrections == []
+
+    def test_range_concatenation_partial_accepted(self):
+        # An LLM quoting only verse 23 of a 5:22-23 range must not be flagged.
+        v22 = FakeVerse("Galatians", 5, 22, "But the fruit of the Spirit is love, joy, peace,")
+        v23 = FakeVerse("Galatians", 5, 23, "gentleness, self-control: against such there is no law.")
+        text = 'Galatians 5:22-23 lists "gentleness, self-control: against such there is no law."'
+        _, corrections = ground_response(
+            text, [v22, v23], context_refs={("galatians", 5, 22), ("galatians", 5, 23)}
+        )
+        assert corrections == []
+
+    def test_unresolved_detected_but_text_unchanged_by_default(self):
+        text = 'Consider also: "a fabricated line never written here" (Obadiah 1:5).'
+        corrected, corrections = ground_response(text, [], context_refs=set())
+        assert len(corrections) == 1
+        assert corrections[0].reason == "unresolved"
+        assert corrections[0].corrected_quote is None
+        assert corrected == text  # detect-and-log only
+
+    def test_unresolved_stripped_when_enabled(self):
+        text = 'Consider also: "a fabricated line never written here" (Obadiah 1:5).'
+        corrected, corrections = ground_response(
+            text, [], context_refs=set(), strip_unresolved=True
+        )
+        assert corrections[0].reason == "unresolved"
+        assert "a fabricated line never written here" not in corrected
+        assert "(Obadiah 1:5)" in corrected
+
+    def test_no_quotes_returns_input_unchanged(self):
+        text = "Take heart and be encouraged today."
+        corrected, corrections = ground_response(text, [], context_refs=set())
+        assert corrected == text
+        assert corrections == []
+
+    def test_threshold_constant_is_reasonable(self):
+        assert 0.8 <= GROUNDING_SIMILARITY_THRESHOLD < 1.0

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -35,6 +35,28 @@ chat_stream_counter = meter.create_counter(
     unit="1",
 )
 
+# ── Verse grounding / scripture-fidelity metrics ──────────────────────────
+# Post-generation grounding rewrites fabricated/mismatched inline verse quotes
+# to the canonical DB text. These metrics make recurrences visible and track the
+# latency the step adds, so we never trade correctness for a silent slowdown.
+verse_grounding_quotes_checked_counter = meter.create_counter(
+    name="chat.verse_grounding.quotes_checked",
+    description="Inline verse quotes inspected by the grounding step",
+    unit="1",
+)  # attributes: language
+
+verse_grounding_corrections_counter = meter.create_counter(
+    name="chat.verse_grounding.corrections",
+    description="Inline verse quotes found fabricated/mismatched/unresolved during grounding",
+    unit="1",
+)  # attributes: language, reason (fabricated|mismatched|unresolved), corrected (bool), book
+
+verse_grounding_duration_histogram = meter.create_histogram(
+    name="chat.verse_grounding.duration_ms",
+    description="Latency overhead added by the post-generation grounding/correction step",
+    unit="ms",
+)  # attributes: language, corrected (bool)
+
 # ── Scripture metrics ─────────────────────────────────────────────────────
 scripture_search_counter = meter.create_counter(
     name="scripture.search.total",

--- a/api/utils/verse_parser.py
+++ b/api/utils/verse_parser.py
@@ -97,6 +97,17 @@ class VerseReference:
 
 
 @dataclass
+class InlineQuote:
+    """A span of quoted text in an LLM response paired with the verse reference
+    it is presented as quoting (e.g. `"For God so loved…" (John 3:16)`)."""
+
+    reference: VerseReference
+    quoted_text: str  # raw text between the quotation marks
+    span: tuple[int, int]  # (start, end) offsets of quoted_text in the source
+    ref_span: tuple[int, int]  # (start, end) offsets of the reference token
+
+
+@dataclass
 class PrayerReference:
     """Parsed prayer/passage reference."""
 
@@ -450,6 +461,115 @@ def parse_structured_citations(text: str) -> list[VerseReference]:
                 results.append(ref)
 
     return results
+
+
+# Quote-mark pairs used across the 11 supported UI languages, as (open, close).
+# Chinese book-title guillemets 《》 are intentionally excluded: they wrap book
+# names inside references (《约翰福音》3:16), not verse quotations, and would
+# otherwise be misread as quoted verse text.
+_QUOTE_PAIRS: list[tuple[str, str]] = [
+    ('"', '"'),
+    ("“", "”"),  # “ ”
+    ("„", "“"),  # „ … “  (German)
+    ("«", "»"),  # « »   (French / Italian)
+    ("「", "」"),  # 「 」  (CJK corner)
+    ("『", "』"),  # 『 』  (CJK white corner)
+    ("‘", "’"),  # ‘ ’
+]
+
+# Each pair captures its inner span on a single line (no newline), length-bounded
+# so a stray opening mark can't swallow the rest of the message.
+_QUOTE_PATTERNS: list[re.Pattern] = [
+    re.compile(re.escape(o) + r"([^\n]{1,600}?)" + re.escape(c)) for o, c in _QUOTE_PAIRS
+]
+
+# Characters allowed to sit between a quotation and its adjacent reference
+# (e.g. `… ." (John 3:16)` or `John 3:16: "…`). Any other character (a letter)
+# means the quote and reference belong to different clauses.
+_ADJACENCY_SEPARATORS = set(" \t\n ()[]—–-,.:;")
+_ADJACENCY_WINDOW = 50
+# Map brackets to spaces before running _VERSE_PATTERN so its whitespace
+# lookbehind matches a reference written as "(John 3:16)"; same length keeps
+# offsets aligned with the original text.
+_BRACKET_TO_SPACE = str.maketrans("()[]", "    ")
+# A reference may introduce a quotation with a short connector — `John 3:16 says:`,
+# `Giovanni 3:16 dice,` — so a gap of a few words ending in a colon/comma also
+# counts as adjacent. Anything richer (sentence punctuation, more text) does not,
+# which keeps a nearby non-verse quotation from being misattributed.
+_QUOTE_INTRO_GAP = re.compile(r"^[\w\s]{0,20}[:,]\s*$")
+
+
+def _gap_is_adjacent(gap: str) -> bool:
+    """True when only separators / a short quote-introducing connector separate a
+    reference from a quotation."""
+    return all(ch in _ADJACENCY_SEPARATORS for ch in gap) or bool(_QUOTE_INTRO_GAP.match(gap))
+
+
+def _find_adjacent_reference(
+    text: str, open_pos: int, close_end: int
+) -> tuple[VerseReference, tuple[int, int]] | None:
+    """Find a verse reference immediately before or after a quotation.
+
+    Returns (reference, (ref_start, ref_end)) using absolute offsets into ``text``,
+    or None when no reference sits directly beside the quote.
+    """
+    # After the quote: `"…" (John 3:16)`
+    after = text[close_end : close_end + _ADJACENCY_WINDOW]
+    m = _VERSE_PATTERN.search(after.translate(_BRACKET_TO_SPACE))
+    if m and all(ch in _ADJACENCY_SEPARATORS for ch in after[: m.start()]):
+        ref = _match_to_verse_reference(m)
+        if ref:
+            return ref, (close_end + m.start(), close_end + m.end())
+
+    # Before the quote: `John 3:16: "…"` — take the reference closest to the quote.
+    start = max(0, open_pos - _ADJACENCY_WINDOW)
+    before = text[start:open_pos]
+    last = None
+    for mm in _VERSE_PATTERN.finditer(before.translate(_BRACKET_TO_SPACE)):
+        last = mm
+    if last and _gap_is_adjacent(before[last.end() :]):
+        ref = _match_to_verse_reference(last)
+        if ref:
+            return ref, (start + last.start(), start + last.end())
+    return None
+
+
+def extract_inline_quotes(text: str) -> list[InlineQuote]:
+    """Find verse text quoted inline next to a parsed reference.
+
+    Detects both orderings — `"…quoted…" (John 3:16)` and `John 3:16: "…quoted…"`
+    — across the quotation styles used by the supported languages. Only quotes
+    sitting immediately beside a resolvable reference (separated by punctuation /
+    whitespace, not other words) are returned, so ordinary quoted phrases are
+    ignored. Offsets are reported against ``text`` unchanged so callers can
+    substitute corrected text safely.
+
+    Limitations: paraphrases without quotation marks are not detected (the prompt
+    rules cover those); a quote is associated with the single nearest reference;
+    unbalanced quotation marks are skipped.
+    """
+    quotes: list[InlineQuote] = []
+    seen_spans: set[tuple[int, int]] = set()
+    for pattern in _QUOTE_PATTERNS:
+        for m in pattern.finditer(text):
+            span = (m.start(1), m.end(1))
+            if span in seen_spans:
+                continue
+            found = _find_adjacent_reference(text, m.start(), m.end())
+            if not found:
+                continue
+            ref, ref_span = found
+            seen_spans.add(span)
+            quotes.append(
+                InlineQuote(
+                    reference=ref,
+                    quoted_text=m.group(1),
+                    span=span,
+                    ref_span=ref_span,
+                )
+            )
+    quotes.sort(key=lambda q: q.span[0])
+    return quotes
 
 
 def _check_direct_match(book_raw_lower: str) -> str | None:

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -496,6 +496,22 @@ export default function ChatIsland({
         } else if (chunk.type === "completion") {
           // Server-provided verse citations (dual-source: LLM structured + regex)
           receivedCompletion = true;
+          // If grounding rewrote a fabricated/mismatched verse quote, swap the
+          // streamed text for the authoritative corrected body.
+          if (chunk.corrected_message) {
+            streamedContent = chunk.corrected_message;
+            setMessages((prev) => {
+              const updated = [...prev];
+              const msg = updated[assistantMessageIndex];
+              if (msg && msg.role === "assistant") {
+                updated[assistantMessageIndex] = {
+                  ...msg,
+                  content: streamedContent,
+                };
+              }
+              return updated;
+            });
+          }
           if (chunk.verses_cited) {
             const serverCited = (chunk.verses_cited as string[]).map(
               (v: string) => v.toLowerCase(),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -476,6 +476,11 @@ export interface StreamChunk {
   // merged into the verse pool so the filter has cards to match for verses
   // outside the semantic search results.
   resolved_verses?: Verse[];
+  // Set only when post-generation grounding rewrote a fabricated/mismatched
+  // inline verse quote to the canonical scripture text. When present, it is the
+  // authoritative full message body and should replace the streamed content.
+  corrected_message?: string;
+  corrections?: { reference: string; reason: string }[];
 }
 
 /**


### PR DESCRIPTION
## Problem

Cited verses are sometimes **LLM-generated text resembling the original**, not the real verse. Reported example (Italian):

> Un altro passaggio che potrebbe essere utile è: "Non temere, perché io sono con te… io ti **fortirò**…" (Isaia 41:10)

`fortirò` isn't even a real Italian word — the model reconstructed Isaiah 41:10 from memory.

This is a **different failure mode** from the earlier fix **BITB-038**, which only forbids *re-wording a verse that was actually retrieved* into the "Scripture Context". Here the model **volunteers a verse that was never retrieved** ("Un altro passaggio…") and invents its wording. Being prompt-only, BITB-038 had no mechanical check, so it recurred.

## Fix — post-generation grounding safety net

- **`extract_inline_quotes()`** (`verse_parser.py`): finds quoted verse text next to a reference across the 11 languages' quotation styles (`" "`, `« »`, `„ "`, `「」`, …) and both `"…" (Ref)` / `Ref says: "…"` orderings. Tuned so a nearby *non-verse* quote isn't misattributed (avoids false corrections).
- **`verse_grounding.py`** (new, pure/no-DB): compares each quoted span to the canonical DB text and rewrites a fabricated/mismatched quote to the canonical wording, **preserving the reference and surrounding prose**. Partial quotes and faithful quotes are left untouched; truly-unresolvable references are detected/logged (optional strip behind `grounding_strip_unresolved`).
- **Wiring** into both `chat()` and `chat_stream()`. The stream reuses already-resolved verses (**zero extra DB calls**) and delivers an authoritative `corrected_message` in the completion event, which the **web and Android** clients swap in over the streamed text (backward-compatible — older clients ignore the field).
- **Monitoring**: OpenTelemetry counters for quotes-checked and corrections (by language / reason / book) **and a histogram for the grounding step's latency overhead**.
- **Prompt**: `SCRIPTURE_FIDELITY_GUIDANCE` reinforced to forbid citing any verse absent from the Scripture Context.

A new setting `verse_grounding_enabled` (default on) gates the whole step.

## Verification

- **API: full suite green — 3144 passed, 3 skipped.** New `test_verse_grounding.py` (extraction, threshold, the exact Italian Isaiah 41:10 case, partial-quote-not-flagged, unresolved) + streaming-contract tests asserting `corrected_message` / `corrections` appear (and are absent when nothing changed).
- **Frontend: type-check clean, 628 unit tests pass.**
- **Android: parser + ViewModel unit tests added, but NOT executed here** — the sandbox network policy blocks Google's Maven repo so Gradle can't resolve the Android plugin. The Kotlin changes are small and mirror existing patterns; please confirm via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016miB4jvN2GBjPk13bAiPJa)_