### PR TITLE
fix(api): bind embedding via CAST() so asyncpg accepts the vector cast in scripture search

### DIFF
--- a/api/scripture/repository.py
+++ b/api/scripture/repository.py
@@ -310,14 +310,14 @@ class ScriptureRepository:
             WITH ranked AS (
                 SELECT
                     v.id,
-                    (1 - (v.embedding <=> :embedding::vector)) AS semantic_score,
+                    (1 - (v.embedding <=> CAST(:embedding AS vector))) AS semantic_score,
                     ts_rank(
                         to_tsvector('simple', v.text),
                         plainto_tsquery('simple', :query_text)
                     ) AS keyword_score_raw
                 FROM verses v
                 WHERE v.embedding IS NOT NULL
-                  AND (1 - (v.embedding <=> :embedding::vector)) >= :threshold
+                  AND (1 - (v.embedding <=> CAST(:embedding AS vector))) >= :threshold
                   {translation_filter}
             ),
             normalized AS (
@@ -403,10 +403,10 @@ class ScriptureRepository:
             WITH base_search AS (
                 SELECT
                     v.id,
-                    (1 - (v.embedding <=> :embedding::vector)) AS base_score
+                    (1 - (v.embedding <=> CAST(:embedding AS vector))) AS base_score
                 FROM verses v
                 WHERE v.embedding IS NOT NULL
-                  AND (1 - (v.embedding <=> :embedding::vector)) >= :threshold
+                  AND (1 - (v.embedding <=> CAST(:embedding AS vector))) >= :threshold
                   {translation_filter}
             ),
             topic_matches AS (
@@ -513,14 +513,14 @@ class ScriptureRepository:
             WITH ranked AS (
                 SELECT
                     v.id,
-                    (1 - (v.embedding <=> :embedding::vector)) AS semantic_score,
+                    (1 - (v.embedding <=> CAST(:embedding AS vector))) AS semantic_score,
                     ts_rank(
                         to_tsvector('simple', v.text),
                         plainto_tsquery('simple', :query_text)
                     ) AS keyword_score_raw
                 FROM verses v
                 WHERE v.embedding IS NOT NULL
-                  AND (1 - (v.embedding <=> :embedding::vector)) >= :threshold
+                  AND (1 - (v.embedding <=> CAST(:embedding AS vector))) >= :threshold
                   {translation_filter}
             ),
             normalized AS (
@@ -674,14 +674,14 @@ class ScriptureRepository:
             WITH ranked AS (
                 SELECT
                     p.id,
-                    (1 - (p.embedding <=> :embedding::vector)) AS semantic_score,
+                    (1 - (p.embedding <=> CAST(:embedding AS vector))) AS semantic_score,
                     ts_rank(
                         to_tsvector('simple', p.text),
                         plainto_tsquery('simple', :query_text)
                     ) AS keyword_score_raw
                 FROM passages p
                 WHERE p.embedding IS NOT NULL
-                  AND (1 - (p.embedding <=> :embedding::vector)) >= :threshold
+                  AND (1 - (p.embedding <=> CAST(:embedding AS vector))) >= :threshold
             ),
             normalized AS (
                 SELECT

--- a/api/tests/functional/test_production_api.py
+++ b/api/tests/functional/test_production_api.py
@@ -565,3 +565,60 @@ class TestContentSafetySmoke:
 # skip when CONTENT_SAFETY_ENABLED=false, making them safe to run in any environment.
 # General input validation tests (not specific to content safety) remain in the unit
 # test suite (api/tests/test_api.py) where Turnstile is not active.
+
+
+# ---------------------------------------------------------------------------
+# Chat grounding smoke — the chat path must return DB-sourced scripture
+# ---------------------------------------------------------------------------
+
+
+class TestChatGroundingSmoke:
+    """Post-deploy smoke test that the chat path actually returns DB-backed verses.
+
+    Why this exists
+    ---------------
+    A broken hybrid-search query (PR #764's stray ``#``; the ``:embedding::vector``
+    cast asyncpg could not bind) silently broke all DB verse retrieval for ~2 weeks.
+    The pipeline fails open — ``/chat`` still returned HTTP 200 with an empty
+    ``scripture_context`` — so a status-code check alone never noticed.
+
+    Unlike ``GET /scripture/search`` (which uses *semantic* search), the chat
+    endpoint exercises ``search_hybrid`` / ``search_hybrid_boosted`` — the exact
+    builders that broke. We assert at least one verse is grounded, not just 200.
+
+    Best-effort in production: skips on free-tier LLM timeouts or edge (Turnstile)
+    blocks, since the verse retrieval is only observable in the final response.
+    """
+
+    def test_chat_returns_grounded_scripture(self, api):
+        """POST /chat for a scripture-eliciting message must include >=1 verse."""
+        message = "What does the Bible say about hope and trusting God?"
+        try:
+            r = api.post("/api/v1/chat", json={"message": message}, timeout=60.0)
+        except httpx.ReadTimeout:
+            pytest.skip(
+                "LLM did not respond within timeout (expected on free tier) — "
+                "cannot observe scripture_context."
+            )
+
+        # Edge/Turnstile may block raw POSTs in some environments.
+        if r.status_code in (401, 403):
+            pytest.skip(f"Chat POST blocked by edge/Turnstile (status {r.status_code}).")
+
+        assert r.status_code == 200, f"chat failed: {r.status_code} — {r.text[:300]}"
+        data = r.json()
+
+        ctx = data.get("scripture_context")
+        assert ctx, (
+            "scripture_context missing/empty — DB verse retrieval (search_hybrid) is "
+            f"likely failing silently. Response keys: {list(data.keys())}"
+        )
+        verses = ctx.get("verses") or []
+        assert len(verses) > 0, (
+            "Chat returned ZERO scripture verses — hybrid search produced no DB results. "
+            "This is the silent fail-open signature behind the BITB-055 / #764 outage."
+        )
+        # Grounded verses carry real references and text, not LLM-invented strings.
+        first = verses[0]
+        for field in ("reference", "text"):
+            assert first.get(field), f"grounded verse missing {field!r}: {first}"

--- a/api/tests/test_hybrid_search.py
+++ b/api/tests/test_hybrid_search.py
@@ -6,9 +6,13 @@ Tests use mocks to avoid requiring a real database connection.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 from scripture.repository import ScriptureRepository
 from scripture.search import ScriptureSearchService
+
+# Compiling against asyncpg's paramstyle reproduces exactly what reaches the driver.
+_ASYNCPG_DIALECT = postgresql.dialect(paramstyle="numeric_dollar")
 
 # ==================== Repository Tests ====================
 
@@ -185,6 +189,91 @@ class TestRawSqlHasNoPythonComment:
         sql = self._first_sql(mock_session)
         assert "#" not in sql
         assert sql.lstrip().upper().startswith(("WITH", "SELECT"))
+
+
+class TestEmbeddingBindCompilesForAsyncpg:
+    """Regression: the embedding bind must survive compilation to asyncpg's paramstyle.
+
+    The builders once cast the embedding with the Postgres ``::`` shorthand
+    (``:embedding::vector``). SQLAlchemy's bind-parameter parser refuses to bind a
+    ``:name`` immediately followed by ``::`` — it mis-detected a phantom ``embeddin``
+    bind and left the literal ``:embedding::vector`` in the compiled SQL, so asyncpg
+    raised ``syntax error at or near ":"`` and the vector was never bound.
+
+    ``CAST(:embedding AS vector)`` binds correctly. These tests compile the real SQL
+    each builder produces against asyncpg's dialect — the step the ``#``-comment tests
+    skip — so a regression to ``:embedding::vector`` (or any unbound ``:name``) fails.
+    """
+
+    @staticmethod
+    def _compile_first_sql(mock_session):
+        text_clause = mock_session.execute.call_args_list[0][0][0]
+        compiled = text_clause.compile(dialect=_ASYNCPG_DIALECT)
+        return str(compiled), compiled.positiontup
+
+    @staticmethod
+    def _assert_clean(sql: str, positiontup) -> None:
+        # No named bind may leak to asyncpg; the embedding must actually be bound.
+        assert ":" not in sql, f"unbound named parameter leaked into SQL: {sql}"
+        assert "embedding" in positiontup
+        assert "embeddin" not in positiontup  # the phantom bind from the ::vector bug
+
+    @pytest.mark.asyncio
+    async def test_search_verses_hybrid_binds_embedding(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_verses_hybrid(
+            query_text="test", query_embedding=[0.1, 0.2], translation="schlachter"
+        )
+
+        self._assert_clean(*self._compile_first_sql(mock_session))
+
+    @pytest.mark.asyncio
+    async def test_search_verses_semantic_boosted_binds_embedding(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_verses_semantic_boosted(
+            query_embedding=[0.1, 0.2], boost_topics=["faith"], translation="schlachter"
+        )
+
+        self._assert_clean(*self._compile_first_sql(mock_session))
+
+    @pytest.mark.asyncio
+    async def test_search_verses_hybrid_boosted_binds_embedding(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_verses_hybrid_boosted(
+            query_text="test",
+            query_embedding=[0.1, 0.2],
+            boost_topics=["faith"],
+            translation="schlachter",
+        )
+
+        self._assert_clean(*self._compile_first_sql(mock_session))
+
+    @pytest.mark.asyncio
+    async def test_search_passages_hybrid_binds_embedding(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await repo.search_passages_hybrid(query_text="test", query_embedding=[0.1, 0.2])
+
+        self._assert_clean(*self._compile_first_sql(mock_session))
 
 
 class TestSearchPassagesHybrid:

--- a/api/tests/test_hybrid_search_integration.py
+++ b/api/tests/test_hybrid_search_integration.py
@@ -1,0 +1,172 @@
+"""
+Integration tests that execute the real scripture-search SQL against a live
+Postgres + pgvector, instead of mocking ``session.execute``.
+
+Why this file exists
+--------------------
+Two production-breaking SQL bugs shipped because every other test mocks
+``session.execute`` — the SQL was never run against a database:
+
+* PR #764: a stray ``#`` made every query start with a Python comment
+  (``syntax error at or near "#"``).
+* The ``:embedding::vector`` cast that SQLAlchemy's ``text()`` could not bind, so
+  asyncpg received a literal ``:`` (``syntax error at or near ":"``) and the
+  embedding was never bound.
+
+These tests run all four raw-SQL builders against a real pgvector database with a
+couple of seeded rows, so an execution-level regression fails *before merge*.
+
+Skips automatically when no Postgres is reachable (e.g. local runs without a DB).
+CI's ``backend-tests`` job provides a ``pgvector/pgvector`` service container with
+``DATABASE_URL`` set, so these run on every PR.
+
+The embedding dimension is taken from ``settings.embedding_dimensions`` (1024 for
+the local Ollama model, 1536 for Azure ``text-embedding-3-small`` in production),
+so the seeded vectors always match the schema column regardless of environment.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from config import settings
+from scripture.database import get_async_database_url
+from scripture.models import Base, Book, Chapter, Passage, Translation, Verse
+from scripture.repository import ScriptureRepository
+
+# Sentinel identifiers so the rolled-back seed never collides with real data.
+_TRANSLATION = "zzint"
+_BOOK_NAME = "ZZ Integration Book"
+_VERSE_TEXT = "For God so loved the world that he gave his only Son."
+
+
+def _seed_vector() -> list[float]:
+    """Non-zero vector of the configured dimension. The query reuses this exact
+    vector, so cosine similarity is 1.0 and the verse clears every threshold."""
+    vec = [0.0] * settings.embedding_dimensions
+    vec[0] = 1.0
+    return vec
+
+
+@pytest_asyncio.fixture
+async def seeded_repo():
+    """A ``ScriptureRepository`` backed by a real session with one seeded verse and
+    passage. All writes happen inside a transaction that is rolled back, so the
+    database is left untouched. Skips when Postgres/pgvector is not reachable."""
+    url, connect_args = get_async_database_url()
+    engine = create_async_engine(url, poolclass=NullPool, connect_args=connect_args)
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            await conn.run_sync(Base.metadata.create_all)
+            # verse_topics is a raw-migration junction table (migration 004), not an
+            # ORM model, so create_all does not make it. The boosted builders LEFT
+            # JOIN it, so it must exist for them to run.
+            await conn.execute(
+                text(
+                    "CREATE TABLE IF NOT EXISTS verse_topics ("
+                    "verse_id INTEGER REFERENCES verses(id) ON DELETE CASCADE, "
+                    "topic_id INTEGER REFERENCES topics(id) ON DELETE CASCADE, "
+                    "PRIMARY KEY (verse_id, topic_id))"
+                )
+            )
+    except Exception as exc:  # connection refused, auth failure, etc.
+        await engine.dispose()
+        pytest.skip(f"Postgres+pgvector not reachable: {exc}")
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    session = factory()
+    await session.begin()
+    try:
+        vec = _seed_vector()
+        book = Book(name=_BOOK_NAME, abbreviation="ZZ", testament="new", position=999)
+        chapter = Chapter(number=3, book=book)
+        verse = Verse(
+            book=book,
+            chapter=chapter,
+            chapter_number=3,
+            verse_number=16,
+            text=_VERSE_TEXT,
+            translation=_TRANSLATION,
+            embedding=vec,
+        )
+        session.add_all(
+            [
+                Translation(
+                    code=_TRANSLATION,
+                    name="Integration",
+                    language="English",
+                    language_code="en",
+                ),
+                book,
+                chapter,
+                verse,
+            ]
+        )
+        await session.flush()  # assigns book.id / verse.id for the passage + reads
+        session.add(
+            Passage(
+                title="ZZ Integration Passage",
+                start_book_id=book.id,
+                start_chapter=3,
+                start_verse=16,
+                end_chapter=3,
+                end_verse=18,
+                text=_VERSE_TEXT,
+                embedding=vec,
+            )
+        )
+        await session.flush()
+        yield ScriptureRepository(session)
+    finally:
+        await session.rollback()
+        await session.close()
+        await engine.dispose()
+
+
+async def test_search_verses_hybrid_executes_against_real_db(seeded_repo):
+    """The production-critical path: real hybrid SQL must run and return the verse.
+
+    Fails with PostgresSyntaxError on the ``:embedding::vector`` regression."""
+    rows = await seeded_repo.search_verses_hybrid(
+        query_text="loved the world",
+        query_embedding=_seed_vector(),
+        translation=_TRANSLATION,
+    )
+    assert rows, "hybrid search returned no rows from the real DB"
+    verse, score = rows[0]
+    assert verse.text == _VERSE_TEXT
+    assert score > 0
+
+
+async def test_search_verses_semantic_boosted_executes_against_real_db(seeded_repo):
+    rows = await seeded_repo.search_verses_semantic_boosted(
+        query_embedding=_seed_vector(),
+        boost_topics=["faith"],  # no matching topics → verse returned via base score
+        translation=_TRANSLATION,
+    )
+    assert rows, "semantic-boosted search returned no rows from the real DB"
+    assert rows[0][0].text == _VERSE_TEXT
+
+
+async def test_search_verses_hybrid_boosted_executes_against_real_db(seeded_repo):
+    rows = await seeded_repo.search_verses_hybrid_boosted(
+        query_text="loved the world",
+        query_embedding=_seed_vector(),
+        boost_topics=["faith"],
+        translation=_TRANSLATION,
+    )
+    assert rows, "hybrid-boosted search returned no rows from the real DB"
+    assert rows[0][0].text == _VERSE_TEXT
+
+
+async def test_search_passages_hybrid_executes_against_real_db(seeded_repo):
+    rows = await seeded_repo.search_passages_hybrid(
+        query_text="loved the world",
+        query_embedding=_seed_vector(),
+    )
+    assert rows, "passage hybrid search returned no rows from the real DB"
+    assert rows[0][0].text == _VERSE_TEXT


### PR DESCRIPTION
## Problem

Scripture search is **still broken in production after #764**. The 2026-06-20 14:37 log shows a *different* error than the one #764 fixed:

```
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near ":"
... (1 - (v.embedding <=> :embedding::vector)) AS semantic_score ...
[parameters: ('Was sagt die Bibel über Geld?', 0.35, 'schlachter', 0.7, 0.3, 10)]
```

`search_verses_hybrid` aborts the shared session transaction, so the cited-verse lookups that run next fail with `InFailedSQLTransactionError` (`Matthew 6:24`, `Proverbs 30:8-9` in the same log). Net effect: no DB verses in the context pool or the Cited panel.

## Root cause (empirically verified, SQLAlchemy 2.0.51)

The raw SQL cast the embedding bind with the Postgres `::` shorthand: `:embedding::vector`. SQLAlchemy's `text()` bind-parameter parser **refuses to bind a `:name` immediately followed by `::`**. Reproduced by compiling against asyncpg's paramstyle:

```
:embedding::vector         -> binds {'embeddin', ...}; SQL keeps literal ":embedding::vector"  (BROKEN)
CAST(:embedding AS vector) -> binds {'embedding', ...}; SQL -> CAST($1 AS vector)              (CORRECT)
```

It mis-detects a phantom `embeddin` bind (last char dropped) and leaves the literal `:embedding::vector` unreplaced, so asyncpg receives a literal `:` and the vector is never bound — note the 6-value parameter tuple in the log has no embedding.

This is independent of #764, which only relocated a misplaced `# nosec` comment.

## Fix

- **`api/scripture/repository.py`** — replace all 8 `:embedding::vector` occurrences with the equivalent `CAST(:embedding AS vector)` across the four raw-SQL builders: `search_verses_hybrid`, `search_verses_semantic_boosted`, `search_verses_hybrid_boosted`, `search_passages_hybrid`. `git grep ':\w\+::\w\+'` over `api/` returns only these 8 lines.
- **`api/tests/test_hybrid_search.py`** — new `TestEmbeddingBindCompilesForAsyncpg` that compiles each builder's real SQL against `postgresql.dialect(paramstyle="numeric_dollar")` and asserts the embedding is bound and no named parameter leaks to the driver. It **fails on the old `:embedding::vector` form and passes on the fix** — closing the blind spot (all prior tests mock `session.execute`) that let both this bug and #764's `#` bug ship.

## Verification

- `test_hybrid_search.py`: 20/20 pass; confirmed the new tests fail when reverted to `:embedding::vector`.
- Full API suite: 3256 passed (the only 2 failures are live-network tests hitting `api.getbible.net`, which returns 403 from the sandbox — unrelated).
- ruff / black / mypy clean.
- Post-deploy: re-run "Was sagt die Bibel über Geld?" (schlachter) and confirm `search_verses_hybrid` returns rows with no `PostgresSyntaxError` / `InFailedSQLTransactionError`, and the Cited panel populates. #764's `scripture_grounding_errors` alert should stay quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016miB4jvN2GBjPk13bAiPJa)_