### PR TITLE
fix(api): repair scripture-search SQL broken by a misplaced # nosec comment

### DIFF
--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -251,7 +251,12 @@ jobs:
           err_re="${err_re}|rate.?limit.*(error|exceeded|hit|reached)|quota exceeded"
           err_re="${err_re}|invalid.?api.?key|api.?key.*(invalid|missing|expired)"
           err_re="${err_re}|embedding.*error|connection.*error|connection refused"
-          err_re="${err_re}|unhandled exception|critical error|fatal)"
+          err_re="${err_re}|unhandled exception|critical error|fatal"
+          # Scripture search / cited-verse / grounding failures. These paths fail
+          # open (verse-less answer, no 5xx), so match their log signatures directly
+          # rather than relying on a `traceback` token that may not be captured.
+          err_re="${err_re}|scripture search failed|failed to resolve cited verse|verse grounding skipped"
+          err_re="${err_re}|postgressyntaxerror|infailedsqltransactionerror|current transaction is aborted)"
           # `sample` is a KQL operator; using it as a column name causes
           # SYN0002. Use `sample_log` instead.
           # KQL has no !matches operator — it only supports ! for scalar

--- a/api/scripture/repository.py
+++ b/api/scripture/repository.py
@@ -305,7 +305,8 @@ class ScriptureRepository:
             translation_filter = "AND v.translation = :translation"
             params["translation"] = translation
 
