### PR TITLE
feat(api): instrument per-stage chat pipeline timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,9 @@ Additional documentation is available in the `docs/` directory:
 - **[How to Enable Content Safety](docs/HOW-TO-ENABLE-CONTENT-SAFETY.md)** - Step-by-step
   guide to enable multi-language content safety filter (deployed 2026-03-04, currently
   disabled)
+- **[How to Read Chat Stage Timings](docs/HOW-TO-READ-CHAT-STAGE-TIMINGS.md)** - Find the
+  per-stage latency breakdown (`chat_stage_timings` log + `chat.stage.duration_ms` metric)
+  in container logs and Application Insights
 - **[GitHub Actions Security](docs/GITHUB_ACTIONS_SECURITY.md)** - CI/CD security best practices
 - **[Technical Debt](docs/TECHNICAL_DEBT.md)** - Known issues and improvement roadmap
 - **[Troubleshooting](docs/TROUBLESHOOTING.md)** - Common issues and solutions

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -32,6 +32,7 @@ from utils.metrics import (
     verse_grounding_duration_histogram,
     verse_grounding_quotes_checked_counter,
 )
+from utils.timing import record_stage, stage_timer
 from utils.verse_parser import (
     extract_all_references,
     extract_inline_quotes,
@@ -322,6 +323,8 @@ Keep it under 100 words."""
             ChatResponse with generated message and context
         """
         total_start = time.time()
+        timings: dict[str, float] = {}
+        stage_attrs = {"stream": False, "provider": settings.llm_provider}
         # Track session interactions (history_count + 1 = total messages in session)
         session_message_count = len(request.conversation_history) + 1
         logger.info(
@@ -367,9 +370,10 @@ Keep it under 100 words."""
         )
 
         # Content safety check BEFORE LLM call
-        safety = await self._check_content_safety(
-            request.message, effective_language, request.session_id, context="chat"
-        )
+        with stage_timer(timings, "content_safety", stage_attrs):
+            safety = await self._check_content_safety(
+                request.message, effective_language, request.session_id, context="chat"
+            )
         if not safety.allowed:
             return self._build_blocked_response(
                 safety, effective_language, translation, translation_info
@@ -377,7 +381,8 @@ Keep it under 100 words."""
 
         # Intent detection: classify before scripture search
         if settings.content_filter_intent_detection:
-            detected_intent = await self._detect_intent(request.message, model_override)
+            with stage_timer(timings, "intent", stage_attrs):
+                detected_intent = await self._detect_intent(request.message, model_override)
             if detected_intent == "OFF_TOPIC":
                 return await self._handle_off_topic(
                     request,
@@ -403,14 +408,17 @@ Keep it under 100 words."""
             )
 
         # Step 1: Search for relevant scripture (if enabled)
-        scripture_context, search_context_prompt = await self._search_scripture(
-            request,
-            translation,
-            verse_refs,
-            is_verse_lookup,
-            detected_language=effective_language,
-            model_override=model_override,
-        )
+        with stage_timer(timings, "retrieval", stage_attrs):
+            scripture_context, search_context_prompt = await self._search_scripture(
+                request,
+                translation,
+                verse_refs,
+                is_verse_lookup,
+                detected_language=effective_language,
+                model_override=model_override,
+                timings=timings,
+                stage_attrs=stage_attrs,
+            )
 
         # Step 2: Build the message list
         prompt_type = self._determine_prompt_type(is_verse_lookup, prayer_ref)
@@ -435,6 +443,7 @@ Keep it under 100 words."""
                 model_override=model_override,
             )
             llm_duration = time.time() - llm_start
+            record_stage(timings, "generation", llm_duration * 1000, stage_attrs)
             logger.info(
                 "LLM response received",
                 extra={
@@ -473,9 +482,13 @@ Keep it under 100 words."""
 
         # Ground the response: rewrite any fabricated/mismatched inline verse
         # quote to the canonical DB text before returning it to the client.
-        message, _ = await self._apply_verse_grounding(
-            response.content, scripture_context, translation, effective_language
-        )
+        with stage_timer(timings, "grounding", stage_attrs):
+            message, _ = await self._apply_verse_grounding(
+                response.content, scripture_context, translation, effective_language
+            )
+
+        record_stage(timings, "total", (time.time() - total_start) * 1000, stage_attrs)
+        logger.info("chat_stage_timings", extra={"timings_ms": timings, "stream": False})
 
         return ChatResponse(
             message_id=message_id,
@@ -595,6 +608,8 @@ Keep it under 100 words."""
         is_verse_lookup: bool,
         detected_language: str = "en",  # NEW
         model_override: str | None = None,  # NEW
+        timings: dict[str, float] | None = None,
+        stage_attrs: dict | None = None,
     ) -> tuple[SearchResults | None, str]:
         """
         Search for relevant scripture, including direct lookups for specific verse references.
@@ -604,6 +619,11 @@ Keep it under 100 words."""
         """
         if not request.include_search:
             return None, ""
+
+        # When called outside the instrumented chat paths, keep a local dict so the
+        # query-expansion sub-stage is still timed (and histogram-recorded) safely.
+        if timings is None:
+            timings = {}
 
         search_start = time.time()
         scripture_context = None
@@ -616,17 +636,18 @@ Keep it under 100 words."""
             # Query expansion (optional feature flag)
             extra_embeddings: list[list[float]] | None = None
             if settings.query_expansion_enabled:
-                expanded_query = await self._expand_query(
-                    request.message, detected_language, model_override
-                )
-                if expanded_query != request.message:
-                    # Generate embedding for expanded query
-                    expansion_embed_response = await self.embedding.embed(expanded_query)
-                    extra_embeddings = [expansion_embed_response.embedding]
-                    logger.info(
-                        "Query expansion embeddings generated",
-                        extra={"num_extra_embeddings": len(extra_embeddings)},
+                with stage_timer(timings, "query_expansion", stage_attrs):
+                    expanded_query = await self._expand_query(
+                        request.message, detected_language, model_override
                     )
+                    if expanded_query != request.message:
+                        # Generate embedding for expanded query
+                        expansion_embed_response = await self.embedding.embed(expanded_query)
+                        extra_embeddings = [expansion_embed_response.embedding]
+                        logger.info(
+                            "Query expansion embeddings generated",
+                            extra={"num_extra_embeddings": len(extra_embeddings)},
+                        )
 
             # Topic detection for boosting (keyword-based, <10ms)
             boost_topics: list[str] = []
@@ -887,6 +908,10 @@ Keep it under 100 words."""
         # Generate unique message ID for feedback tracking
         message_id = str(uuid.uuid4())
 
+        total_start = time.perf_counter()
+        timings: dict[str, float] = {}
+        stage_attrs = {"stream": True, "provider": settings.llm_provider}
+
         # Resolve translation: user preference > language detection > default
         detected_language = detect_language(request.message)
         # Use the client-supplied language when present; fall back to auto-detection.
@@ -914,9 +939,10 @@ Keep it under 100 words."""
         )
 
         # Content safety check BEFORE LLM call
-        safety = await self._check_content_safety(
-            request.message, effective_language, request.session_id, context="chat stream"
-        )
+        with stage_timer(timings, "content_safety", stage_attrs):
+            safety = await self._check_content_safety(
+                request.message, effective_language, request.session_id, context="chat stream"
+            )
         if not safety.allowed:
             async for chunk in self._stream_blocked_response(
                 safety, message_id, effective_language, translation, translation_info
@@ -926,7 +952,8 @@ Keep it under 100 words."""
 
         # Intent detection: short-circuit off-topic before scripture search
         if settings.content_filter_intent_detection:
-            detected_intent = await self._detect_intent(request.message, model_override)
+            with stage_timer(timings, "intent", stage_attrs):
+                detected_intent = await self._detect_intent(request.message, model_override)
             if detected_intent == "OFF_TOPIC":
                 logger.info("Off-topic message detected in stream, skipping scripture search")
 
@@ -965,14 +992,17 @@ Keep it under 100 words."""
         verse_refs, prayer_ref = extract_references(request.message)
 
         # Step 1: Search for relevant scripture
-        scripture_context, search_context_prompt = await self._search_scripture(
-            request,
-            translation,
-            verse_refs,
-            is_verse_lookup,
-            detected_language=effective_language,
-            model_override=model_override,
-        )
+        with stage_timer(timings, "retrieval", stage_attrs):
+            scripture_context, search_context_prompt = await self._search_scripture(
+                request,
+                translation,
+                verse_refs,
+                is_verse_lookup,
+                detected_language=effective_language,
+                model_override=model_override,
+                timings=timings,
+                stage_attrs=stage_attrs,
+            )
 
         # Step 2: Send metadata before streaming starts
         yield {
@@ -1000,14 +1030,24 @@ Keep it under 100 words."""
 
         # Step 4: Stream response content and accumulate full response
         full_response = ""
+        first_token_at: float | None = None
         async for token in self.llm.chat_stream(
             messages=messages,
             temperature=settings.llm_temperature,
             max_tokens=settings.llm_max_tokens,
             model_override=model_override,
         ):
+            if first_token_at is None:
+                # TTFT = everything the user waits through before the first visible
+                # token (safety + intent + retrieval + provider latency).
+                first_token_at = time.perf_counter()
+                record_stage(timings, "ttft", (first_token_at - total_start) * 1000, stage_attrs)
             full_response += token
             yield {"type": "content", "content": token}
+        if first_token_at is not None:
+            record_stage(
+                timings, "generation", (time.perf_counter() - first_token_at) * 1000, stage_attrs
+            )
 
         # Step 5: Extract cited verses (dual-source) and yield completion event
         structured = parse_structured_citations(full_response)
@@ -1029,20 +1069,23 @@ Keep it under 100 words."""
         # can merge them into its verse panel. Without this, a cited verse that
         # is outside the semantic pool (common on follow-up questions) never
         # appears in the "Cited" tab.
-        resolved_verses = await self._resolve_cited_verses(list(merged_refs.values()), translation)
+        with stage_timer(timings, "grounding", stage_attrs):
+            resolved_verses = await self._resolve_cited_verses(
+                list(merged_refs.values()), translation
+            )
 
-        # Ground the streamed answer: detect fabricated/mismatched inline verse
-        # quotes and rewrite them to canonical text. Reuses resolved_verses (no
-        # extra DB calls). The tokens are already on the client's screen, so the
-        # correction is delivered as an authoritative `corrected_message` the
-        # client swaps in — only when something actually changed.
-        corrected_message, corrections = await self._apply_verse_grounding(
-            full_response,
-            scripture_context,
-            translation,
-            effective_language,
-            resolved_verses=resolved_verses,
-        )
+            # Ground the streamed answer: detect fabricated/mismatched inline verse
+            # quotes and rewrite them to canonical text. Reuses resolved_verses (no
+            # extra DB calls). The tokens are already on the client's screen, so the
+            # correction is delivered as an authoritative `corrected_message` the
+            # client swaps in — only when something actually changed.
+            corrected_message, corrections = await self._apply_verse_grounding(
+                full_response,
+                scripture_context,
+                translation,
+                effective_language,
+                resolved_verses=resolved_verses,
+            )
 
         # Track LLM structured output compliance — helps decide whether to
         # invest in tool/function calling as a more reliable mechanism.
@@ -1083,6 +1126,10 @@ Keep it under 100 words."""
             completion["corrections"] = [
                 {"reference": c.reference, "reason": c.reason} for c in corrections
             ]
+
+        record_stage(timings, "total", (time.perf_counter() - total_start) * 1000, stage_attrs)
+        logger.info("chat_stage_timings", extra={"timings_ms": timings, "stream": True})
+
         yield completion
 
     def _determine_prompt_type(self, is_verse_lookup: bool, prayer_ref) -> str:

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -32,7 +32,7 @@ from utils.metrics import (
     verse_grounding_duration_histogram,
     verse_grounding_quotes_checked_counter,
 )
-from utils.timing import record_stage, stage_timer
+from utils.timing import record_stage, timed_stage
 from utils.verse_parser import (
     extract_all_references,
     extract_inline_quotes,
@@ -138,7 +138,14 @@ class ChatService:
         self.llm = llm_provider
         self.embedding = embedding_provider
         self.search_service = ScriptureSearchService(db_session, embedding_provider)
+        # Per-request timing context read by the @timed_stage decorator. Set at the top
+        # of chat()/chat_stream(); a fresh ChatService is created per request
+        # (api/routes/chat.py), so these are safe to keep on the instance.
+        self._timings: dict[str, float] | None = None
+        self._stage_attrs: dict | None = None
+        self._active_stages: set[str] = set()
 
+    @timed_stage("intent")
     async def _detect_intent(self, message: str, model_override: str | None = None) -> str:
         """
         Classify user intent with a fast LLM call.
@@ -168,6 +175,7 @@ class ChatService:
             logger.warning("Intent detection failed, defaulting to GENERAL: %s", e)
             return "GENERAL"
 
+    @timed_stage("content_safety")
     async def _check_content_safety(
         self,
         message: str,
@@ -298,6 +306,26 @@ Keep it under 100 words."""
             logger.warning("Query expansion failed, using original query: %s", e)
             return user_message
 
+    @timed_stage("query_expansion")
+    async def _build_expansion_embeddings(
+        self, message: str, detected_language: str, model_override: str | None = None
+    ) -> list[list[float]] | None:
+        """Expand the query and embed the expansion for multi-embedding search.
+
+        Returns the extra embeddings to feed into semantic search, or ``None`` when
+        expansion produced nothing new. Timed as the ``query_expansion`` stage.
+        """
+        expanded_query = await self._expand_query(message, detected_language, model_override)
+        if expanded_query == message:
+            return None
+        expansion_embed_response = await self.embedding.embed(expanded_query)
+        extra_embeddings = [expansion_embed_response.embedding]
+        logger.info(
+            "Query expansion embeddings generated",
+            extra={"num_extra_embeddings": len(extra_embeddings)},
+        )
+        return extra_embeddings
+
     def _detect_topics(self, message: str) -> list[str]:
         """
         Detect biblical topics in user message using keyword-based mapping.
@@ -325,6 +353,10 @@ Keep it under 100 words."""
         total_start = time.time()
         timings: dict[str, float] = {}
         stage_attrs = {"stream": False, "provider": settings.llm_provider}
+        # Activate the per-request timing context read by @timed_stage-decorated methods.
+        self._timings = timings
+        self._stage_attrs = stage_attrs
+        self._active_stages = set()
         # Track session interactions (history_count + 1 = total messages in session)
         session_message_count = len(request.conversation_history) + 1
         logger.info(
@@ -369,11 +401,10 @@ Keep it under 100 words."""
             },
         )
 
-        # Content safety check BEFORE LLM call
-        with stage_timer(timings, "content_safety", stage_attrs):
-            safety = await self._check_content_safety(
-                request.message, effective_language, request.session_id, context="chat"
-            )
+        # Content safety check BEFORE LLM call (timed via @timed_stage on the method)
+        safety = await self._check_content_safety(
+            request.message, effective_language, request.session_id, context="chat"
+        )
         if not safety.allowed:
             return self._build_blocked_response(
                 safety, effective_language, translation, translation_info
@@ -381,8 +412,7 @@ Keep it under 100 words."""
 
         # Intent detection: classify before scripture search
         if settings.content_filter_intent_detection:
-            with stage_timer(timings, "intent", stage_attrs):
-                detected_intent = await self._detect_intent(request.message, model_override)
+            detected_intent = await self._detect_intent(request.message, model_override)
             if detected_intent == "OFF_TOPIC":
                 return await self._handle_off_topic(
                     request,
@@ -407,18 +437,15 @@ Keep it under 100 words."""
                 },
             )
 
-        # Step 1: Search for relevant scripture (if enabled)
-        with stage_timer(timings, "retrieval", stage_attrs):
-            scripture_context, search_context_prompt = await self._search_scripture(
-                request,
-                translation,
-                verse_refs,
-                is_verse_lookup,
-                detected_language=effective_language,
-                model_override=model_override,
-                timings=timings,
-                stage_attrs=stage_attrs,
-            )
+        # Step 1: Search for relevant scripture (if enabled; timed via @timed_stage)
+        scripture_context, search_context_prompt = await self._search_scripture(
+            request,
+            translation,
+            verse_refs,
+            is_verse_lookup,
+            detected_language=effective_language,
+            model_override=model_override,
+        )
 
         # Step 2: Build the message list
         prompt_type = self._determine_prompt_type(is_verse_lookup, prayer_ref)
@@ -482,10 +509,9 @@ Keep it under 100 words."""
 
         # Ground the response: rewrite any fabricated/mismatched inline verse
         # quote to the canonical DB text before returning it to the client.
-        with stage_timer(timings, "grounding", stage_attrs):
-            message, _ = await self._apply_verse_grounding(
-                response.content, scripture_context, translation, effective_language
-            )
+        message, _ = await self._apply_verse_grounding(
+            response.content, scripture_context, translation, effective_language
+        )
 
         record_stage(timings, "total", (time.time() - total_start) * 1000, stage_attrs)
         logger.info("chat_stage_timings", extra={"timings_ms": timings, "stream": False})
@@ -600,6 +626,7 @@ Keep it under 100 words."""
             await asyncio.sleep(0)  # cooperative yield, no real delay
         yield {"type": "completion", "verses_cited": []}
 
+    @timed_stage("retrieval")
     async def _search_scripture(  # noqa: C901
         self,
         request: ChatRequest,
@@ -608,8 +635,6 @@ Keep it under 100 words."""
         is_verse_lookup: bool,
         detected_language: str = "en",  # NEW
         model_override: str | None = None,  # NEW
-        timings: dict[str, float] | None = None,
-        stage_attrs: dict | None = None,
     ) -> tuple[SearchResults | None, str]:
         """
         Search for relevant scripture, including direct lookups for specific verse references.
@@ -619,11 +644,6 @@ Keep it under 100 words."""
         """
         if not request.include_search:
             return None, ""
-
-        # When called outside the instrumented chat paths, keep a local dict so the
-        # query-expansion sub-stage is still timed (and histogram-recorded) safely.
-        if timings is None:
-            timings = {}
 
         search_start = time.time()
         scripture_context = None
@@ -636,18 +656,9 @@ Keep it under 100 words."""
             # Query expansion (optional feature flag)
             extra_embeddings: list[list[float]] | None = None
             if settings.query_expansion_enabled:
-                with stage_timer(timings, "query_expansion", stage_attrs):
-                    expanded_query = await self._expand_query(
-                        request.message, detected_language, model_override
-                    )
-                    if expanded_query != request.message:
-                        # Generate embedding for expanded query
-                        expansion_embed_response = await self.embedding.embed(expanded_query)
-                        extra_embeddings = [expansion_embed_response.embedding]
-                        logger.info(
-                            "Query expansion embeddings generated",
-                            extra={"num_extra_embeddings": len(extra_embeddings)},
-                        )
+                extra_embeddings = await self._build_expansion_embeddings(
+                    request.message, detected_language, model_override
+                )
 
             # Topic detection for boosting (keyword-based, <10ms)
             boost_topics: list[str] = []
@@ -822,6 +833,7 @@ Keep it under 100 words."""
                 logger.warning(f"Failed to resolve cited verse {ref}: {e}")
         return list(resolved.values())
 
+    @timed_stage("grounding")
     async def _apply_verse_grounding(
         self,
         text: str,
@@ -885,6 +897,37 @@ Keep it under 100 words."""
             )
         return corrected, corrections
 
+    @timed_stage("grounding")
+    async def _ground_streamed_answer(
+        self,
+        cited_refs: list,
+        full_response: str,
+        scripture_context: SearchResults | None,
+        translation: str | None,
+        language: str,
+    ) -> tuple[list, str, list]:
+        """Resolve cited verses and ground the streamed answer as one timed stage.
+
+        Returns ``(resolved_verses, corrected_message, corrections)``. The inner
+        ``_apply_verse_grounding`` is also ``@timed_stage("grounding")``, but the
+        re-entrancy guard means this outer frame owns the single "grounding"
+        measurement (resolve + rewrite), matching the previous streaming behaviour.
+        """
+        resolved_verses = await self._resolve_cited_verses(cited_refs, translation)
+        # Ground the streamed answer: detect fabricated/mismatched inline verse quotes
+        # and rewrite them to canonical text. Reuses resolved_verses (no extra DB calls).
+        # The tokens are already on the client's screen, so the correction is delivered
+        # as an authoritative `corrected_message` the client swaps in — only when
+        # something actually changed.
+        corrected_message, corrections = await self._apply_verse_grounding(
+            full_response,
+            scripture_context,
+            translation,
+            language,
+            resolved_verses=resolved_verses,
+        )
+        return resolved_verses, corrected_message, corrections
+
     def _merge_direct_verses(self, scripture_context: SearchResults, direct_verses: list) -> None:
         """Merge direct lookup verses into scripture context (at beginning)."""
         if not direct_verses or not scripture_context:
@@ -911,6 +954,10 @@ Keep it under 100 words."""
         total_start = time.perf_counter()
         timings: dict[str, float] = {}
         stage_attrs = {"stream": True, "provider": settings.llm_provider}
+        # Activate the per-request timing context read by @timed_stage-decorated methods.
+        self._timings = timings
+        self._stage_attrs = stage_attrs
+        self._active_stages = set()
 
         # Resolve translation: user preference > language detection > default
         detected_language = detect_language(request.message)
@@ -938,11 +985,10 @@ Keep it under 100 words."""
             },
         )
 
-        # Content safety check BEFORE LLM call
-        with stage_timer(timings, "content_safety", stage_attrs):
-            safety = await self._check_content_safety(
-                request.message, effective_language, request.session_id, context="chat stream"
-            )
+        # Content safety check BEFORE LLM call (timed via @timed_stage on the method)
+        safety = await self._check_content_safety(
+            request.message, effective_language, request.session_id, context="chat stream"
+        )
         if not safety.allowed:
             async for chunk in self._stream_blocked_response(
                 safety, message_id, effective_language, translation, translation_info
@@ -952,8 +998,7 @@ Keep it under 100 words."""
 
         # Intent detection: short-circuit off-topic before scripture search
         if settings.content_filter_intent_detection:
-            with stage_timer(timings, "intent", stage_attrs):
-                detected_intent = await self._detect_intent(request.message, model_override)
+            detected_intent = await self._detect_intent(request.message, model_override)
             if detected_intent == "OFF_TOPIC":
                 logger.info("Off-topic message detected in stream, skipping scripture search")
 
@@ -991,18 +1036,15 @@ Keep it under 100 words."""
         is_verse_lookup = is_verse_lookup_request(request.message)
         verse_refs, prayer_ref = extract_references(request.message)
 
-        # Step 1: Search for relevant scripture
-        with stage_timer(timings, "retrieval", stage_attrs):
-            scripture_context, search_context_prompt = await self._search_scripture(
-                request,
-                translation,
-                verse_refs,
-                is_verse_lookup,
-                detected_language=effective_language,
-                model_override=model_override,
-                timings=timings,
-                stage_attrs=stage_attrs,
-            )
+        # Step 1: Search for relevant scripture (timed via @timed_stage)
+        scripture_context, search_context_prompt = await self._search_scripture(
+            request,
+            translation,
+            verse_refs,
+            is_verse_lookup,
+            detected_language=effective_language,
+            model_override=model_override,
+        )
 
         # Step 2: Send metadata before streaming starts
         yield {
@@ -1069,23 +1111,13 @@ Keep it under 100 words."""
         # can merge them into its verse panel. Without this, a cited verse that
         # is outside the semantic pool (common on follow-up questions) never
         # appears in the "Cited" tab.
-        with stage_timer(timings, "grounding", stage_attrs):
-            resolved_verses = await self._resolve_cited_verses(
-                list(merged_refs.values()), translation
-            )
-
-            # Ground the streamed answer: detect fabricated/mismatched inline verse
-            # quotes and rewrite them to canonical text. Reuses resolved_verses (no
-            # extra DB calls). The tokens are already on the client's screen, so the
-            # correction is delivered as an authoritative `corrected_message` the
-            # client swaps in — only when something actually changed.
-            corrected_message, corrections = await self._apply_verse_grounding(
-                full_response,
-                scripture_context,
-                translation,
-                effective_language,
-                resolved_verses=resolved_verses,
-            )
+        resolved_verses, corrected_message, corrections = await self._ground_streamed_answer(
+            list(merged_refs.values()),
+            full_response,
+            scripture_context,
+            translation,
+            effective_language,
+        )
 
         # Track LLM structured output compliance — helps decide whether to
         # invest in tool/function calling as a more reliable mechanism.

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -32,7 +32,7 @@ from utils.metrics import (
     verse_grounding_duration_histogram,
     verse_grounding_quotes_checked_counter,
 )
-from utils.timing import record_stage, timed_stage
+from utils.timing import format_timings, record_stage, timed_stage
 from utils.verse_parser import (
     extract_all_references,
     extract_inline_quotes,
@@ -514,7 +514,11 @@ Keep it under 100 words."""
         )
 
         record_stage(timings, "total", (time.time() - total_start) * 1000, stage_attrs)
-        logger.info("chat_stage_timings", extra={"timings_ms": timings, "stream": False})
+        logger.info(
+            "chat_stage_timings %s",
+            format_timings(timings),
+            extra={"timings_ms": timings, "stream": False},
+        )
 
         return ChatResponse(
             message_id=message_id,
@@ -1160,7 +1164,11 @@ Keep it under 100 words."""
             ]
 
         record_stage(timings, "total", (time.perf_counter() - total_start) * 1000, stage_attrs)
-        logger.info("chat_stage_timings", extra={"timings_ms": timings, "stream": True})
+        logger.info(
+            "chat_stage_timings %s",
+            format_timings(timings),
+            extra={"timings_ms": timings, "stream": True},
+        )
 
         yield completion
 

--- a/api/tests/test_chat_timing.py
+++ b/api/tests/test_chat_timing.py
@@ -15,7 +15,7 @@ import pytest
 
 from utils import timing
 from utils.metrics import chat_stage_duration_histogram
-from utils.timing import record_stage, timed_stage
+from utils.timing import format_timings, record_stage, timed_stage
 
 
 class TestRecordStage:
@@ -46,6 +46,15 @@ class TestRecordStage:
             record_stage(timings, "generation", 10.0)
 
         assert timings == {"generation": 10.0}
+
+
+class TestFormatTimings:
+    def test_renders_compact_key_value_string(self):
+        timings = {"intent": 3100.5, "retrieval": 8200.1, "total": 11500.0}
+        assert format_timings(timings) == "intent=3100.5 retrieval=8200.1 total=11500.0"
+
+    def test_empty_timings_is_empty_string(self):
+        assert format_timings({}) == ""
 
 
 class _FakeService:

--- a/api/tests/test_chat_timing.py
+++ b/api/tests/test_chat_timing.py
@@ -1,17 +1,21 @@
 """
-Tests for the per-stage chat timing helper (utils.timing).
+Tests for the per-stage chat timing helpers (utils.timing).
 
-These verify that stage durations are written into the per-request ``timings``
-dict (the source of the ``chat_stage_timings`` log line) and recorded into the
-``chat.stage.duration_ms`` OpenTelemetry histogram, and that recording is
-best-effort (a telemetry failure must never propagate into a chat response).
+These verify that stage durations are written into the per-request ``timings`` dict
+(the source of the ``chat_stage_timings`` log line) and recorded into the
+``chat.stage.duration_ms`` OpenTelemetry histogram, that recording is best-effort (a
+telemetry failure must never propagate into a chat response), and that the
+``@timed_stage`` decorator times the methods it wraps without double-counting nested
+same-stage calls.
 """
 
 from unittest.mock import patch
 
+import pytest
+
 from utils import timing
 from utils.metrics import chat_stage_duration_histogram
-from utils.timing import record_stage, stage_timer
+from utils.timing import record_stage, timed_stage
 
 
 class TestRecordStage:
@@ -44,27 +48,70 @@ class TestRecordStage:
         assert timings == {"generation": 10.0}
 
 
-class TestStageTimer:
-    def test_times_block_and_records(self):
-        timings: dict[str, float] = {}
+class _FakeService:
+    """Minimal stand-in exposing the attributes ``@timed_stage`` reads off ``self``."""
+
+    def __init__(self, timings: dict[str, float] | None):
+        self._timings = timings
+        self._stage_attrs = {"stream": False}
+        self._active_stages: set[str] = set()
+
+    @timed_stage("intent")
+    async def detect(self, value):
+        return value
+
+    @timed_stage("grounding")
+    async def boom(self):
+        raise ValueError("inner failure")
+
+    @timed_stage("grounding")
+    async def outer(self):
+        # Nested same-stage call: the inner decorated method must not double-record.
+        return await self.inner()
+
+    @timed_stage("grounding")
+    async def inner(self):
+        return "ok"
+
+
+class TestTimedStage:
+    async def test_records_into_timings_and_histogram(self):
+        svc = _FakeService(timings={})
         # Patch perf_counter so the measured duration is deterministic.
         with patch.object(timing.time, "perf_counter", side_effect=[1.0, 1.25]):
             with patch.object(chat_stage_duration_histogram, "record") as mock_record:
-                with stage_timer(timings, "search", {"stream": False}):
-                    pass
+                result = await svc.detect("hello")
 
-        assert timings == {"search": 250.0}
-        mock_record.assert_called_once_with(250.0, {"stage": "search", "stream": False})
+        assert result == "hello"
+        assert svc._timings == {"intent": 250.0}
+        mock_record.assert_called_once_with(250.0, {"stage": "intent", "stream": False})
 
-    def test_records_even_when_block_raises(self):
-        timings: dict[str, float] = {}
+    async def test_noop_when_no_timing_context(self):
+        """Called outside a chat request (``_timings is None``) → run, record nothing."""
+        svc = _FakeService(timings=None)
+        with patch.object(chat_stage_duration_histogram, "record") as mock_record:
+            result = await svc.detect("hello")
+
+        assert result == "hello"
+        assert svc._timings is None
+        mock_record.assert_not_called()
+
+    async def test_records_even_when_method_raises(self):
+        svc = _FakeService(timings={})
         with patch.object(timing.time, "perf_counter", side_effect=[2.0, 2.1]):
-            try:
-                with stage_timer(timings, "grounding"):
-                    raise ValueError("inner failure")
-            except ValueError:
-                pass
+            with pytest.raises(ValueError):
+                await svc.boom()
 
         # finally-clause still records the partial duration.
-        assert "grounding" in timings
-        assert timings["grounding"] == 100.0
+        assert svc._timings == {"grounding": 100.0}
+
+    async def test_nested_same_stage_records_once(self):
+        svc = _FakeService(timings={})
+        with patch.object(chat_stage_duration_histogram, "record") as mock_record:
+            result = await svc.outer()
+
+        assert result == "ok"
+        # Only the outermost frame owns the "grounding" measurement.
+        assert list(svc._timings.keys()) == ["grounding"]
+        mock_record.assert_called_once()
+        assert mock_record.call_args.args[1]["stage"] == "grounding"

--- a/api/tests/test_chat_timing.py
+++ b/api/tests/test_chat_timing.py
@@ -1,0 +1,70 @@
+"""
+Tests for the per-stage chat timing helper (utils.timing).
+
+These verify that stage durations are written into the per-request ``timings``
+dict (the source of the ``chat_stage_timings`` log line) and recorded into the
+``chat.stage.duration_ms`` OpenTelemetry histogram, and that recording is
+best-effort (a telemetry failure must never propagate into a chat response).
+"""
+
+from unittest.mock import patch
+
+from utils import timing
+from utils.metrics import chat_stage_duration_histogram
+from utils.timing import record_stage, stage_timer
+
+
+class TestRecordStage:
+    def test_writes_into_timings_and_rounds(self):
+        timings: dict[str, float] = {}
+        with patch.object(chat_stage_duration_histogram, "record") as mock_record:
+            record_stage(timings, "intent", 3100.456, {"stream": True, "provider": "openrouter"})
+
+        assert timings == {"intent": 3100.5}
+        mock_record.assert_called_once_with(
+            3100.456, {"stage": "intent", "stream": True, "provider": "openrouter"}
+        )
+
+    def test_works_without_base_attributes(self):
+        timings: dict[str, float] = {}
+        with patch.object(chat_stage_duration_histogram, "record") as mock_record:
+            record_stage(timings, "retrieval", 42.0)
+
+        assert timings == {"retrieval": 42.0}
+        mock_record.assert_called_once_with(42.0, {"stage": "retrieval"})
+
+    def test_telemetry_failure_is_swallowed(self):
+        """A histogram error must not break the response; the dict is still written."""
+        timings: dict[str, float] = {}
+        with patch.object(
+            chat_stage_duration_histogram, "record", side_effect=RuntimeError("boom")
+        ):
+            record_stage(timings, "generation", 10.0)
+
+        assert timings == {"generation": 10.0}
+
+
+class TestStageTimer:
+    def test_times_block_and_records(self):
+        timings: dict[str, float] = {}
+        # Patch perf_counter so the measured duration is deterministic.
+        with patch.object(timing.time, "perf_counter", side_effect=[1.0, 1.25]):
+            with patch.object(chat_stage_duration_histogram, "record") as mock_record:
+                with stage_timer(timings, "search", {"stream": False}):
+                    pass
+
+        assert timings == {"search": 250.0}
+        mock_record.assert_called_once_with(250.0, {"stage": "search", "stream": False})
+
+    def test_records_even_when_block_raises(self):
+        timings: dict[str, float] = {}
+        with patch.object(timing.time, "perf_counter", side_effect=[2.0, 2.1]):
+            try:
+                with stage_timer(timings, "grounding"):
+                    raise ValueError("inner failure")
+            except ValueError:
+                pass
+
+        # finally-clause still records the partial duration.
+        assert "grounding" in timings
+        assert timings["grounding"] == 100.0

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -35,6 +35,16 @@ chat_stream_counter = meter.create_counter(
     unit="1",
 )
 
+# Per-stage latency breakdown within a single chat request. The `stage` attribute
+# carries which step the duration belongs to (content_safety | intent |
+# query_expansion | retrieval | ttft | generation | grounding | total), so a single
+# histogram answers "where does the minute go?" without one metric per stage.
+chat_stage_duration_histogram = meter.create_histogram(
+    name="chat.stage.duration_ms",
+    description="Per-stage latency within a single chat request",
+    unit="ms",
+)  # attributes: stage, stream (bool), provider
+
 # ── Verse grounding / scripture-fidelity metrics ──────────────────────────
 # Post-generation grounding rewrites fabricated/mismatched inline verse quotes
 # to the canonical DB text. These metrics make recurrences visible and track the

--- a/api/utils/timing.py
+++ b/api/utils/timing.py
@@ -1,0 +1,57 @@
+"""
+Per-stage timing for the chat pipeline.
+
+Each stage is recorded in two places:
+
+* a per-request ``timings`` dict, so the orchestrator can emit a single
+  ``chat_stage_timings`` log line ("intent=3100 retrieval=8200 generation=...")
+  that is instantly readable in the backend logs; and
+* the ``chat.stage.duration_ms`` OpenTelemetry histogram, so the same data drives
+  Application Insights dashboards and alerts.
+
+Recording is best-effort: instrumentation must never break a chat response, so the
+histogram write is guarded.
+"""
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from utils.metrics import chat_stage_duration_histogram
+
+
+def record_stage(
+    timings: dict[str, float],
+    stage: str,
+    elapsed_ms: float,
+    base_attributes: dict | None = None,
+) -> None:
+    """Record one stage's duration into ``timings`` and the OTel histogram."""
+    timings[stage] = round(elapsed_ms, 1)
+    attrs: dict = {"stage": stage}
+    if base_attributes:
+        attrs.update(base_attributes)
+    try:
+        chat_stage_duration_histogram.record(elapsed_ms, attrs)
+    except Exception:  # pragma: no cover - telemetry must never break a response
+        pass
+
+
+@contextmanager
+def stage_timer(
+    timings: dict[str, float],
+    stage: str,
+    base_attributes: dict | None = None,
+) -> Iterator[None]:
+    """Time the wrapped block and record it as ``stage``.
+
+    Works across ``await`` because the awaited code runs inside the ``with`` body::
+
+        with stage_timer(timings, "intent", attrs):
+            intent = await self._detect_intent(...)
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        record_stage(timings, stage, (time.perf_counter() - start) * 1000, base_attributes)

--- a/api/utils/timing.py
+++ b/api/utils/timing.py
@@ -41,6 +41,17 @@ def record_stage(
         pass
 
 
+def format_timings(timings: dict[str, float]) -> str:
+    """Render the per-stage timings dict as a compact, log-friendly string.
+
+    e.g. ``{"intent": 3100.5, "retrieval": 8200.1}`` -> ``"intent=3100.5 retrieval=8200.1"``.
+    This lets the single ``chat_stage_timings`` log line carry the breakdown in plain
+    text (readable straight from ``az containerapp logs`` / stdout), not only as
+    Application Insights ``customDimensions``.
+    """
+    return " ".join(f"{stage}={ms}" for stage, ms in timings.items())
+
+
 def timed_stage(
     stage: str,
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:

--- a/api/utils/timing.py
+++ b/api/utils/timing.py
@@ -13,11 +13,15 @@ Recording is best-effort: instrumentation must never break a chat response, so t
 histogram write is guarded.
 """
 
+import functools
 import time
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import Awaitable, Callable
+from typing import Any, ParamSpec, TypeVar
 
 from utils.metrics import chat_stage_duration_histogram
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def record_stage(
@@ -37,21 +41,55 @@ def record_stage(
         pass
 
 
-@contextmanager
-def stage_timer(
-    timings: dict[str, float],
+def timed_stage(
     stage: str,
-    base_attributes: dict | None = None,
-) -> Iterator[None]:
-    """Time the wrapped block and record it as ``stage``.
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Decorator that times an async ``ChatService`` method and records it as ``stage``.
 
-    Works across ``await`` because the awaited code runs inside the ``with`` body::
+    The wrapped method becomes self-instrumenting: instead of wrapping each call site in
+    a ``with`` block, decorate the stage method and it records its own duration into the
+    per-request ``self._timings`` dict and the ``chat.stage.duration_ms`` histogram.
 
-        with stage_timer(timings, "intent", attrs):
-            intent = await self._detect_intent(...)
+    Behaviour:
+
+    * No-op when no timing context is active (``self._timings is None``) — e.g. when the
+      method is called outside a chat request — the method still runs normally.
+    * Re-entrant: if the same ``stage`` is already being timed by an outer frame, the
+      inner call still runs but does not record, so nesting two same-stage methods (e.g.
+      the streaming grounding block calling ``_apply_verse_grounding``) yields a single
+      measurement owned by the outermost frame.
+    * Best-effort: the histogram write is guarded inside ``record_stage`` so telemetry
+      can never break a response. The duration is recorded even if the wrapped coroutine
+      raises.
     """
-    start = time.perf_counter()
-    try:
-        yield
-    finally:
-        record_stage(timings, stage, (time.perf_counter() - start) * 1000, base_attributes)
+
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            self: Any = args[0]  # decorator is applied to instance methods
+            timings = getattr(self, "_timings", None)
+            if timings is None:
+                return await func(*args, **kwargs)
+            active = getattr(self, "_active_stages", None)
+            if active is None:
+                active = set()
+                self._active_stages = active
+            if stage in active:
+                # Nested same-stage call: run it, but let the outer frame own the timing.
+                return await func(*args, **kwargs)
+            active.add(stage)
+            start = time.perf_counter()
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                active.discard(stage)
+                record_stage(
+                    timings,
+                    stage,
+                    (time.perf_counter() - start) * 1000,
+                    getattr(self, "_stage_attrs", None),
+                )
+
+        return wrapper
+
+    return decorator

--- a/docs/HOW-TO-READ-CHAT-STAGE-TIMINGS.md
+++ b/docs/HOW-TO-READ-CHAT-STAGE-TIMINGS.md
@@ -1,0 +1,115 @@
+# How to Read Chat Stage Timings
+
+Every `/chat` request emits a per-stage latency breakdown so you can see exactly
+where time goes in the pipeline (intent detection, scripture retrieval, LLM
+generation, grounding, …). This is the baseline used to validate latency work:
+each optimization is only "done" once the stage it targets drops here.
+
+See also: [`api/chat/service.py`](../api/chat/service.py) (the orchestration that
+records each stage) and [`api/utils/timing.py`](../api/utils/timing.py)
+(`record_stage`, the `@timed_stage` decorator, `format_timings`, and the
+`chat.stage.duration_ms` histogram).
+
+## What gets recorded
+
+Each request writes its stages into two places (both best-effort — instrumentation
+never breaks a chat response):
+
+1. A single structured log line, `chat_stage_timings`, emitted once per request.
+2. The `chat.stage.duration_ms` OpenTelemetry **histogram**, tagged with
+   `stage`, `stream` (bool), and `provider`.
+
+### Stages
+
+| Stage             | What it measures                                                        |
+| ----------------- | ---------------------------------------------------------------------- |
+| `content_safety`  | Pre-LLM safety check (0 when the safety filter is disabled).            |
+| `intent`          | Intent-classification LLM round-trip.                                   |
+| `query_expansion` | Query-expansion LLM call + its embedding (only when expansion is on).   |
+| `retrieval`       | Full scripture search (includes `query_expansion` as a sub-stage).     |
+| `ttft`            | Time to first streamed token — what the user actually waits (stream).   |
+| `generation`      | LLM answer generation (token stream for `chat_stream`).                 |
+| `grounding`       | Resolving cited verses + rewriting fabricated/mismatched quotes.        |
+| `total`           | Whole request, end to end.                                              |
+
+All values are milliseconds. `ttft` is stream-only; the `stream` field
+distinguishes `chat()` (`stream=false`) from `chat_stream()` (`stream=true`).
+
+## Where to find it
+
+The backend is deployed as an Azure Container App (`bible-app-backend`, resource
+group `bible-app-rg`); telemetry flows to Application Insights
+(`bible-app-insights`).
+
+### 1. Plain logs / stdout (quickest)
+
+The log line carries the breakdown in its **message text**, so it is readable
+straight from the container logs:
+
+```
+chat_stage_timings content_safety=0.0 intent=3100.5 query_expansion=2900.3 retrieval=8200.1 ttft=14210.7 generation=4300.2 grounding=180.4 total=18650.9
+```
+
+```bash
+az containerapp logs show \
+  --name bible-app-backend \
+  --resource-group bible-app-rg \
+  --follow \
+  | grep chat_stage_timings
+```
+
+Locally (dev), the same line prints to stdout when you run the API
+(`uvicorn main:app`). Set `LOG_LEVEL=INFO` (the default) so it is emitted.
+
+### 2. Application Insights — structured `traces` (best for querying)
+
+The `extra` fields are exported as `customDimensions`, so you can filter and
+extract them. Portal → Application Insights `bible-app-insights` → **Logs**:
+
+```kusto
+traces
+| where message startswith "chat_stage_timings"
+| order by timestamp desc
+| project timestamp,
+          stream      = tostring(customDimensions.stream),
+          timings_ms  = tostring(customDimensions.timings_ms)
+| take 20
+```
+
+Or from the CLI:
+
+```bash
+az monitor app-insights query \
+  --app bible-app-insights --resource-group bible-app-rg \
+  --analytics-query "traces | where message startswith 'chat_stage_timings' | order by timestamp desc | project timestamp, customDimensions | take 5"
+```
+
+### 3. Application Insights — the histogram (best for "which stage dominates")
+
+The metric form aggregates across many requests, so you can rank stages by
+percentile instead of reading individual lines:
+
+```kusto
+customMetrics
+| where name == "chat.stage.duration_ms"
+| extend stage  = tostring(customDimensions.stage),
+         stream = tostring(customDimensions.stream)
+| summarize p50 = percentile(value, 50),
+            p95 = percentile(value, 95),
+            n   = count()
+        by stage
+| order by p95 desc
+```
+
+To split streaming vs non-streaming, add `, stream` to the `by` clause.
+
+## Tips
+
+- **Reproduce a slow query.** The known-slow case is a non-English topical
+  question (e.g. German, translation `schlachter`); these exercise intent +
+  expansion + retrieval on the full pipeline.
+- **`total` ≈ sum of stages** for the non-stream path; on the stream path,
+  `ttft` is the number users feel, and `generation` runs after it.
+- **A `0.0` stage** usually means that stage is disabled by a feature flag
+  (e.g. `content_safety` when `CONTENT_SAFETY_ENABLED=false`, or
+  `query_expansion` when `QUERY_EXPANSION_ENABLED=false`).


### PR DESCRIPTION
Answers regressed to ~1 min once scripture search was restored (PR #768) and
the full pipeline started running again. Before optimizing we need to see where
the time actually goes, so add a single per-request timing breakdown across all
chat stages.

- utils/metrics.py: new chat.stage.duration_ms histogram (stage/stream/provider
  attributes) so one metric answers "where does the minute go?".
- utils/timing.py: stage_timer context manager + record_stage helper. Both write
  into a per-request timings dict AND the histogram; recording is best-effort so
  telemetry can never break a chat response.
- chat/service.py: time content_safety, intent, query_expansion (sub-stage of
  retrieval), retrieval, ttft (request start -> first streamed token), generation,
  grounding and total in both chat() and chat_stream(); emit one structured
  "chat_stage_timings" log line per request.

No behavior change — instrumentation only. This is the baseline/acceptance test
for the planned latency fixes (index-friendly search, dropping the redundant
semantic scan, routing sub-task LLM calls to a small model).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MQt11L49Q1dMpAUaY77mUx