### PR TITLE
fix: recover Turnstile widget to stop chat retry and bug-report 403s

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptor.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptor.kt
@@ -17,6 +17,10 @@ class TurnstileInterceptor @Inject constructor(
     // dispatcher. Hilt provides the production instance via the @Inject constructor.
     internal var tokenWaitMillis: Long = DEFAULT_TOKEN_WAIT_MILLIS
 
+    // Wait used on the 403-retry path; longer than the first-attempt wait because
+    // it may need to cover the WebView's error-recovery backoff. Mutable for tests.
+    internal var retryTokenWaitMillis: Long = DEFAULT_RETRY_TOKEN_WAIT_MILLIS
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val original = chain.request()
         // Turnstile-gated endpoints on this backend are all POST requests
@@ -46,13 +50,19 @@ class TurnstileInterceptor @Inject constructor(
             chain.proceed(original)
         }
 
-        // On 403 for any POST the token was missing or stale. The WebView reset
-        // was already triggered by onTokenConsumed() above (or was never needed).
-        // Wait for the fresh token and retry exactly once before surfacing the
-        // error — fail-open: if still no token after the wait, proceed without one.
+        // On 403 for any POST the token was missing or stale. Kick the widget to
+        // re-render (this also nudges recovery if the widget is in an error state —
+        // TurnstileWebView reloads on hasError) and wait for a fresh token, then
+        // retry exactly once. We wait via awaitFreshTokenOrNull(), which — unlike
+        // the first-attempt path — does NOT short-circuit on hasError: a 403 means
+        // we already need a token, so we give the WebView's recovery a chance to
+        // deliver one instead of immediately failing open. Fail-open remains the
+        // last resort: if no token arrives within the (longer) wait, proceed
+        // without one and let the backend's 403 surface to the user.
         if (response.code == 403 && needsToken) {
             response.close()
-            val freshToken = awaitTokenOrNull()
+            turnstileManager.requestReset()
+            val freshToken = awaitFreshTokenOrNull()
                 ?: return chain.proceed(original)
             val retried = chain.proceed(
                 original.newBuilder()
@@ -79,7 +89,19 @@ class TurnstileInterceptor @Inject constructor(
         }
     }
 
+    // Like awaitTokenOrNull() but does NOT short-circuit on hasError, and waits
+    // longer. Used only on the 403-retry path: a 403 means the request genuinely
+    // needs a token, so we give the WebView's error-recovery (reload + re-render,
+    // which can take a backoff tick) time to produce a fresh one rather than
+    // bailing out immediately the way the latency-sensitive first attempt does.
+    private fun awaitFreshTokenOrNull(): String? = runBlocking {
+        withTimeoutOrNull(retryTokenWaitMillis) {
+            turnstileManager.tokenFlow.filterNotNull().first()
+        }
+    }
+
     companion object {
         const val DEFAULT_TOKEN_WAIT_MILLIS: Long = 5_000L
+        const val DEFAULT_RETRY_TOKEN_WAIT_MILLIS: Long = 8_000L
     }
 }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/TurnstileWebView.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/TurnstileWebView.kt
@@ -14,8 +14,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import org.voxquieta.app.BuildConfig
 import org.voxquieta.app.security.TurnstileManager
+
+// Error-recovery backoff bounds for re-rendering a wedged Turnstile widget.
+private const val INITIAL_RECOVERY_BACKOFF_MILLIS = 1_000L
+private const val MAX_RECOVERY_BACKOFF_MILLIS = 8_000L
+private const val MAX_RECOVERY_ATTEMPTS = 5
 
 /**
  * Unwraps a [ContextWrapper] chain until an [Activity] is found.
@@ -58,6 +65,29 @@ fun TurnstileWebView(
     LaunchedEffect(turnstileManager) {
         turnstileManager.resetTrigger.collect {
             webViewRef.value?.evaluateJavascript("window.resetWidget()", null)
+        }
+    }
+
+    // Self-heal when the Turnstile widget enters an error state. Cloudflare fires
+    // its error-callback after the widget is reset too aggressively (every message
+    // forces a fresh single-use token), which used to wedge the app: hasError
+    // stayed true for the whole session and every POST went out token-less → 403
+    // on both chat and the bug-report form. Here we reload the WebView (a full
+    // reload re-runs onTurnstileLoad and re-renders the widget — more reliable
+    // than reset() on a wedged widget) with exponential backoff until a fresh
+    // token arrives (onTokenReceived clears hasError, ending the loop).
+    LaunchedEffect(turnstileManager) {
+        turnstileManager.hasError.collectLatest { hasError ->
+            if (!hasError) return@collectLatest
+            var backoffMillis = INITIAL_RECOVERY_BACKOFF_MILLIS
+            repeat(MAX_RECOVERY_ATTEMPTS) {
+                delay(backoffMillis)
+                // If a token arrived during the wait, hasError is already false and
+                // collectLatest will have cancelled this block; the guard is belt-and-braces.
+                if (!turnstileManager.hasError.value) return@collectLatest
+                webViewRef.value?.reload()
+                backoffMillis = (backoffMillis * 2).coerceAtMost(MAX_RECOVERY_BACKOFF_MILLIS)
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -1181,6 +1181,17 @@ class ChatViewModel @Inject constructor(
                 context.getString(R.string.error_server)
             }
         }
+        // 403: Cloudflare Turnstile bot verification. The backend returns a
+        // body with code TURNSTILE_REQUIRED (no/empty token reached the server)
+        // or TURNSTILE_FAILED (token rejected, e.g. stale/duplicate). Log the
+        // body so future diagnostic reports show which one it was, then tell the
+        // user it's a verification hiccup — not a generic "server error" — since
+        // the Turnstile widget self-heals and a retry usually succeeds.
+        e is HttpException && e.code() == 403 -> {
+            val body = e.response()?.errorBody()?.string() ?: ""
+            Timber.w("Turnstile verification rejected request (HTTP 403): %s", body)
+            context.getString(R.string.error_verification)
+        }
         // 422 request validation: the realistic client-controllable cause is an
         // over-long message. Tell the user to shorten it rather than showing a
         // generic server error.

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">خطأ في الشبكة. يرجى التحقق من الاتصال.</string>
     <string name="error_timeout">انتهت مهلة الطلب. يرجى المحاولة مرة أخرى.</string>
     <string name="error_server">خطأ في الخادم. يرجى المحاولة لاحقاً.</string>
+    <string name="error_verification">تعذّر التحقق من جهازك. يرجى الانتظار قليلاً ثم المحاولة مرة أخرى.</string>
     <string name="error_generic">حدث خطأ ما. يرجى المحاولة مرة أخرى.</string>
     <string name="error_message_too_long">رسالتك طويلة بعض الشيء (الحد الأقصى %1$d حرفًا). يرجى اختصارها والمحاولة مرة أخرى.</string>
     <string name="error_contact_email_invalid">يرجى إدخال بريد إلكتروني صالح حتى نتمكن من الرد.</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">Netzwerkfehler. Bitte Verbindung prüfen.</string>
     <string name="error_timeout">Zeitüberschreitung. Bitte erneut versuchen.</string>
     <string name="error_server">Serverfehler. Bitte später erneut versuchen.</string>
+    <string name="error_verification">Wir konnten dein Gerät nicht verifizieren. Bitte warte einen Moment und versuche es erneut.</string>
     <string name="error_generic">Etwas ist schiefgelaufen. Bitte erneut versuchen.</string>
     <string name="error_message_too_long">Deine Nachricht ist etwas lang (max. %1$d Zeichen). Bitte kürze sie und versuche es erneut.</string>
     <string name="error_contact_email_invalid">Bitte gib eine gültige E-Mail an, damit wir antworten können.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">Error de red. Comprueba tu conexión.</string>
     <string name="error_timeout">Tiempo de espera agotado. Inténtalo de nuevo.</string>
     <string name="error_server">Error del servidor. Inténtalo más tarde.</string>
+    <string name="error_verification">No pudimos verificar tu dispositivo. Espera un momento e inténtalo de nuevo.</string>
     <string name="error_generic">Algo salió mal. Inténtalo de nuevo.</string>
     <string name="error_message_too_long">Tu mensaje es un poco largo (máximo %1$d caracteres). Acórtalo e inténtalo de nuevo.</string>
     <string name="error_contact_email_invalid">Introduce un correo válido para que podamos responder.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">Erreur réseau. Vérifiez votre connexion.</string>
     <string name="error_timeout">Délai expiré. Veuillez réessayer.</string>
     <string name="error_server">Erreur serveur. Veuillez réessayer plus tard.</string>
+    <string name="error_verification">Impossible de vérifier votre appareil. Veuillez patienter un instant et réessayer.</string>
     <string name="error_generic">Une erreur s\'est produite. Veuillez réessayer.</string>
     <string name="error_message_too_long">Votre message est un peu long (maximum %1$d caractères). Raccourcissez-le et réessayez.</string>
     <string name="error_contact_email_invalid">Veuillez saisir un e-mail valide afin que nous puissions répondre.</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">नेटवर्क त्रुटि। अपना कनेक्शन जांचें।</string>
     <string name="error_timeout">अनुरोध का समय समाप्त हो गया। पुनः प्रयास करें।</string>
     <string name="error_server">सर्वर त्रुटि। बाद में पुनः प्रयास करें।</string>
+    <string name="error_verification">हम आपके डिवाइस को सत्यापित नहीं कर सके। कृपया कुछ क्षण रुककर पुनः प्रयास करें।</string>
     <string name="error_generic">कुछ गलत हो गया। पुनः प्रयास करें।</string>
     <string name="error_message_too_long">आपका संदेश थोड़ा लंबा है (अधिकतम %1$d वर्ण)। कृपया इसे छोटा करके फिर से प्रयास करें।</string>
     <string name="error_contact_email_invalid">कृपया एक मान्य ईमेल दर्ज करें ताकि हम उत्तर दे सकें।</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">Errore di rete. Controlla la connessione.</string>
     <string name="error_timeout">Richiesta scaduta. Riprova.</string>
     <string name="error_server">Errore del server. Riprova più tardi.</string>
+    <string name="error_verification">Non è stato possibile verificare il tuo dispositivo. Attendi un momento e riprova.</string>
     <string name="error_generic">Qualcosa è andato storto. Riprova.</string>
     <string name="error_message_too_long">Il tuo messaggio è un po\' lungo (massimo %1$d caratteri). Accorcialo e riprova.</string>
     <string name="error_contact_email_invalid">Inserisci un\'email valida così possiamo risponderti.</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">네트워크 오류입니다. 연결을 확인하세요.</string>
     <string name="error_timeout">요청 시간이 초과되었습니다. 다시 시도하세요.</string>
     <string name="error_server">서버 오류입니다. 나중에 다시 시도하세요.</string>
+    <string name="error_verification">기기를 확인할 수 없습니다. 잠시 후 다시 시도하세요.</string>
     <string name="error_generic">문제가 발생했습니다. 다시 시도하세요.</string>
     <string name="error_message_too_long">메시지가 조금 깁니다 (최대 %1$d자). 줄여서 다시 시도해 주세요.</string>
     <string name="error_contact_email_invalid">답변을 드릴 수 있도록 유효한 이메일을 입력해 주세요.</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">Erro de rede. Verifique sua conexão.</string>
     <string name="error_timeout">Tempo esgotado. Por favor, tente novamente.</string>
     <string name="error_server">Erro no servidor. Por favor, tente mais tarde.</string>
+    <string name="error_verification">Não foi possível verificar o seu dispositivo. Aguarde um momento e tente novamente.</string>
     <string name="error_generic">Algo deu errado. Por favor, tente novamente.</string>
     <string name="error_message_too_long">A sua mensagem é um pouco longa (máximo %1$d caracteres). Encurte-a e tente novamente.</string>
     <string name="error_contact_email_invalid">Insira um e-mail válido para podermos responder.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">Ошибка сети. Проверьте подключение.</string>
     <string name="error_timeout">Запрос истёк. Повторите попытку.</string>
     <string name="error_server">Ошибка сервера. Повторите попытку позже.</string>
+    <string name="error_verification">Не удалось подтвердить ваше устройство. Подождите немного и попробуйте снова.</string>
     <string name="error_generic">Что-то пошло не так. Повторите попытку.</string>
     <string name="error_message_too_long">Ваше сообщение слишком длинное (максимум %1$d символов). Сократите его и попробуйте снова.</string>
     <string name="error_contact_email_invalid">Введите действительный email, чтобы мы могли ответить.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -116,6 +116,7 @@
     <string name="error_network">网络错误，请检查您的连接。</string>
     <string name="error_timeout">请求超时，请重试。</string>
     <string name="error_server">服务器错误，请稍后重试。</string>
+    <string name="error_verification">无法验证您的设备。请稍候片刻后重试。</string>
     <string name="error_generic">出了些问题，请重试。</string>
     <string name="error_message_too_long">您的消息有点长（最多 %1$d 个字符）。请缩短后再试一次。</string>
     <string name="error_contact_email_invalid">请输入有效的邮箱，以便我们回复。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -183,6 +183,7 @@
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="error_timeout">Request timed out. Please try again.</string>
     <string name="error_server">Server error. Please try again later.</string>
+    <string name="error_verification">We couldn\'t verify your device. Please wait a moment and try again.</string>
     <string name="error_generic">Something went wrong. Please try again.</string>
     <string name="error_message_too_long">Your message is a little long (max %1$d characters). Please shorten it and try again.</string>
     <string name="error_contact_email_invalid">Please enter a valid email so we can reply.</string>

--- a/android/app/src/test/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptorTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptorTest.kt
@@ -10,6 +10,7 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -111,6 +112,45 @@ class TurnstileInterceptorTest {
         assertTrue("expected to wait for the token, took ${elapsed}ms", elapsed >= 40)
     }
 
+    @Test
+    fun `403 resets and retries with a freshly recovered token even after prior error`() {
+        // Reproduces the wedge fix: the widget has errored (hasError=true), so the
+        // first attempt goes out token-less and the server replies 403. The WebView
+        // recovery then delivers a fresh token; the interceptor must request a
+        // reset, wait *through* hasError on the retry path, and resend with that
+        // token instead of immediately failing open.
+        manager.onError("110200")
+        interceptor.retryTokenWaitMillis = 5_000L
+
+        val captured = mutableListOf<Request>()
+        val chain: Interceptor.Chain = mockk()
+        every { chain.request() } returns post("https://api.example.com/api/v1/chat/stream")
+        every { chain.proceed(capture(captured)) } answers {
+            if (captured.size == 1) {
+                // First (token-less) attempt rejected; a worker delivers a fresh
+                // token shortly after so the retry wait can observe it.
+                Thread {
+                    Thread.sleep(50)
+                    manager.onTokenReceived("recovered-token")
+                }.start()
+                response(firstArg(), 403)
+            } else {
+                response(firstArg(), 200)
+            }
+        }
+
+        interceptor.intercept(chain)
+
+        assertEquals("expected one retry after the 403", 2, captured.size)
+        assertNull(
+            "first attempt is token-less (prior error short-circuits the wait)",
+            captured[0].header("X-Turnstile-Token"),
+        )
+        assertEquals("recovered-token", captured[1].header("X-Turnstile-Token"))
+        // The single-use token is consumed after the successful retry.
+        assertNull(manager.currentToken())
+    }
+
     private fun runIntercept(request: Request): Request {
         val chain: Interceptor.Chain = mockk()
         val captured = slot<Request>()
@@ -133,6 +173,15 @@ class TurnstileInterceptorTest {
         .protocol(Protocol.HTTP_1_1)
         .code(200)
         .message("OK")
+        .build()
+
+    // Response with a body so the interceptor can call close() on the 403 path.
+    private fun response(forRequest: Request, code: Int): Response = Response.Builder()
+        .request(forRequest)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message(if (code in 200..299) "OK" else "Error")
+        .body("{}".toResponseBody("application/json".toMediaType()))
         .build()
 
 }


### PR DESCRIPTION
Both reported bugs surfaced as HTTP 403: chat failing after ~3 messages
(showing a Retry) and the bug-report form showing "server error" with all
fields filled. They share one root cause — the Cloudflare Turnstile widget.

Because each message forces a fresh single-use token (reset after every
request), Cloudflare's widget eventually fires its error-callback, setting
hasError=true. From then on the interceptor short-circuited every POST to a
token-less request, so the server returned 403 for both chat and the contact
form, and nothing ever re-rendered the wedged widget for the rest of the
session.

Changes:
- TurnstileWebView: self-heal on error by reloading the WebView with
  exponential backoff until a fresh token arrives (clears hasError).
- TurnstileInterceptor: on a 403 retry, request a reset and wait for a
  freshly recovered token without short-circuiting on hasError; fail open
  only as a last resort.
- ChatViewModel: handle HTTP 403 distinctly with a clear "couldn't verify
  your device" message (instead of the misleading "server error") and log
  the 403 response body so future diagnostics show TURNSTILE_REQUIRED vs
  TURNSTILE_FAILED.
- Add error_verification string in all 11 locales.
- Add interceptor test covering 403 reset + retry with a recovered token
  after a prior error.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MXUb7vXvpjK1yDEuhWW88C