### PR TITLE
feat(db): move hnsw.ef_search tuning from migration to connection pool

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -96,9 +96,11 @@ class Settings(BaseSettings):
     vector_candidate_pool: int = 100
     # HNSW query-time exploration depth (hnsw.ef_search). MUST be >= vector_candidate_pool,
     # otherwise the ANN cannot return a full candidate pool and recall is silently capped
-    # (pgvector default is 40; migration 002 set 80 — below the pool of 100). This value is
-    # the single source of truth applied to the database by migration 007 via
-    # `ALTER DATABASE ... SET hnsw.ef_search`; the connection pool inherits it per session.
+    # (pgvector default is 40; migration 002 set 80 — below the pool of 100). The runtime
+    # source of truth is the connection pool, which applies this per session on connect
+    # (api/scripture/database.py); migration 007 also tries to set the DB-wide default via
+    # `ALTER DATABASE ... SET hnsw.ef_search`, but that is best-effort (the managed-Postgres
+    # app role lacks the privilege), so the per-session SET is what the search path relies on.
     hnsw_ef_search: int = 120
 
     # Topic Boosting Settings

--- a/api/scripture/database.py
+++ b/api/scripture/database.py
@@ -2,15 +2,18 @@
 Database connection and session management.
 """
 
+import logging
 import ssl
 from typing import Annotated, AsyncGenerator
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from fastapi import Depends
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from config import settings
+
+logger = logging.getLogger(__name__)
 
 
 def get_async_database_url() -> tuple[str, dict]:
@@ -75,6 +78,35 @@ engine = create_async_engine(
     pool_recycle=settings.db_pool_recycle,
     pool_pre_ping=True,
 )
+
+
+@event.listens_for(engine.sync_engine, "connect")
+def _apply_session_hnsw_ef_search(dbapi_connection, connection_record):
+    """Apply ``hnsw.ef_search`` on every new pooled connection.
+
+    This is the runtime source of truth for the HNSW exploration depth. The
+    database-level ``ALTER DATABASE ... SET hnsw.ef_search`` (migration 007)
+    requires DB-owner/superuser privileges that the Azure Flexible Server
+    application role does not have, so it cannot be relied upon. Setting the GUC
+    at the *session* level needs no special privilege (any role may ``SET`` a
+    namespaced custom GUC) and the value persists for the life of the pooled,
+    reused connection.
+
+    The listener fires inside SQLAlchemy's asyncio greenlet, so the synchronous
+    DBAPI cursor facade transparently awaits the underlying asyncpg call. A
+    failure here would break every connection, so it is logged and swallowed:
+    falling back to the server default degrades recall but keeps the app up
+    (``config`` already enforces ``hnsw_ef_search >= vector_candidate_pool``).
+    """
+    try:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(f"SET hnsw.ef_search = {int(settings.hnsw_ef_search)}")
+        finally:
+            cursor.close()
+    except Exception:  # noqa: BLE001 - never let this take down a connection
+        logger.warning("Failed to set hnsw.ef_search on new connection", exc_info=True)
+
 
 # Session factory
 async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/scripts/migrations/007_partial_hnsw_verse_indexes.py
+++ b/scripts/migrations/007_partial_hnsw_verse_indexes.py
@@ -74,12 +74,25 @@ async def run_migration():
         # 1. ef_search >= candidate pool so the ANN returns a full pool. Use
         #    current_database() (not a hard-coded name like migration 002's
         #    `bibleapp`) so this is robust to the actual prod database name.
+        #
+        #    This is best-effort: ALTER DATABASE ... SET requires DB-owner/superuser
+        #    privileges that the Azure Flexible Server app role does not have, so it
+        #    raises InsufficientPrivilegeError there. The application applies the same
+        #    GUC per session in api/scripture/database.py (the runtime source of truth),
+        #    so a failure here is non-fatal — we just skip the DB-wide default, which
+        #    only benefits non-app clients (psql, ad-hoc tools).
         ef_search = max(settings.hnsw_ef_search, settings.vector_candidate_pool)
         dbname = await conn.fetchval("SELECT current_database()")
         log(f"Setting hnsw.ef_search = {ef_search} on database '{dbname}'")
         # dbname/ef_search are not bindable in ALTER DATABASE; dbname comes from the
         # server and ef_search is an int from config, so inlining is safe.
-        await conn.execute(f'ALTER DATABASE "{dbname}" SET hnsw.ef_search = {int(ef_search)}')
+        try:
+            await conn.execute(f'ALTER DATABASE "{dbname}" SET hnsw.ef_search = {int(ef_search)}')
+        except asyncpg.exceptions.InsufficientPrivilegeError:
+            log(
+                "Skipping ALTER DATABASE SET hnsw.ef_search (insufficient privilege); "
+                "the application sets it per session at the connection level instead."
+            )
 
         # 2. Discover the translations actually present so the index set tracks
         #    reality instead of a hard-coded list that can drift.

--- a/scripts/migrations/007_partial_hnsw_verse_indexes.py
+++ b/scripts/migrations/007_partial_hnsw_verse_indexes.py
@@ -16,8 +16,17 @@ fills, and the per-query working set drops ~12x (each partial is ~1/12th the siz
 and fits in shared_buffers). The full index is kept for the no-translation search
 path (``/scripture/search`` without a translation).
 
-It also raises ``hnsw.ef_search`` to >= vector_candidate_pool so the ANN can
-return a full candidate pool (the old default of 80 was below the pool of 100).
+This migration does NOT set ``hnsw.ef_search``. The ANN needs
+``ef_search >= vector_candidate_pool`` to return a full candidate pool (pgvector's
+default of 40 and migration 002's 80 are both below the pool of 100), but managed
+Postgres (Azure Flexible Server, AWS RDS) forbids *persisting* that GUC at the
+database or role level: ``ALTER DATABASE/ROLE ... SET hnsw.ef_search`` raises
+``permission denied to set parameter`` even for the admin role. An earlier version
+of this migration ran ``ALTER DATABASE ... SET hnsw.ef_search`` and failed CI with
+exactly that error. The knob now lives in the application instead, which issues
+``SET hnsw.ef_search`` per session on every pooled connection (see
+``api/scripture/database.py``) — a session-level SET of a namespaced custom GUC
+needs no special privilege and is the vendor-recommended way to tune it.
 
 Why a .py migration (not .sql): ``CREATE INDEX CONCURRENTLY`` cannot run inside a
 transaction block, but ``run_migrations.py:run_sql_migration`` executes the whole
@@ -64,37 +73,21 @@ def index_name(translation: str) -> str:
 
 
 async def run_migration():
-    """Create per-translation partial HNSW indexes and raise hnsw.ef_search."""
+    """Create per-translation partial HNSW indexes for verse search."""
     log("Connecting to database...")
     database_url = settings.database_url
     clean_url, conn_kwargs = get_migration_connection_params(database_url)
     conn = await asyncpg.connect(clean_url, **conn_kwargs)
 
     try:
-        # 1. ef_search >= candidate pool so the ANN returns a full pool. Use
-        #    current_database() (not a hard-coded name like migration 002's
-        #    `bibleapp`) so this is robust to the actual prod database name.
-        #
-        #    This is best-effort: ALTER DATABASE ... SET requires DB-owner/superuser
-        #    privileges that the Azure Flexible Server app role does not have, so it
-        #    raises InsufficientPrivilegeError there. The application applies the same
-        #    GUC per session in api/scripture/database.py (the runtime source of truth),
-        #    so a failure here is non-fatal — we just skip the DB-wide default, which
-        #    only benefits non-app clients (psql, ad-hoc tools).
-        ef_search = max(settings.hnsw_ef_search, settings.vector_candidate_pool)
-        dbname = await conn.fetchval("SELECT current_database()")
-        log(f"Setting hnsw.ef_search = {ef_search} on database '{dbname}'")
-        # dbname/ef_search are not bindable in ALTER DATABASE; dbname comes from the
-        # server and ef_search is an int from config, so inlining is safe.
-        try:
-            await conn.execute(f'ALTER DATABASE "{dbname}" SET hnsw.ef_search = {int(ef_search)}')
-        except asyncpg.exceptions.InsufficientPrivilegeError:
-            log(
-                "Skipping ALTER DATABASE SET hnsw.ef_search (insufficient privilege); "
-                "the application sets it per session at the connection level instead."
-            )
+        # NOTE: hnsw.ef_search is intentionally NOT set here. Managed Postgres
+        # (Azure Flexible Server / AWS RDS) refuses to persist it at the database or
+        # role level — `ALTER DATABASE ... SET hnsw.ef_search` raised "permission
+        # denied to set parameter" and failed CI. The application sets it per session
+        # on every pooled connection instead (api/scripture/database.py), which needs
+        # no special privilege. See the module docstring for the full story.
 
-        # 2. Discover the translations actually present so the index set tracks
+        # 1. Discover the translations actually present so the index set tracks
         #    reality instead of a hard-coded list that can drift.
         rows = await conn.fetch(
             "SELECT DISTINCT translation FROM verses "
@@ -106,7 +99,7 @@ async def run_migration():
             return
         log(f"Found {len(translations)} translations: {', '.join(translations)}")
 
-        # 3. One partial HNSW index per translation. CONCURRENTLY keeps the verses
+        # 2. One partial HNSW index per translation. CONCURRENTLY keeps the verses
         #    table readable during the build; each statement runs in its own
         #    autocommit execute because CONCURRENTLY cannot run inside a txn.
         for t in translations:
@@ -123,7 +116,7 @@ async def run_migration():
                 f"WHERE translation = '{literal}'"
             )
 
-        # 4. Warm the new indexes into shared_buffers so the first post-deploy query
+        # 3. Warm the new indexes into shared_buffers so the first post-deploy query
         #    doesn't pay the cold-cache penalty. Best-effort: pg_prewarm must be
         #    allow-listed (azure.extensions); skip silently if unavailable.
         try:

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -221,8 +221,15 @@ translations, then the `WHERE translation = :t` filter drops the non-matching ro
 at `ef_search = 80`) and hurting recall. A partial index per translation
 (`... WHERE translation = '<t>'`) is filtered *by the index*: no post-filter, the
 `LIMIT` fills, and the per-query working set drops ~12× (each partial ≈ 220 MB vs
-the 2.6 GB full index). It also sets `hnsw.ef_search = 120` (≥ `vector_candidate_pool`)
-so the ANN can return a full pool.
+the 2.6 GB full index). It also tries to set `hnsw.ef_search = 120`
+(≥ `vector_candidate_pool`) so the ANN can return a full pool.
+
+> **`hnsw.ef_search` is best-effort here.** `ALTER DATABASE ... SET hnsw.ef_search`
+> needs DB-owner/superuser privileges the managed-Postgres app role lacks, so the
+> migration skips it with a warning when it hits `InsufficientPrivilegeError`. The
+> **runtime source of truth** is the API connection pool, which applies the GUC per
+> session on connect (`api/scripture/database.py`); the DB-wide default only benefits
+> non-app clients (psql, ad-hoc tools).
 
 ### Why a `.py` migration
 

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -211,7 +211,8 @@ LIMIT 5;
 **Date:** 2026-06-24
 **Purpose:** Phase 2 chat-latency fix. Replace reliance on the single full HNSW
 index (`idx_verse_embedding_hnsw`) for per-language chat search with one **partial**
-HNSW index per translation, and raise `hnsw.ef_search` to match the candidate pool.
+HNSW index per translation. (`hnsw.ef_search` is tuned by the application per
+session, not by this migration — see the note below.)
 
 ### Why
 
@@ -221,15 +222,17 @@ translations, then the `WHERE translation = :t` filter drops the non-matching ro
 at `ef_search = 80`) and hurting recall. A partial index per translation
 (`... WHERE translation = '<t>'`) is filtered *by the index*: no post-filter, the
 `LIMIT` fills, and the per-query working set drops ~12× (each partial ≈ 220 MB vs
-the 2.6 GB full index). It also tries to set `hnsw.ef_search = 120`
-(≥ `vector_candidate_pool`) so the ANN can return a full pool.
+the 2.6 GB full index).
 
-> **`hnsw.ef_search` is best-effort here.** `ALTER DATABASE ... SET hnsw.ef_search`
-> needs DB-owner/superuser privileges the managed-Postgres app role lacks, so the
-> migration skips it with a warning when it hits `InsufficientPrivilegeError`. The
-> **runtime source of truth** is the API connection pool, which applies the GUC per
-> session on connect (`api/scripture/database.py`); the DB-wide default only benefits
-> non-app clients (psql, ad-hoc tools).
+> **Why this migration no longer touches `hnsw.ef_search`.** The ANN still needs
+> `ef_search ≥ vector_candidate_pool` (≥ 120) to return a full pool, but managed
+> Postgres (Azure Flexible Server, AWS RDS) refuses to *persist* that GUC at the
+> database/role level — `ALTER DATABASE ... SET hnsw.ef_search` raises
+> `permission denied to set parameter` even for the admin role, and an earlier
+> version of this migration failed CI with exactly that error. The knob now lives
+> in the API connection pool, which runs `SET hnsw.ef_search` per session on connect
+> (`api/scripture/database.py`); a session-level SET needs no special privilege and
+> is the vendor-recommended way to tune it.
 
 ### Why a `.py` migration
 


### PR DESCRIPTION
## Summary
This PR relocates the responsibility for setting PostgreSQL's `hnsw.ef_search` GUC parameter from migration 007 to the application's connection pool. This change is necessary because managed Postgres services (Azure Flexible Server, AWS RDS) forbid persisting this parameter at the database or role level, causing migration 007 to fail in CI.

## Key Changes

- **Migration 007 (`scripts/migrations/007_partial_hnsw_verse_indexes.py`)**: Removed the `ALTER DATABASE ... SET hnsw.ef_search` logic that was failing on managed Postgres. The migration now only creates per-translation partial HNSW indexes. Updated docstrings and comments to explain why the GUC tuning was moved to the application layer.

- **Connection Pool (`api/scripture/database.py`)**: Added a new SQLAlchemy event listener (`_apply_session_hnsw_ef_search`) that runs on every new pooled connection. This listener executes `SET hnsw.ef_search` at the session level, which requires no special privileges and is the vendor-recommended approach for managed Postgres. Failures are logged but swallowed to prevent connection pool breakage.

- **Configuration (`api/config.py`)**: Updated the `hnsw_ef_search` setting documentation to clarify that the connection pool is now the runtime source of truth, with migration 007's attempt being best-effort only.

- **Documentation (`scripts/migrations/README.md`)**: Updated migration 007's documentation to explain the shift in responsibility and the rationale for using session-level GUC setting instead of database-level persistence.

## Implementation Details

- The connection pool listener uses SQLAlchemy's `@event.listens_for(engine.sync_engine, "connect")` decorator to hook into the DBAPI connection lifecycle
- The listener executes synchronously within SQLAlchemy's asyncio greenlet, transparently awaiting the underlying asyncpg call
- Exception handling is broad (`except Exception`) to ensure a GUC-setting failure never breaks the connection pool; failures are logged as warnings
- The approach maintains the same effective behavior (ensuring `ef_search >= vector_candidate_pool`) while working within managed Postgres constraints

https://claude.ai/code/session_01NEpXG1zrZMaVtjmXYCwb7V