-        sql = f"""  # nosec B608 - parameterized query, safe from SQL injection
+        # Parameterized query: only :named binds + internal translation_filter constant (no user SQL).
+        sql = f"""
             WITH ranked AS (
                 SELECT
                     v.id,
@@ -397,7 +398,8 @@ class ScriptureRepository:
             translation_filter = "AND v.translation = :translation"
             params["translation"] = translation
 
-        sql = f"""  # nosec B608 - parameterized query, safe from SQL injection
+        # Parameterized query: only :named binds + internal translation_filter constant (no user SQL).
+        sql = f"""
             WITH base_search AS (
                 SELECT
                     v.id,
@@ -506,7 +508,8 @@ class ScriptureRepository:
             translation_filter = "AND v.translation = :translation"
             params["translation"] = translation
 
-        sql = f"""  # nosec B608 - parameterized query, safe from SQL injection
+        # Parameterized query: only :named binds + internal translation_filter constant (no user SQL).
+        sql = f"""
             WITH ranked AS (
                 SELECT
                     v.id,

--- a/api/tests/test_hybrid_search.py
+++ b/api/tests/test_hybrid_search.py
@@ -118,6 +118,75 @@ class TestSearchVersesHybrid:
         assert params["translation"] == "kjv"
 
 
+class TestRawSqlHasNoPythonComment:
+    """Regression: the raw-SQL search builders must not leak a Python ``#`` comment
+    into the SQL string sent to Postgres.
+
+    A misplaced ``# nosec`` after the opening triple-quote once made every query
+    start with ``# nosec ...``, which Postgres rejected with
+    ``syntax error at or near "#"`` and aborted the transaction. These tests
+    execute the real SQL-building path (mocked session, empty rows) and assert the
+    generated SQL is clean — coverage that was missing because other tests mock the
+    repository methods themselves.
+    """
+
+    @staticmethod
+    def _first_sql(mock_session) -> str:
+        # First execute() call passes text(sql) as the first positional arg.
+        return mock_session.execute.call_args_list[0][0][0].text
+
+    @pytest.mark.asyncio
+    async def test_search_verses_hybrid_sql_is_clean(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_verses_hybrid(
+            query_text="test", query_embedding=[0.1, 0.2], translation="schlachter"
+        )
+
+        sql = self._first_sql(mock_session)
+        assert "#" not in sql
+        assert sql.lstrip().upper().startswith(("WITH", "SELECT"))
+
+    @pytest.mark.asyncio
+    async def test_search_verses_semantic_boosted_sql_is_clean(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_verses_semantic_boosted(
+            query_embedding=[0.1, 0.2], boost_topics=["faith"], translation="schlachter"
+        )
+
+        sql = self._first_sql(mock_session)
+        assert "#" not in sql
+        assert sql.lstrip().upper().startswith(("WITH", "SELECT"))
+
+    @pytest.mark.asyncio
+    async def test_search_verses_hybrid_boosted_sql_is_clean(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_verses_hybrid_boosted(
+            query_text="test",
+            query_embedding=[0.1, 0.2],
+            boost_topics=["faith"],
+            translation="schlachter",
+        )
+
+        sql = self._first_sql(mock_session)
+        assert "#" not in sql
+        assert sql.lstrip().upper().startswith(("WITH", "SELECT"))
+
+
 class TestSearchPassagesHybrid:
     """Tests for ScriptureRepository.search_passages_hybrid()."""
 

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -27,6 +27,11 @@
 #       Fires when verse/chapter fetch failures (timeout/db_error/empty_text) occur.
 #   - azurerm_monitor_scheduled_query_rules_alert_v2.scripture_fetch_latency_p95 (BITB-041)
 #       Fires when p95 latency of verse/chapter DB reads exceeds 1000ms.
+#   - azurerm_monitor_scheduled_query_rules_alert_v2.scripture_grounding_errors
+#       Fires when scripture search / cited-verse resolution / grounding logs an
+#       error. These code paths swallow exceptions (fail open to a verse-less
+#       answer), so without this alert a broken search can run silently — exactly
+#       how the "# nosec inside SQL" syntax-error regression went unnoticed.
 
 locals {
   alerts_enabled = var.alert_email != "" && var.enable_application_insights
@@ -163,6 +168,49 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scripture_fetch_error
       | where name == "scripture.fetch.errors"
       | summarize total = sum(valueSum) by bin(timestamp, 5m)
       | where total > 0
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
+# Scripture grounding / search failure alert.
+# The chat scripture pipeline fails open: _search_scripture, _resolve_cited_verses
+# and _apply_verse_grounding each catch exceptions and degrade to a verse-less
+# answer (no 5xx). This rule surfaces those swallowed failures by matching the
+# exact log signatures they emit, so a broken search/grounding path can no longer
+# run silently. Runs every 5 minutes over the last 10 minutes of backend logs.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scripture_grounding_errors" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-scripture-grounding-errors"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_log_analytics_workspace.main.id]
+  severity             = 2
+  description          = "Scripture search, cited-verse resolution, or verse grounding logged an error in the last 10 minutes (these paths fail open, so errors are otherwise invisible)."
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      | where TimeGenerated > ago(10m)
+      | where ContainerAppName_s == "${azurerm_container_app.backend.name}"
+      | where Log_s matches regex "(?i)(scripture search failed|failed to resolve cited verse|verse grounding skipped|PostgresSyntaxError|InFailedSQLTransactionError|current transaction is aborted)"
+      | summarize cnt = count() by bin(TimeGenerated, 5m)
+      | where cnt > 0
     KQL
     time_aggregation_method = "Count"
     threshold               = 0


### PR DESCRIPTION
## Problem

In production, chat answers stopped surfacing verses from the database — neither the semantic "context" pool nor the **Cited** verse panel. The database itself is correct (a direct query returns John 3:16 / Isaiah 41:10 in `web`, Isaiah 41:10 in `schlachter`).

Backend logs show the real cause, on **every** chat request:

```
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near "#"
  File "/app/scripture/repository.py", line 343, in search_verses_hybrid
... and the SQL sent to Postgres literally starts with:
  # nosec B608 - parameterized query, safe from SQL injection
  WITH ranked AS ( ...
```

The `# nosec B608` comment was placed **after** the opening triple-quote, so it became the literal first line of the SQL string. Postgres comments are `--`, not `#`, so every query raised a syntax error.

### Why it broke everything

`search_verses_hybrid` runs on every message. When it raised, it **aborted the shared session transaction**, so the cited-verse resolution that runs next in the same request then failed too:

```
WARNING ... Failed to resolve cited verse Jeremiah 29:11:
  asyncpg.exceptions.InFailedSQLTransactionError: current transaction is aborted
```

Net effect: correctly-cited, fully-present verses never reached the panel — the transaction was already poisoned.

### Why it went unnoticed (~2 weeks)

The scripture pipeline **fails open** through three nested `except Exception` blocks (`_search_scripture`, `_resolve_cited_verses`, `_apply_verse_grounding`), so the chat still answered — just without verses, no 5xx. CI never executed the SQL (the repo methods are mocked), and the `# nosec` named a bandit check that `.pre-commit-config.yaml` already globally skips (`--skip B608`), so it was never needed in the first place.

## Fix

- **`api/scripture/repository.py`** — relocate the misplaced `# nosec` in all three raw-SQL builders (`search_verses_hybrid`, `search_verses_semantic_boosted`, `search_verses_hybrid_boosted`). The safety rationale moves to a normal Python comment above each assignment; the `#` line no longer leaks into the SQL. Queries are genuinely safe (only `:named` binds + an internal `translation_filter` constant).
- **`api/tests/test_hybrid_search.py`** — regression tests that execute the *real* SQL-building path and assert the generated SQL contains no `#` and starts with a valid keyword. These fail before the fix and pass after — the coverage that was missing.
- **`deployment/monitoring.tf`** — new `scripture_grounding_errors` scheduled-query alert matching the swallowed failure signatures, so this error class can no longer run silent.
- **`.github/workflows/prod-monitor.yml`** — extend the Telegram log-scan `err_re` with those signatures (the structured `ERROR`/`WARNING` lines now match directly, rather than relying on a `traceback` token the captured logs don't contain).

## Verification

- API: `ruff`, `black`, `mypy` clean; `test_hybrid_search.py` 16/16 and 87 related tests pass.
- Terraform formatting mirrors the existing BITB-041 alert resources (run `terraform fmt -check && validate` in your pipeline — `terraform` isn't available in the sandbox).

## Operator actions required

- **Redeploy the backend** — this is a code fix; it takes effect only after deploy.
- **Enable the new alert**: it is gated on `alerts_enabled = var.alert_email != "" && var.enable_application_insights`. Set `TF_VAR_ALERT_EMAIL` and enable Application Insights for prod, or the alert (like the existing ones) is never created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016miB4jvN2GBjPk13bAiPJa)_