### PR TITLE
fix(content-filter): stop blocking ellipses and surface blocked message on Android

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -445,8 +445,13 @@ fun ChatMessageItem(
     // Show the retry button when:
     //  - this is an assistant message
     //  - it is NOT currently streaming
-    //  - it was flagged as an error (blank content + error flag)
+    //  - it was flagged as an error
     val showRetry = !isUser && !message.isStreaming && message.isError
+
+    // Render the message bubble for normal messages, and also for error messages
+    // that carry explanatory text (e.g. the content-blocked / network-error copy) so
+    // the user sees *why* it failed above the Retry button — not a bare button alone.
+    val showBubble = !showRetry || message.content.isNotBlank()
 
     // Show the share button only for finished (non-streaming) assistant messages with content.
     val showShare = !isUser && !message.isStreaming && !message.isError && message.content.isNotBlank()
@@ -480,7 +485,7 @@ fun ChatMessageItem(
             modifier = Modifier.widthIn(max = 320.dp),
             horizontalAlignment = if (isUser) Alignment.End else Alignment.Start,
         ) {
-            if (!showRetry) {
+            if (showBubble) {
                 val bubbleModifier = if (isUser) {
                     // User bubble: filled primary, no border
                     Modifier

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -463,8 +463,15 @@ class ChatViewModel @Inject constructor(
                                             isError = false,
                                         )
                                     } else {
+                                        // Carry the (often empathetic) explanation on the
+                                        // message itself so it renders in the chat bubble
+                                        // above the Retry button. Previously this was left
+                                        // empty and the text only went to the snackbar, which
+                                        // ChatScreen suppresses whenever an inline Retry exists
+                                        // — so blocked/error messages showed only a bare Retry
+                                        // button with no explanation.
                                         msg.copy(
-                                            content = "",
+                                            content = errorMessage,
                                             isStreaming = false,
                                             isError = true,
                                         )

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -117,6 +117,7 @@ class ChatViewModelTest {
             every { getString(R.string.error_generic) } returns "Something went wrong. Please try again."
             every { getString(R.string.error_session_limit) } returns "You've had 10 messages..."
             every { getString(R.string.error_contact_email_invalid) } returns "Please enter a valid email so we can reply."
+            every { getString(R.string.error_content_blocked) } returns "I wasn't able to respond to that one — please try rephrasing."
         }
         networkMonitor = mockk {
             every { isOffline } returns MutableStateFlow(false)
@@ -319,7 +320,10 @@ class ChatViewModelTest {
         assertEquals(Message.Role.ASSISTANT, lastMessage.role)
         assertTrue(lastMessage.isError)
         assertFalse(lastMessage.isStreaming)
-        assertEquals("", lastMessage.content)
+        // The error message now carries the explanatory text on the bubble (so it renders
+        // above the Retry button) instead of being left blank.
+        assertTrue(lastMessage.content.isNotBlank())
+        assertEquals("Network error. Please check your connection.", lastMessage.content)
     }
 
     @Test
@@ -1037,6 +1041,36 @@ class ChatViewModelTest {
         val errorBody = body.toResponseBody("application/json".toMediaType())
         val response = Response.error<Any>(422, errorBody)
         return HttpException(response)
+    }
+
+    private fun make400Exception(body: String): HttpException {
+        val errorBody = body.toResponseBody("application/json".toMediaType())
+        val response = Response.error<Any>(400, errorBody)
+        return HttpException(response)
+    }
+
+    @Test
+    fun `HTTP 400 content_blocked surfaces empathetic message on the assistant bubble`() = runTest {
+        every { repository.chatStream(any()) } returns flow {
+            throw make400Exception(
+                """{"detail": {"error": "content_blocked", "message": "blocked"}}""",
+            )
+        }
+
+        viewModel.sendMessage("mi manca tanto la....... Anna la mia Amica")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The blocked message must be shown to the user (not lost to a suppressed snackbar):
+        // it is carried on the error-flagged assistant bubble, where the Retry button renders
+        // beneath it.
+        val lastMsg = viewModel.uiState.value.messages.last()
+        assertEquals(Message.Role.ASSISTANT, lastMsg.role)
+        assertTrue(lastMsg.isError)
+        assertFalse(lastMsg.isStreaming)
+        assertEquals(
+            "I wasn't able to respond to that one — please try rephrasing.",
+            lastMsg.content,
+        )
     }
 
     @Test

--- a/api/tests/test_security.py
+++ b/api/tests/test_security.py
@@ -244,6 +244,61 @@ class TestContentFilter:
             allowed, _, _ = filter.check("Helloo there")
             assert allowed is True
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # The exact message from the reported false positive (ellipsis "......").
+            "mi manca tanto la....... Anna la mia Amica",
+            # Bare punctuation runs that natural messages contain.
+            ".......",
+            "!!!!!!!!",
+            "???????",
+            "--------",
+            # Accented (Unicode) text with an ellipsis must still be allowed.
+            "perché........ non lo so",
+        ],
+    )
+    def test_allows_repeated_punctuation(self, message):
+        """Repeated punctuation/whitespace (ellipses, !!!, ???) must not be spam.
+
+        Regression for the reported false positive where "mi manca tanto la......."
+        was rejected with HTTP 400 content_blocked because of the trailing dots.
+        """
+        filter = ContentFilter()
+        with patch("utils.security.settings") as mock_settings:
+            mock_settings.content_filter_enabled = True
+            mock_settings.content_filter_block_profanity = False
+            mock_settings.content_filter_block_spam = True
+            mock_settings.content_filter_max_repeated_chars = 5
+            mock_settings.content_filter_max_urls = 1
+
+            allowed, violation, _ = filter.check(message)
+            assert allowed is True, f"Should NOT block punctuation: {message!r}"
+            assert violation is None
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Hellooooooo there",  # existing case — stretched word
+            "soooooooo",
+            "aaaaaaaa",
+            "1111111",  # repeated digits are word chars, still spammy
+        ],
+    )
+    def test_blocks_stretched_words(self, message):
+        """Stretched *word* characters (letters/digits) must still be blocked."""
+        filter = ContentFilter()
+        with patch("utils.security.settings") as mock_settings:
+            mock_settings.content_filter_enabled = True
+            mock_settings.content_filter_block_profanity = False
+            mock_settings.content_filter_block_spam = True
+            mock_settings.content_filter_max_repeated_chars = 5
+            mock_settings.content_filter_max_urls = 1
+
+            allowed, violation, _ = filter.check(message)
+            assert allowed is False, f"Should block stretched word: {message!r}"
+            assert violation == ViolationType.REPEATED_CHARS
+
     def test_disabled_filter_allows_all(self):
         """Disabled filter should allow all content."""
         filter = ContentFilter()
@@ -282,3 +337,46 @@ class TestSecurityIntegration:
             json={"message": "Hello", "session_id": "invalid!@#"},
         )
         assert response.status_code == 422
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette Request for the content-filter dependency."""
+
+    def __init__(self, body: dict):
+        self.method = "POST"
+        self.headers: dict[str, str] = {}
+        self.client = None
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+class TestContentFilterDependency:
+    """End-to-end tests for the check_content_filter FastAPI dependency.
+
+    Exercises the real HTTP 400 `content_blocked` path that rejected the reported
+    message, without invoking the LLM.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ellipsis_message_not_blocked(self):
+        """The reported ellipsis message must pass the content-filter dependency."""
+        from utils.security import check_content_filter
+
+        request = _FakeRequest({"message": "mi manca tanto la....... Anna la mia Amica"})
+        # Must NOT raise HTTPException(400, content_blocked).
+        await check_content_filter(request)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_stretched_word_still_blocked(self):
+        """A stretched word still trips the dependency with HTTP 400 content_blocked."""
+        from fastapi import HTTPException
+
+        from utils.security import check_content_filter
+
+        request = _FakeRequest({"message": "Hellooooooo there"})
+        with pytest.raises(HTTPException) as exc_info:
+            await check_content_filter(request)  # type: ignore[arg-type]
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"] == "content_blocked"

--- a/api/utils/security.py
+++ b/api/utils/security.py
@@ -134,7 +134,12 @@ class ContentFilter:
         # Check repeated characters
         if settings.content_filter_block_spam:
             max_repeat = settings.content_filter_max_repeated_chars
-            repeat_pattern = re.compile(r"(.)\1{" + str(max_repeat) + r",}")
+            # Only flag stretched *word* characters (e.g. "Hellooooooo", "aaaaaa").
+            # Punctuation/whitespace/emoji repetition — ellipses "......", "!!!",
+            # "???", "----" — is natural in real messages and must not be treated as
+            # spam. `\w` is Unicode-aware for str patterns, so accented letters (e.g.
+            # Italian "perché") are still covered. (Fixes ellipsis false positive.)
+            repeat_pattern = re.compile(r"(\w)\1{" + str(max_repeat) + r",}", re.UNICODE)
             if repeat_pattern.search(message):
                 return (
                     False,


### PR DESCRIPTION
The repeated-character spam filter compiled `(.)\1{5,}`, which matched any
character repeated 6+ times — including punctuation. An Italian message
"mi manca tanto la....... Anna la mia Amica" was rejected with HTTP 400
content_blocked purely because of the trailing ellipsis. Restrict the check
to repeated word characters (`\w`, Unicode-aware) so stretched-word spam
("Hellooooooo", "aaaaaa") is still blocked while ellipses, "!!!", "???",
"----" and emoji are allowed.

On Android, blocked/error messages showed only a bare "Retry" button: the
explanatory (empathetic) text was put solely on the snackbar channel, which
ChatScreen suppresses whenever an inline Retry exists. Carry the text on the
error-flagged assistant message and render the bubble above the Retry button
so the user sees why the message failed.

Adds backend regression tests (allowed punctuation vs. still-blocked stretched
words, plus a dependency-level check of the HTTP 400 path) and Android
ViewModel tests asserting the explanation text now reaches the bubble.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AAhFcjoRfwbFsH1MVD71wG