### PR TITLE
feat(monitoring): actionable ERROR-level backend alerts + DB saturation detection (BITB-056)

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -482,6 +482,11 @@ jobs:
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
+      # BITB-056: Azure Monitor -> Telegram bridge. Only the chat id is a TF var; the
+      # bot token is written to Key Vault out-of-band (see the deploy job's
+      # "Populate Telegram bot token in Key Vault" step), so it never enters terraform
+      # state. Leave the chat id unset to keep Azure alert delivery email-only.
+      TF_VAR_telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
       # Default to empty JSON array when the secret is unset; an empty TF_VAR_
       # for a list(string) variable would crash terraform parsing otherwise.
       TF_VAR_budget_alert_emails: ${{ secrets.TF_VAR_BUDGET_ALERT_EMAILS || '[]' }}
@@ -751,6 +756,11 @@ jobs:
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
+      # BITB-056: Azure Monitor -> Telegram bridge. Only the chat id is a TF var; the
+      # bot token is written to Key Vault out-of-band (see the deploy job's
+      # "Populate Telegram bot token in Key Vault" step), so it never enters terraform
+      # state. Leave the chat id unset to keep Azure alert delivery email-only.
+      TF_VAR_telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
       # Default to empty JSON array when the secret is unset; an empty TF_VAR_
       # for a list(string) variable would crash terraform parsing otherwise.
       TF_VAR_budget_alert_emails: ${{ secrets.TF_VAR_BUDGET_ALERT_EMAILS || '[]' }}
@@ -977,6 +987,40 @@ jobs:
               "tenantId": "${{ secrets.ARM_TENANT_ID }}"
             }
 
+      # BITB-056: set the Telegram bot token into Key Vault out-of-band, so it never
+      # enters terraform state. No-op unless the Telegram bridge is enabled (the
+      # telegram_kv_name output is non-empty, i.e. TF_VAR_telegram_chat_id was set).
+      - name: Populate Telegram bot token in Key Vault (BITB-056)
+        working-directory: deployment
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+        run: |
+          set -o pipefail
+          kv=$(terraform output -raw telegram_kv_name 2>/dev/null || echo "")
+          if [ -z "$kv" ]; then
+            echo "Telegram bridge disabled (no Key Vault) — skipping token upload."
+            exit 0
+          fi
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ]; then
+            echo "::warning::TELEGRAM_BOT_TOKEN empty; KV exists but Logic App can't post until it is set."
+            exit 0
+          fi
+          # Retry: the deployer access policy can take a few seconds to propagate.
+          for i in 1 2 3 4; do
+            if az keyvault secret set \
+                 --vault-name "$kv" \
+                 --name telegram-bot-token \
+                 --value "$TELEGRAM_BOT_TOKEN" \
+                 --output none; then
+              echo "Telegram bot token stored in Key Vault $kv."
+              exit 0
+            fi
+            echo "secret set attempt $i failed (access policy may still be propagating); retrying..."
+            sleep $((i * 5))
+          done
+          echo "::error::Failed to set telegram-bot-token in Key Vault $kv after retries."
+          exit 1
+
       - name: Verify Deployment
         id: verify
         run: |
@@ -1187,6 +1231,11 @@ jobs:
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
+      # BITB-056: Azure Monitor -> Telegram bridge. Only the chat id is a TF var; the
+      # bot token is written to Key Vault out-of-band (see the deploy job's
+      # "Populate Telegram bot token in Key Vault" step), so it never enters terraform
+      # state. Leave the chat id unset to keep Azure alert delivery email-only.
+      TF_VAR_telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
       # Default to empty JSON array when the secret is unset; an empty TF_VAR_
       # for a list(string) variable would crash terraform parsing otherwise.
       TF_VAR_budget_alert_emails: ${{ secrets.TF_VAR_BUDGET_ALERT_EMAILS || '[]' }}

--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -246,33 +246,17 @@ jobs:
         id: query
         run: |
           set -o pipefail
-          err_re='(?i)(openrouter error|llm streaming error|anthropic error'
-          err_re="${err_re}|internal server error|traceback"
-          err_re="${err_re}|rate.?limit.*(error|exceeded|hit|reached)|quota exceeded"
-          err_re="${err_re}|invalid.?api.?key|api.?key.*(invalid|missing|expired)"
-          err_re="${err_re}|embedding.*error|connection.*error|connection refused"
-          err_re="${err_re}|unhandled exception|critical error|fatal"
-          # Scripture search / cited-verse / grounding failures. These paths fail
-          # open (verse-less answer, no 5xx), so match their log signatures directly
-          # rather than relying on a `traceback` token that may not be captured.
-          err_re="${err_re}|scripture search failed|failed to resolve cited verse|verse grounding skipped"
-          err_re="${err_re}|postgressyntaxerror|infailedsqltransactionerror|current transaction is aborted)"
-          # `sample` is a KQL operator; using it as a column name causes
-          # SYN0002. Use `sample_log` instead.
-          # BITB-055: decouple level-marker and keyword conditions. The former
-          # AND-join caused multi-line tracebacks to be silently missed: the
-          # | ERROR | marker lands on one line and the exception keyword on the
-          # next, so no single log line matched both conditions. Fix: drop the
-          # level-marker WHERE clause and instead exclude the one known benign
-          # INFO string that the denylist would otherwise surface. The
-          # scripture-pipeline metric alerts (BITB-055) cover swallowed
-          # exceptions structurally; this log-scan is the backstop.
-          query="ContainerAppConsoleLogs_CL
-            | where TimeGenerated > ago(10m)
-            | where ContainerAppName_s == \"bible-app-backend\"
-            | where Log_s !contains \"bypassing rate limit\"
-            | where Log_s matches regex \"${err_re}\"
-            | summarize cnt = count(), sample_log = any(Log_s)
+          # BITB-056: single source of truth for the error definition, shared with the
+          # Azure rule (deployment/monitoring.tf -> backend-error-filter.kql). This job
+          # only appends its own aggregation tail. The shared filter selects ERROR-level
+          # lines (the backend logs transient, self-recovered conditions at WARNING), so
+          # this Telegram early-warning no longer fires on rate-limit / timeout / fallback
+          # noise — the synthetic-chat, verse-search and health probes already cover the
+          # user-facing symptoms of those. `sample` is a KQL operator, so the column is
+          # `sample_log`; each sample is prefixed with its ErrorCategory.
+          filter=$(cat deployment/azure-monitor/queries/backend-error-filter.kql)
+          query="${filter}
+            | summarize cnt = count(), sample_log = any(strcat('[', ErrorCategory, '] ', Log_s))
             | project cnt, sample_log"
           result=$(az monitor log-analytics query \
             --workspace "${{ steps.ws.outputs.id }}" \

--- a/deployment/azure-monitor/queries/backend-error-filter.kql
+++ b/deployment/azure-monitor/queries/backend-error-filter.kql
@@ -1,0 +1,38 @@
+// Single source of truth for "a backend ERROR log line" (BITB-056).
+//
+// Consumed by two delivery channels, each of which appends its own aggregation tail:
+//   - deployment/monitoring.tf
+//       azurerm_monitor_scheduled_query_rules_alert_v2.backend_errors        (Sev2 email + Telegram)
+//       azurerm_monitor_scheduled_query_rules_alert_v2.backend_error_rate_other (Sev3)
+//   - .github/workflows/prod-monitor.yml  (log-scan job -> Telegram)
+//
+// Why level, not keywords: the backend already encodes signal-vs-noise in the log LEVEL
+// (see api/utils/logging_config.py). Transient, self-recovered conditions — rate limits,
+// timeouts, server-side routing failures, client-side fallback churn, query-expansion
+// fallback, verse-grounding skips — are logged at WARNING. Genuinely actionable failures
+// (unhandled 5xx, all-models-down, DB failures) go through logger.exception()/logger.error
+// at ERROR. So we alert on the "| ERROR |" level marker, not on keyword substrings like
+// "traceback" or "internal server error" that also appear in handled/transient cases and in
+// multi-line stack dumps.
+//
+// This file contains ONLY the filter + field extraction. Do NOT add a summarize/aggregation
+// here — each consumer appends its own (see the call sites above).
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(10m)
+| where ContainerAppName_s == "bible-app-backend"
+| where Log_s matches regex @"\|\s*ERROR\s*\|"          // level marker, not keywords
+| where Log_s !contains "bypassing rate limit"          // known-benign INFO line
+| extend RequestId = extract(@"\|\s*\[([^\]]*)\]\s*\|", 1, Log_s)
+| extend ErrorCategory = case(
+    // DB connection-pool / server saturation (the conc>=32 threshold cliff). Checked first so
+    // a pool timeout surfaced via "Chat request failed: QueuePool limit ..." is labelled as the
+    // capacity signal it is, not as a generic chat error.
+    Log_s has "QueuePool limit" or Log_s has "connection timed out" or Log_s has "TimeoutError"
+        or Log_s has "too many connections" or Log_s has "remaining connection slots", "db_pool_timeout",
+    Log_s has "All OpenRouter" and Log_s has "unavailable",                    "llm_all_models_down",
+    Log_s has "Chat stream failed" or Log_s has "Chat stream runtime error",   "chat_stream_unhandled",
+    Log_s has "Chat request failed" or Log_s has "Chat runtime error",         "chat_unhandled",
+    Log_s has "Get verse context failed",                                      "verse_context_failed",
+    Log_s has "Scripture search failed",                                       "scripture_search_failed",
+    Log_s has "LLM provider error",                                            "llm_provider_error",
+    "other_error")

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -340,7 +340,10 @@ resource "azurerm_postgresql_flexible_server" "main" {
   storage_mb                   = 32768 # 32GB minimum
   backup_retention_days        = 7
   geo_redundant_backup_enabled = false
-  auto_grow_enabled            = false
+  # BITB-056: auto-grow removes the disk-full write-failure cliff (storage was a fixed
+  # 32GB with no growth). Storage only ever grows, so this is a safe, one-way change;
+  # the db-storage-high alert (monitoring.tf) backstops a fill faster than growth.
+  auto_grow_enabled = true
 
   # Allow Azure services to connect
   public_network_access_enabled = true

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -6,23 +6,35 @@
 # channel is Telegram via .github/workflows/prod-monitor.yml, which catches
 # functional failures (e.g. in-band SSE error chunks the way the OpenRouter
 # 401 incident manifested). This Azure-native baseline covers the case where
-# GitHub Actions itself is degraded.
+# GitHub Actions itself is degraded. BITB-056 also pushes this baseline to
+# Telegram (via the Logic App bridge below) so the backup channel matches.
 #
 # All resources are gated on var.alert_email being non-empty; leave it empty
 # in non-prod to skip the email action group and downstream alerts entirely.
 #
 # Resources defined here:
 #   - azurerm_monitor_action_group.ops_email
-#       Email-only action group, target: var.alert_email.
+#       Email action group (+ Telegram logic_app_receiver when telegram_chat_id set).
+#   - azurerm_key_vault.alerts + azurerm_logic_app_workflow/_trigger/_action_custom.telegram_* (BITB-056)
+#       Bridge that reposts the common alert schema to Telegram. The bot token lives in
+#       Key Vault (set out-of-band by the deploy workflow) and is read at run time via the
+#       Logic App's managed identity, so it never enters terraform state. Gated on
+#       telegram_enabled (= alerts_enabled && telegram_chat_id != "").
 #   - azurerm_monitor_metric_alert.backend_availability
 #       Wires the existing azurerm_application_insights_standard_web_test
 #       (defined in main.tf) to the action group. Without this, the web test
 #       runs but never alerts.
 #   - azurerm_monitor_metric_alert.backend_restarts
 #       Fires when the backend container app reports >0 restarts in 15 min.
-#   - azurerm_monitor_scheduled_query_rules_alert_v2.backend_errors
-#       Same KQL the prod-monitor.yml log-scan job runs; alerts via email if
-#       any backend error log line is seen in the last 10 minutes.
+#   - azurerm_monitor_scheduled_query_rules_alert_v2.backend_errors (BITB-056)
+#       ERROR-level backend log lines, categorised; shares backend-error-filter.kql
+#       with the prod-monitor.yml log-scan job. Sev2 for hard-failure categories.
+#   - azurerm_monitor_scheduled_query_rules_alert_v2.backend_error_rate_other (BITB-056)
+#       Sev3 companion: 5+ uncategorised ERROR lines in 10 min.
+#   - azurerm_monitor_metric_alert.db_cpu/db_memory/db_storage/db_connections_failed (BITB-056)
+#       Postgres flexible-server resource saturation (the conc~32 threshold knee) + disk-full.
+#   - azurerm_monitor_scheduled_query_rules_alert_v2.scripture_search_latency_p95 (BITB-056)
+#       Semantic-search p95 > 2000ms — the user-facing signal of the DB saturation knee.
 #   - azurerm_monitor_scheduled_query_rules_alert_v2.scripture_fetch_errors (BITB-041)
 #       Fires when verse/chapter fetch failures (timeout/db_error/empty_text) occur.
 #   - azurerm_monitor_scheduled_query_rules_alert_v2.scripture_fetch_latency_p95 (BITB-041)
@@ -35,6 +47,12 @@
 
 locals {
   alerts_enabled = var.alert_email != "" && var.enable_application_insights
+  # BITB-056: the Azure-native action group also pushes to Telegram (so the backup
+  # channel matches prod-monitor.yml) when a chat id is supplied. The bot token is
+  # NOT a TF var — it lives in Key Vault (set out-of-band by the deploy workflow) and
+  # is fetched by the Logic App at run time via managed identity, so it never enters
+  # terraform state.
+  telegram_enabled = local.alerts_enabled && var.telegram_chat_id != ""
 }
 
 resource "azurerm_monitor_action_group" "ops_email" {
@@ -49,7 +67,167 @@ resource "azurerm_monitor_action_group" "ops_email" {
     use_common_alert_schema = true
   }
 
+  # BITB-056: deliver the same alerts to Telegram via the Logic App bridge below.
+  # Gated on telegram_enabled so apply still succeeds when the Telegram vars are unset
+  # (email-only). use_common_alert_schema keeps the payload shape the Logic App parses.
+  dynamic "logic_app_receiver" {
+    for_each = local.telegram_enabled ? [1] : []
+    content {
+      name                    = "telegram"
+      resource_id             = azurerm_logic_app_workflow.telegram_alert[0].id
+      callback_url            = azurerm_logic_app_trigger_http_request.telegram_alert[0].callback_url
+      use_common_alert_schema = true
+    }
+  }
+
   tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
+# Azure Monitor -> Telegram bridge (BITB-056)
+# -----------------------------------------------------------------------------
+# Action-group webhooks post the Azure common alert schema, which Telegram's
+# sendMessage API cannot consume directly. This Consumption Logic App accepts the
+# alert payload on an HTTP trigger and reposts a formatted message to Telegram, so
+# the Azure-native baseline (the channel that exists for when GitHub Actions is
+# degraded) lands in the same chat as prod-monitor.yml. Gated on telegram_enabled.
+#
+# Secret handling: the bot token is NEVER a Terraform value. It is written to the
+# Key Vault below by the deploy workflow (`az keyvault secret set`, from the
+# TELEGRAM_BOT_TOKEN repo secret) and the Logic App fetches it at run time using its
+# system-assigned managed identity. Terraform state therefore contains no token —
+# only the vault name and a managed-identity grant.
+
+data "azurerm_client_config" "current" {}
+
+# Vault that holds the Telegram bot token. The secret VALUE is set out-of-band by
+# the deploy workflow, so it is not declared as an azurerm_key_vault_secret (that
+# would put the value back into state).
+resource "azurerm_key_vault" "alerts" {
+  count                      = local.telegram_enabled ? 1 : 0
+  name                       = "${local.name_prefix}-akv-${local.resource_suffix}"
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+
+  tags = local.tags
+}
+
+# Deployer (the Terraform/az service principal) may set/read the token secret so the
+# workflow's `az keyvault secret set` step works. Standalone resource (not an inline
+# access_policy block) so it doesn't conflict with telegram_logic_app below — the
+# azurerm provider forbids mixing inline and standalone access policies on one vault.
+resource "azurerm_key_vault_access_policy" "telegram_deployer" {
+  count        = local.telegram_enabled ? 1 : 0
+  key_vault_id = azurerm_key_vault.alerts[0].id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  secret_permissions = ["Get", "List", "Set", "Delete", "Purge"]
+}
+
+resource "azurerm_logic_app_workflow" "telegram_alert" {
+  count               = local.telegram_enabled ? 1 : 0
+  name                = "${local.name_prefix}-telegram-alert"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  # System-assigned managed identity used to read the bot token from Key Vault.
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = local.tags
+}
+
+# Grant the Logic App's managed identity read access to the token secret only.
+resource "azurerm_key_vault_access_policy" "telegram_logic_app" {
+  count        = local.telegram_enabled ? 1 : 0
+  key_vault_id = azurerm_key_vault.alerts[0].id
+  tenant_id    = azurerm_logic_app_workflow.telegram_alert[0].identity[0].tenant_id
+  object_id    = azurerm_logic_app_workflow.telegram_alert[0].identity[0].principal_id
+
+  secret_permissions = ["Get"]
+}
+
+resource "azurerm_logic_app_trigger_http_request" "telegram_alert" {
+  count        = local.telegram_enabled ? 1 : 0
+  name         = "When_an_Azure_alert_fires"
+  logic_app_id = azurerm_logic_app_workflow.telegram_alert[0].id
+
+  # Permissive schema: the action group sends the common alert schema; we only read
+  # a few fields from it, so accept any object rather than pinning the full schema.
+  schema = jsonencode({
+    type = "object"
+  })
+}
+
+# Step 1: read the bot token from Key Vault using the Logic App's managed identity.
+# Defined as a custom action because azurerm_logic_app_action_http cannot express
+# ManagedServiceIdentity authentication. secureData hides the token from run history.
+resource "azurerm_logic_app_action_custom" "telegram_get_token" {
+  count        = local.telegram_enabled ? 1 : 0
+  name         = "Get_token"
+  logic_app_id = azurerm_logic_app_workflow.telegram_alert[0].id
+
+  # The trigger and both actions each read-modify-write the same workflow definition;
+  # serialize their creation so the azurerm provider doesn't race on parallel writes.
+  depends_on = [azurerm_logic_app_trigger_http_request.telegram_alert]
+
+  body = jsonencode({
+    type = "Http"
+    inputs = {
+      method = "GET"
+      uri    = "${azurerm_key_vault.alerts[0].vault_uri}secrets/telegram-bot-token?api-version=7.4"
+      authentication = {
+        type     = "ManagedServiceIdentity"
+        audience = "https://vault.azure.net"
+      }
+    }
+    runtimeConfiguration = {
+      secureData = {
+        properties = ["outputs"]
+      }
+    }
+    runAfter = {}
+  })
+}
+
+# Step 2: post to Telegram. The token is injected from the Get_token output at run
+# time (@{body('Get_token')?['value']}) — it is never stored in the definition.
+# Plain text (no parse_mode) so a stray '<' or '&' in a dynamic field can't make
+# Telegram reject the message; coalesce guards fields absent for some alert types.
+resource "azurerm_logic_app_action_custom" "telegram_send" {
+  count        = local.telegram_enabled ? 1 : 0
+  name         = "Send_to_Telegram"
+  logic_app_id = azurerm_logic_app_workflow.telegram_alert[0].id
+
+  # Serialize after Get_token (see note there) to avoid parallel workflow writes.
+  depends_on = [azurerm_logic_app_action_custom.telegram_get_token]
+
+  body = jsonencode({
+    type = "Http"
+    inputs = {
+      method  = "POST"
+      uri     = "https://api.telegram.org/bot@{body('Get_token')?['value']}/sendMessage"
+      headers = { "Content-Type" = "application/json" }
+      body = {
+        chat_id = var.telegram_chat_id
+        text    = "@{concat('🚨 ', coalesce(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Alert'), ' — ', coalesce(triggerBody()?['data']?['essentials']?['severity'], ''), ' ', coalesce(triggerBody()?['data']?['essentials']?['alertRule'], 'Azure Monitor alert'), decodeUriComponent('%0A'), coalesce(triggerBody()?['data']?['essentials']?['description'], ''), decodeUriComponent('%0A'), 'Fired: ', coalesce(triggerBody()?['data']?['essentials']?['firedDateTime'], ''))}"
+      }
+    }
+    runtimeConfiguration = {
+      secureData = {
+        properties = ["inputs"]
+      }
+    }
+    runAfter = {
+      Get_token = ["Succeeded"]
+    }
+  })
 }
 
 # Wire the existing standard web test to the action group so a region failing
@@ -107,9 +285,18 @@ resource "azurerm_monitor_metric_alert" "backend_restarts" {
   tags = local.tags
 }
 
-# Backend error-log alert (mirror of prod-monitor.yml's log-scan job).
-# Runs every 5 minutes; fires if any error-shaped log line was emitted in the
-# last 10 minutes.
+# Backend error-log alert (BITB-056).
+#
+# Fires on ERROR-level backend log lines only. The error definition (the level
+# filter + known-benign exclusion + RequestId/ErrorCategory extraction) lives in a
+# single checked-in file shared with the prod-monitor.yml log-scan job so the two
+# channels cannot drift; this rule just appends an aggregation tail. The previous
+# version matched keyword substrings (traceback|internal server error|...) regardless
+# of level, so it paged at Sev2 on handled/transient WARNINGs and multi-line stack
+# dumps while carrying no sample/count/request-id to act on.
+#
+# This rule covers the hard-failure categories (everything except "other_error");
+# uncategorised ERROR noise is handled at Sev3 by backend_error_rate_other below.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_errors" {
   count                = local.alerts_enabled ? 1 : 0
   name                 = "${local.name_prefix}-backend-error-logs"
@@ -119,16 +306,53 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_errors" {
   window_duration      = "PT10M"
   scopes               = [azurerm_log_analytics_workspace.main.id]
   severity             = 2
-  description          = "Backend logs contain error-shaped messages (OpenRouter, LLM, traceback) in the last 10 minutes."
+  description          = "Backend logged an actionable ERROR in the last 10 minutes. Category is one of: db_pool_timeout (DB connection-pool/server saturation), llm_all_models_down, chat_unhandled / chat_stream_unhandled (unhandled 5xx), verse_context_failed, scripture_search_failed, llm_provider_error. The alert payload carries the count, ErrorCategory, a Sample log line and up to 5 RequestIds per category — triage from those before opening the portal."
+
+  criteria {
+    # Shared filter (ERROR-level + category extraction) + this rule's aggregation tail.
+    query                   = <<-KQL
+      ${file("${path.module}/azure-monitor/queries/backend-error-filter.kql")}
+      | summarize cnt = count(), Sample = any(Log_s), RequestIds = make_set(RequestId, 5) by ErrorCategory
+      | where ErrorCategory != "other_error"
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
+# Uncategorised ERROR-rate alert (BITB-056). Sev3 informational companion to
+# backend_errors: surfaces a sustained spike of ERROR lines that don't match a known
+# hard-failure category, without paging at Sev2 on a single blip. Threshold of 5 over
+# 10 minutes is conservative; tune once a baseline is observed.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_error_rate_other" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-backend-error-rate-other"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_log_analytics_workspace.main.id]
+  severity             = 3
+  description          = "5+ uncategorised backend ERROR lines (ErrorCategory=other_error) in the last 10 minutes. Informational: investigate the Sample to decide whether it warrants a new explicit category in backend-error-filter.kql."
 
   criteria {
     query                   = <<-KQL
-      ContainerAppConsoleLogs_CL
-      | where TimeGenerated > ago(10m)
-      | where ContainerAppName_s == "${azurerm_container_app.backend.name}"
-      | where Log_s matches regex "(?i)(openrouter error|llm streaming error|anthropic error|internal server error|traceback)"
-      | summarize cnt = count() by bin(TimeGenerated, 5m)
-      | where cnt > 0
+      ${file("${path.module}/azure-monitor/queries/backend-error-filter.kql")}
+      | where ErrorCategory == "other_error"
+      | summarize cnt = count(), Sample = any(Log_s), RequestIds = make_set(RequestId, 5)
+      | where cnt >= 5
     KQL
     time_aggregation_method = "Count"
     threshold               = 0
@@ -335,6 +559,161 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scripture_fetch_laten
       | where op in ("get_verse", "get_chapter")
       | summarize p95 = percentile(value, 95) by bin(timestamp, 5m)
       | where p95 > 1000
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
+# Database saturation / threshold-failure alerts (BITB-056)
+# -----------------------------------------------------------------------------
+# A concurrency load test of /api/v1/scripture/search showed a clean latency knee
+# at concurrency ~32 (p95 4-8x baseline, ~0% errors) on the 2-vCore burstable
+# B_Standard_B2s: pgvector HNSW search is CPU-bound, so DB CPU is the wall and the
+# connection pool (size 10 + overflow 10) adds queue-wait above it. Previously NONE
+# of the DB server's own metrics were alerted. These rules add the *leading* signals
+# so the threshold is visible before users see errors. (Root-cause hardening — storage
+# auto-grow, DB tier, pool retune — is tracked in main.tf and the BITB-056 story.)
+
+# Primary leading signal: CPU is the wall for the CPU-bound HNSW search workload.
+resource "azurerm_monitor_metric_alert" "db_cpu" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-db-cpu-high"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_postgresql_flexible_server.main.id]
+  description         = "PostgreSQL CPU averaged >85% over 15 minutes — the leading indicator of the CPU-bound search saturation knee (measured at concurrency ~32). Sustained high CPU degrades search/chat latency before errors appear; consider a tier bump."
+  severity            = 2
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "cpu_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 85
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_metric_alert" "db_memory" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-db-memory-high"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_postgresql_flexible_server.main.id]
+  description         = "PostgreSQL memory averaged >90% over 15 minutes. On a 4GB burstable this risks cache thrash (HNSW indexes spilling out of shared_buffers) and OOM."
+  severity            = 3
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "memory_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 90
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
+# Disk-full is a hard write-failure cliff. auto_grow is being enabled (main.tf), but
+# keep this as a backstop in case growth lags a fast fill.
+resource "azurerm_monitor_metric_alert" "db_storage" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-db-storage-high"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_postgresql_flexible_server.main.id]
+  description         = "PostgreSQL storage averaged >85% over 30 minutes. Past full, writes fail and the server can go read-only. auto_grow should absorb this; investigate if it is climbing despite auto-grow."
+  severity            = 2
+  frequency           = "PT15M"
+  window_size         = "PT30M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "storage_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 85
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
+# The hard form of the threshold cliff: the server rejecting connections.
+resource "azurerm_monitor_metric_alert" "db_connections_failed" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-db-connections-failed"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes              = [azurerm_postgresql_flexible_server.main.id]
+  description         = "PostgreSQL rejected one or more connections in the last 15 minutes (connections_failed > 0). This is the hard threshold breach — clients could not get a DB connection."
+  severity            = 2
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "connections_failed"
+    aggregation      = "Total"
+    operator         = "GreaterThan"
+    threshold        = 0
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
+# Direct user-facing signal of the measured knee: semantic-search p95. The load test
+# baseline p95 was ~0.5s and the degraded knee at concurrency ~32 was ~1.9-2.1s, so a
+# sustained p95 > 2000ms means we are at/over the saturation threshold. Uses the
+# existing db.search.duration_ms histogram (api/scripture/repository.py) — no app change.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scripture_search_latency_p95" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-scripture-search-latency-p95"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT15M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 2
+  description          = "p95 of pgvector semantic search (db.search.duration_ms) exceeded 2000ms over the last 15 minutes — the search saturation knee measured at concurrency ~32. Indicates the DB is CPU-bound under load; check the db-cpu-high alert and consider a tier bump / pool retune."
+
+  criteria {
+    query                   = <<-KQL
+      customMetrics
+      | where timestamp > ago(15m)
+      | where name == "db.search.duration_ms"
+      | summarize p95 = percentile(value, 95) by bin(timestamp, 5m)
+      | where p95 > 2000
     KQL
     time_aggregation_method = "Count"
     threshold               = 0

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -11,6 +11,18 @@ output "resource_group_name" {
   value       = azurerm_resource_group.main.name
 }
 
+# BITB-056: name of the Key Vault holding the Telegram bot token (empty when the
+# Telegram bridge is disabled). The deploy workflow reads this to set the secret
+# value out-of-band, so the token never enters terraform state.
+output "telegram_kv_name" {
+  description = "Key Vault name for the Telegram bot token (empty when the bridge is disabled)"
+  value       = local.telegram_enabled ? azurerm_key_vault.alerts[0].name : ""
+  # Marked sensitive only because the value derives from the sensitive
+  # telegram_chat_id var; the vault name itself is not secret. `terraform output
+  # -raw telegram_kv_name` still returns it for the deploy workflow.
+  sensitive = true
+}
+
 output "resource_group_id" {
   description = "ID of the resource group"
   value       = azurerm_resource_group.main.id

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -266,6 +266,25 @@ variable "monitor_probe_secret" {
   sensitive   = true
 }
 
+variable "telegram_chat_id" {
+  description = <<-EOT
+    Telegram chat/group ID for the Azure Monitor -> Telegram bridge (BITB-056),
+    negative for groups. Reuse the existing TELEGRAM_CHAT_ID value via
+    TF_VAR_TELEGRAM_CHAT_ID. Setting this enables the bridge (Key Vault + Logic
+    App + logic_app_receiver); leave empty to keep Azure alert delivery
+    email-only.
+
+    The bot TOKEN is deliberately NOT a Terraform variable: it is written to
+    Key Vault out-of-band by the deploy workflow (from the TELEGRAM_BOT_TOKEN
+    repo secret) and fetched by the Logic App at run time via managed identity,
+    so it never lands in terraform state. A chat id is only a routing
+    identifier (useless without the bot token), so it is fine as a variable.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "openrouter_model" {
   description = "OpenRouter model name (e.g., meta-llama/llama-3.3-70b-instruct:free)"
   type        = string

--- a/docs/BACKLOG_STORIES/BITB-056-backend-error-alert-actionability.md
+++ b/docs/BACKLOG_STORIES/BITB-056-backend-error-alert-actionability.md
@@ -1,0 +1,125 @@
+# BITB-056: Backend Error Alert — Precise, Actionable, and DB-Threshold-Aware
+
+**Status:** 🚧 In progress (Phase 1 implemented; Phase 2 + DB tier bump = follow-up)
+**Priority:** P2 (Medium) — alert quality / on-call signal-to-noise
+**Size:** M (1-2 days)
+**Created:** 2026-06-26
+
+## User Story
+
+As the operator of getinspiredbythebible / Vox Quieta, I want the backend error-log alert to
+fire only on genuinely actionable failures and to tell me *what* broke, *how often*, and *for
+which request* in the notification itself, so that I can triage from my phone without opening the
+Azure portal — and I want the database's threshold-failure mode (the latency knee a load test
+found at concurrency ≈ 32) to be both **detected** before users see errors and **hardened** at
+the root.
+
+## Problem / Motivation
+
+A Sev2 `bible-app-backend-error-logs` alert (`deployment/monitoring.tf`) fired on a keyword regex:
+
+```kql
+Log_s matches regex "(?i)(openrouter error|llm streaming error|anthropic error|internal server error|traceback)"
+```
+
+It is too general and too noisy, for a specific reason: **the backend already encodes
+signal-vs-noise in the log *level*, and the alert ignores it.** `api/utils/logging_config.py`
+formats every line as `… | LEVEL | name:line | [request_id] | message`. The code logs transient,
+self-recovered conditions (rate limits, timeouts, server-side routing failures, client-side
+fallback churn, query-expansion fallback, verse-grounding skips) at **WARNING**, and genuinely
+actionable failures at **ERROR** (verified in `api/providers/openrouter.py`, `api/routes/chat.py`,
+`api/chat/service.py`). Concretely:
+
+1. **No level filter.** A `WARNING` that merely *mentions* `internal server error` (an upstream
+   500 echoed in a message that was then retried successfully via fallback) pages at Sev2.
+2. **`traceback` is the noisiest token.** Each `logger.exception()` dumps a multi-line Python
+   traceback; in Container Apps every newline becomes a separate `ContainerAppConsoleLogs_CL`
+   row, so one *handled* exception lights up the regex.
+3. **Dead tokens + catch-alls.** `openrouter error` / `anthropic error` / `llm streaming error`
+   don't match the actual log strings, so only the broad catch-alls fire — and they fire on noise.
+4. **Fires on `cnt > 0`, one period, fixed Sev2** — no threshold, no dedup, no severity tiering.
+5. **Zero actionability in the email.** `summarize cnt = count() by bin(...)` throws away the log
+   text — no sample, no `request_id`, no count, no category. The responder must re-run a query.
+6. **Two diverged copies.** The Azure rule and the `prod-monitor.yml` log-scan job maintain
+   separate regexes in two languages that were meant to mirror each other and had already drifted.
+
+Separately, a concurrency load test (`search_concurrency_test.py` against
+`/api/v1/scripture/search`) found a clean latency knee at **concurrency ≈ 32** (p95 4.3x baseline
+at 32, 8.4x at 64; err-rate ~0%). The knee sits *above* the app pool ceiling (`pool_size 10 +
+max_overflow 10 = 20`), implicating the **2-vCore burstable `B_Standard_B2s`** as the wall:
+pgvector HNSW search is CPU-bound and runs at `hnsw.ef_search = 120`. **None of the Postgres
+server's own metrics were alerted**, the `/scripture/search` path had no latency alert, and the
+`db.connections.active` gauge is defined but never wired — so this degradation was invisible.
+
+## Acceptance Criteria
+
+### Phase 1 — alert precision, actionability & delivery (no backend code) — **implemented here**
+
+- [x] **Alert on ERROR-level lines, not keywords.** A single checked-in
+      `deployment/azure-monitor/queries/backend-error-filter.kql` selects `| ERROR |` lines, excludes
+      the known-benign `bypassing rate limit`, and extracts `RequestId` + an `ErrorCategory`
+      (`db_pool_timeout`, `llm_all_models_down`, `chat_unhandled`, `chat_stream_unhandled`,
+      `verse_context_failed`, `scripture_search_failed`, `llm_provider_error`, `other_error`).
+- [x] **Self-contained notification.** The Azure rule projects `cnt` / `ErrorCategory` / `Sample`
+      / `RequestIds` so the common-alert-schema email carries them, and a Logic App bridge reposts
+      the alert to Telegram so the backup channel matches `prod-monitor.yml`.
+- [x] **No secret in Terraform state.** The Telegram bot token is written to a Key Vault
+      out-of-band by the deploy workflow (`az keyvault secret set` from the `TELEGRAM_BOT_TOKEN`
+      repo secret) and read by the Logic App at run time via its system-assigned managed identity;
+      Terraform stores only the vault name and the managed-identity grant. The chat id (a routing
+      identifier, useless without the token) remains a TF var that gates the bridge.
+- [x] **Severity tiered.** Hard-failure categories page at **Sev2** (`backend_errors`); a Sev3
+      companion (`backend_error_rate_other`) covers uncategorised ERROR spikes (≥5 in 10m).
+- [x] **Single source of truth.** `prod-monitor.yml`'s log-scan job reads the same shared `.kql`
+      file, so the two channels can no longer drift.
+
+### DB threshold-failure — detect + harden
+
+- [x] **Detect (infra-only):** Postgres resource metric alerts (`cpu_percent` Sev2, `memory_percent`
+      Sev3, `storage_percent` Sev2, `connections_failed` Sev2) + a `/scripture/search` p95 latency
+      alert (`db.search.duration_ms` > 2000ms, Sev2) + a `db_pool_timeout` error category at Sev2.
+- [x] **Harden (free):** `auto_grow_enabled = true` on the Postgres server removes the disk-full
+      write-failure cliff.
+- [ ] **Harden (capacity, cost decision):** bump the burstable `B_Standard_B2s` to more vCores
+      (e.g. `B_Standard_B4ms` or GP `D2ds_v5`/`D4ds_v5`) to move the conc-32 knee up, and retune
+      `db_pool_size`/`db_max_overflow` alongside it. *Requires owner sign-off on the monthly delta.*
+- [ ] **Optional:** evaluate lowering `hnsw.ef_search` (120) — cuts CPU/query and raises the knee
+      at some recall cost. Search-quality call; do not change without an eval.
+
+### Phase 2 — structured error metric (backend code) — **follow-up**
+
+- [ ] Add a `backend.errors` counter (with a `category` dimension) in `api/utils/metrics.py`,
+      incremented in the genuinely-actionable handlers (`api/routes/chat.py`,
+      `api/providers/openrouter.py`, `api/chat/service.py`), mirroring `scripture.pipeline.errors`.
+- [ ] Add a metric-based alert on `backend.errors` (split by `category`) as the precise **primary**
+      Sev2 signal; keep the log-based rule as a backstop (same defence-in-depth as
+      `scripture_pipeline_errors`).
+- [ ] Wire the `db.connections.active` gauge to SQLAlchemy pool `checkout`/`checkin` events and add
+      a pool-saturation alert (active ≥ 80% of the pool ceiling) as a leading indicator.
+
+## Notes / Reuse
+
+- Log level discipline lives in `api/utils/logging_config.py`; the `| ERROR |` marker is the linchpin.
+- `request_id` is already on every line via `middleware/correlation_id.py` — extract, don't add.
+- `azurerm_monitor_scheduled_query_rules_alert_v2` + `customMetrics … percentile` patterns already
+  exist (`scripture_fetch_latency_p95`, `scripture_pipeline_errors`) — the search-latency alert copies them.
+- `db.search.duration_ms` already emits from `api/scripture/repository.py` (`_record_duration`), so
+  the search-latency alert needs no backend change.
+- Telegram formatting reference: `.github/actions/notify-telegram` + `scripts/monitor/*.py`.
+- Related: **BITB-055** (scripture-pipeline observability) is the structural metric work this builds on.
+
+## Out of Scope
+
+- Transaction-cascade hardening (savepoints around cited-verse resolution) — tracked separately.
+- Frontend changes; this story is alerting + DB capacity only.
+
+## Verification
+
+- `az monitor log-analytics query` with the shared filter over a 24h window: confirm it returns
+  genuine ERRORs with sensible `ErrorCategory`/`RequestId` and excludes WARNING rate-limit/fallback noise.
+- `terraform -chdir=deployment fmt -check` + `validate`; `plan` (no apply) renders the rewritten rule,
+  Sev3 companion, DB metric alerts, search-latency alert, Logic App + `logic_app_receiver`.
+- POST a sample common-alert-schema payload to the Logic App trigger URL → formatted Telegram message.
+- `prod-monitor.yml` via `workflow_dispatch force_alert=true` → log-scan still runs against the shared filter.
+- Re-run `search_concurrency_test.py --mode both --concurrency 1,2,4,8,16,32,64` after the DB tier
+  bump and confirm the knee moves above 32 and the db-cpu-high / search-latency alerts fire when pushed past it.


### PR DESCRIPTION
## Summary

Overhauls the backend error-log alert to fire only on genuinely actionable **ERROR-level** failures (not keyword matches), puts the error category / count / sample / request-ids in the notification itself, and adds **database saturation detection** (CPU, memory, storage, connection failures, search latency) so the threshold knee is visible before users see errors.

## Key Changes

**Alert precision & actionability**

- Replaced the keyword regex (`traceback`, `internal server error`, …) — which paged on handled/transient `WARNING`s and multi-line tracebacks — with a single shared KQL filter (`deployment/azure-monitor/queries/backend-error-filter.kql`) that selects only `| ERROR |` lines (the level the backend already uses for genuinely actionable failures), excluding the known-benign `bypassing rate limit`.
- Extracts `ErrorCategory` (`db_pool_timeout`, `llm_all_models_down`, `chat_unhandled`, `chat_stream_unhandled`, `verse_context_failed`, `scripture_search_failed`, `llm_provider_error`, `other_error`) and `RequestId` from each line.
- Two severity tiers: `backend_errors` (Sev2, hard-failure categories, pages) and `backend_error_rate_other` (Sev3, uncategorised ERROR spikes ≥5 in 10m).
- Alerts project `cnt` / `ErrorCategory` / `Sample` / `RequestIds`, so the email/Telegram notification is self-contained (no portal lookup).

**Single source of truth**

- The shared `backend-error-filter.kql` is consumed by **both** the Azure Monitor rules (`monitoring.tf`) and the `prod-monitor.yml` log-scan job (Telegram early-warning), so the two channels can no longer drift.

**Azure Monitor → Telegram bridge — bot token kept OUT of Terraform state**

- A Consumption Logic App reposts the Azure common-alert-schema payload to Telegram, wired into the action group via `logic_app_receiver` so the Azure-native backup channel (for when GitHub Actions is degraded) lands in the same chat as `prod-monitor.yml`.
- The bot **token is never a Terraform value**: it is written to a Key Vault out-of-band by the deploy workflow (`az keyvault secret set` from the existing `TELEGRAM_BOT_TOKEN` secret) and read at run time via the Logic App's **system-assigned managed identity** (custom HTTP action with `ManagedServiceIdentity` auth; `secureData` hides it from run history). Terraform stores only the vault name and the MI grant.
- Gated on `telegram_chat_id` alone (a routing identifier, useless without the token); leave it unset to keep Azure delivery email-only.

**Database saturation detection (the measured concurrency ≈ 32 knee)**

- Postgres flexible-server metric alerts: `db_cpu` (Sev2, >85% — the CPU-bound HNSW search wall), `db_memory` (Sev3, >90%), `db_storage` (Sev2, >85%), `db_connections_failed` (Sev2, any rejected connection).
- `scripture_search_latency_p95` (Sev2): p95 of `db.search.duration_ms` > 2000ms — the direct user-facing signal of the knee (the metric already emits; no backend change).
- Enabled `auto_grow_enabled = true` on the Postgres server to remove the disk-full write cliff.

**Docs**

- Adds the `BITB-056` backlog story (problem, acceptance criteria, Phase 2 follow-ups, verification).

## Scope notes

- Phase 1 (alerting + infra) only — no backend code changes. **Phase 2** (a structured `backend.errors` counter + metric-based alert, and wiring the unused `db.connections.active` gauge) and the **DB tier bump** (a cost decision) are tracked as follow-ups in the story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUs8dUkcqKMAHAUjsj6svL