### PR TITLE
fix(api+ci): stop readiness-probe flapping; bound + observe upstream dependencies

### DIFF
--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -126,7 +126,12 @@ jobs:
         env:
           BACKEND_URL: ${{ env.BACKEND_URL }}
           MONITOR_PROBE_SECRET: ${{ secrets.MONITOR_PROBE_SECRET }}
-          PROBE_MESSAGE: "hi"
+          # Must be a real scripture prompt: the probe asserts the response cites/
+          # resolves verses (PROBE_REQUIRE_VERSES defaults to 1, BITB-055). A greeting
+          # like "hi" only sometimes elicits a citation, so it produced nondeterministic
+          # false failures. A direct verse question deterministically exercises — and
+          # asserts on — the scripture-retrieval path the probe is meant to guard.
+          PROBE_MESSAGE: "What does John 3:16 say?"
           PROBE_TIMEOUT_SECONDS: "30"
           PROBE_FIRST_CHUNK_SECONDS: "20"
         run: python scripts/monitor/synthetic_chat.py --detail-out "$RUNNER_TEMP/detail.txt"

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -64,6 +64,32 @@ logger = get_logger(__name__)
 MAX_RANGE_SPAN = 50
 
 
+def _is_disconnection_error(exc: Exception) -> bool:
+    """True if ``exc`` indicates a dropped/invalidated Postgres connection.
+
+    ``pool_pre_ping`` validates a connection at checkout, but cannot save one that
+    dies *mid-operation* (e.g. Azure Postgres closing an idle backend, or asyncpg's
+    ``ConnectionDoesNotExistError: connection was closed in the middle of operation``).
+    Those are transient — SQLAlchemy invalidates the connection and the next checkout
+    gets a fresh, pre-pinged one — so the caller can safely retry once.
+    """
+    from sqlalchemy.exc import DBAPIError, DisconnectionError
+
+    transient_names = {
+        "ConnectionDoesNotExistError",
+        "ConnectionResetError",
+        "InterfaceError",
+    }
+    if isinstance(exc, DisconnectionError):
+        return True
+    if isinstance(exc, DBAPIError) and getattr(exc, "connection_invalidated", False):
+        return True
+    if type(exc).__name__ in transient_names:
+        return True
+    cause = getattr(exc, "orig", None) or getattr(exc, "__cause__", None)
+    return cause is not None and type(cause).__name__ in transient_names
+
+
 class ConversationMessage(BaseModel):
     """A message in the conversation."""
 
@@ -655,6 +681,7 @@ Keep it under 100 words."""
         is_verse_lookup: bool,
         detected_language: str = "en",  # NEW
         model_override: str | None = None,  # NEW
+        _allow_retry: bool = True,  # retry once on a transient DB disconnect
     ) -> tuple[SearchResults | None, str]:
         """
         Search for relevant scripture, including direct lookups for specific verse references.
@@ -766,6 +793,23 @@ Keep it under 100 words."""
                 },
             )
         except Exception as e:
+            # A pooled connection dropped mid-operation is transient (pool_pre_ping
+            # only validates at checkout, not mid-query): retry the whole search once
+            # on a fresh, pre-pinged connection before degrading to a verse-less reply.
+            if _allow_retry and _is_disconnection_error(e):
+                logger.warning(
+                    f"Scripture search hit a transient DB disconnect "
+                    f"({type(e).__name__}); retrying once"
+                )
+                return await self._search_scripture(
+                    request,
+                    translation,
+                    verse_refs,
+                    is_verse_lookup,
+                    detected_language=detected_language,
+                    model_override=model_override,
+                    _allow_retry=False,
+                )
             scripture_pipeline_errors_counter.add(
                 1, {"stage": "search", "error_type": type(e).__name__}
             )

--- a/api/config.py
+++ b/api/config.py
@@ -77,13 +77,18 @@ class Settings(BaseSettings):
     db_pool_timeout: int = 30  # seconds to wait for a free connection before erroring
     db_pool_recycle: int = 1800  # recycle a connection after 30 min (avoid stale/idle drops)
     # Per-query ceilings so a slow/hung backend fails fast and *visibly* (raises ->
-    # logged + metric + retried) instead of tying up a pooled connection until
-    # db_pool_timeout. db_command_timeout is the asyncpg client-side bound; the
-    # server-side statement_timeout (slightly lower) kills a runaway query first so
-    # the client gets a clean error rather than a wedged socket. Both sit well above
-    # normal request-path latency (<1s), so they only fire on genuine stalls.
-    db_command_timeout: int = 30  # asyncpg client-side per-query timeout (seconds)
-    db_statement_timeout_ms: int = 25000  # server-side statement_timeout (milliseconds)
+    # logged + metric + retried) instead of holding a pooled connection until
+    # db_pool_timeout (30s) and cascading into pool exhaustion. Sizing: normal queries
+    # run <100ms (slow_query_threshold_ms); the p95 *saturation* SLOs are 1s (verse
+    # reads, BITB-041) and 2s (semantic search, BITB-056). These ceilings sit ~4x above
+    # the 2s saturation line — high enough never to cancel a legitimately slow query
+    # even during a concurrency spike (~8x baseline at conc 64), low enough to free the
+    # connection well before the 30s pool timeout. statement_timeout (server) is set
+    # below command_timeout (client) so Postgres cancels first and asyncpg surfaces a
+    # clean "canceling statement due to statement timeout" error instead of a raw
+    # socket timeout.
+    db_command_timeout: int = 10  # asyncpg client-side per-query timeout (seconds)
+    db_statement_timeout_ms: int = 8000  # server-side statement_timeout (milliseconds)
 
     # Chat Settings
     max_context_verses: int = 10  # Max verses to include in context

--- a/api/config.py
+++ b/api/config.py
@@ -76,6 +76,14 @@ class Settings(BaseSettings):
     db_max_overflow: int = 10  # burst capacity above pool_size
     db_pool_timeout: int = 30  # seconds to wait for a free connection before erroring
     db_pool_recycle: int = 1800  # recycle a connection after 30 min (avoid stale/idle drops)
+    # Per-query ceilings so a slow/hung backend fails fast and *visibly* (raises ->
+    # logged + metric + retried) instead of tying up a pooled connection until
+    # db_pool_timeout. db_command_timeout is the asyncpg client-side bound; the
+    # server-side statement_timeout (slightly lower) kills a runaway query first so
+    # the client gets a clean error rather than a wedged socket. Both sit well above
+    # normal request-path latency (<1s), so they only fire on genuine stalls.
+    db_command_timeout: int = 30  # asyncpg client-side per-query timeout (seconds)
+    db_statement_timeout_ms: int = 25000  # server-side statement_timeout (milliseconds)
 
     # Chat Settings
     max_context_verses: int = 10  # Max verses to include in context
@@ -133,6 +141,11 @@ class Settings(BaseSettings):
     health_check_timeout: int = (
         15  # Timeout for dependency checks in seconds (longer for free APIs)
     )
+    # Readiness probe checks ONLY the database and must answer well within the
+    # platform readiness-probe deadline (deployment/main.tf readiness_probe.timeout,
+    # currently 5s), so it uses a short timeout independent of the 15s budget the
+    # comprehensive /health endpoint allows for slow free-tier inference providers.
+    readiness_check_timeout: int = 3
     memory_warning_threshold_mb: int = 512  # Memory usage warning threshold
 
     # Security Settings

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -46,14 +46,20 @@ class HealthResponse(BaseModel):
     memory: dict[str, Any]
 
 
-async def check_database_health() -> ComponentHealth:
-    """Check database connectivity and measure latency."""
+async def check_database_health(timeout: float | None = None) -> ComponentHealth:
+    """Check database connectivity and measure latency.
+
+    ``timeout`` defaults to ``settings.health_check_timeout`` (the comprehensive
+    ``/health`` budget). The readiness probe passes a shorter value so it answers
+    within the platform probe deadline instead of hanging up to the full budget.
+    """
+    timeout = settings.health_check_timeout if timeout is None else timeout
     start = time.perf_counter()
     try:
         async with async_session_factory() as session:
             result = await asyncio.wait_for(
                 session.execute(text("SELECT 1")),
-                timeout=settings.health_check_timeout,
+                timeout=timeout,
             )
             result.scalar()
             latency_ms = (time.perf_counter() - start) * 1000
@@ -62,9 +68,15 @@ async def check_database_health() -> ComponentHealth:
                 latency_ms=round(latency_ms, 2),
             )
     except asyncio.TimeoutError:
+        latency_ms = (time.perf_counter() - start) * 1000
+        # Log so a stalled DB is visible to the log-scan even though the platform
+        # readiness probe gives up (and stays silent) before this returns.
+        logger.warning(
+            f"Database health check timed out after {timeout}s (elapsed {latency_ms:.0f}ms)"
+        )
         return ComponentHealth(
             status="unhealthy",
-            error=f"Database check timed out after {settings.health_check_timeout}s",
+            error=f"Database check timed out after {timeout}s",
         )
     except Exception as e:
         latency_ms = (time.perf_counter() - start) * 1000
@@ -92,6 +104,10 @@ async def check_llm_health() -> ComponentHealth:
             details={"provider": provider.provider_name},
         )
     except asyncio.TimeoutError:
+        logger.warning(
+            f"LLM health check timed out after {settings.health_check_timeout}s "
+            f"(provider={settings.llm_provider})"
+        )
         return ComponentHealth(
             status="unhealthy",
             error=f"LLM check timed out after {settings.health_check_timeout}s",
@@ -136,6 +152,10 @@ async def check_embedding_health() -> ComponentHealth:
             },
         )
     except asyncio.TimeoutError:
+        logger.warning(
+            f"Embedding health check timed out after {settings.health_check_timeout}s "
+            f"(provider={settings.embedding_provider})"
+        )
         return ComponentHealth(
             status="unhealthy",
             error=f"Embedding check timed out after {settings.health_check_timeout}s",
@@ -254,42 +274,32 @@ async def readiness_probe():
     """
     Readiness probe for Kubernetes/orchestration.
 
-    Returns 200 if the app can serve requests, 503 only if critical
-    dependencies are unavailable.
+    Returns 200 if the app can serve requests, 503 only when the database —
+    the dependency that actually gates request serving — is unavailable.
 
-    Lenient by design: returns 200 when LLM **or** embedding is unhealthy
-    (single-dependency degradation should not bounce the pod). Returns 503
-    only when the database is unhealthy, or when **both** LLM and embedding
-    are down. The response body always lists each dependency's state so
-    Azure can scrape it for dependency-failure alerts (in addition to the
-    metric-based alerts on `llama_guard_fallback_total` /
-    `openrouter_fallback_total`).
+    Intentionally cheap: it checks ONLY the database, with a short timeout
+    (`settings.readiness_check_timeout`) that stays under the platform probe
+    deadline (`deployment/main.tf` readiness_probe.timeout). The LLM and
+    embedding providers are deliberately NOT probed here. Calling those external
+    APIs on every scrape (~every 10s) made readiness exceed the probe deadline
+    whenever a free-tier upstream was slow, flapping the pod for weeks while it
+    was otherwise serving fine. Their health is covered by the comprehensive
+    `/health` endpoint and by the LLM/embedding fallback metric alerts;
+    single-dependency inference degradation still serves (degraded) responses
+    and must not bounce the pod.
     """
-    db_health, llm_health, embedding_health = await asyncio.gather(
-        check_database_health(),
-        check_llm_health(),
-        check_embedding_health(),
-    )
+    db_health = await check_database_health(timeout=settings.readiness_check_timeout)
 
-    dependencies = {
-        "database": db_health.status,
-        "llm": llm_health.status,
-        "embedding": embedding_health.status,
-    }
+    dependencies = {"database": db_health.status}
 
-    db_down = db_health.status == "unhealthy"
-    both_inference_down = (
-        llm_health.status == "unhealthy" and embedding_health.status == "unhealthy"
-    )
-
-    if db_down or both_inference_down:
+    if db_health.status == "unhealthy":
         return JSONResponse(
             status_code=503,
             content={
                 "status": "not_ready",
-                "reason": "database_unavailable" if db_down else "inference_unavailable",
+                "reason": "database_unavailable",
                 "dependencies": dependencies,
-                "error": db_health.error if db_down else None,
+                "error": db_health.error,
             },
         )
 

--- a/api/scripture/database.py
+++ b/api/scripture/database.py
@@ -59,6 +59,17 @@ def get_async_database_url() -> tuple[str, dict]:
 # Get async URL and connection args
 _async_url, _connect_args = get_async_database_url()
 
+# Bound every query at the driver and the server so a slow/hung backend fails fast
+# and *visibly* instead of tying up a pooled connection until db_pool_timeout.
+#   - command_timeout (asyncpg, client side): the request coroutine raises promptly,
+#     so the fail-open guard logs it, emits scripture.pipeline.errors and retries once.
+#   - statement_timeout (server side, ms, set a little lower): Postgres cancels the
+#     runaway query itself, so even a wedged client socket cannot hold a backend open.
+# Both sit well above normal request latency, so they only trip on genuine stalls.
+_connect_args.setdefault("command_timeout", settings.db_command_timeout)
+_server_settings = _connect_args.setdefault("server_settings", {})
+_server_settings.setdefault("statement_timeout", str(settings.db_statement_timeout_ms))
+
 # Create async engine.
 #
 # Use SQLAlchemy's default async pool (AsyncAdaptedQueuePool) rather than NullPool.

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -940,6 +940,81 @@ class TestChatServiceSearchScripture:
         assert context is None
         assert prompt == ""
 
+    @pytest.mark.asyncio
+    async def test_search_retries_once_on_db_disconnect(self):
+        service, _, embedding = _make_chat_service()
+        service.search_service = AsyncMock()
+
+        # A pooled connection dropped mid-operation surfaces as asyncpg
+        # ConnectionDoesNotExistError; _is_disconnection_error matches it by name.
+        class ConnectionDoesNotExistError(Exception):
+            pass
+
+        search_result = SearchResults(
+            query="test",
+            verses=[
+                VerseResult(
+                    reference="John 3:16",
+                    text="For God so loved the world...",
+                    book="John",
+                    chapter=3,
+                    verse=16,
+                )
+            ],
+            passages=[],
+        )
+        service.search_service.search_hybrid = AsyncMock(
+            side_effect=[ConnectionDoesNotExistError("closed mid-operation"), search_result]
+        )
+
+        request = ChatRequest(message="test")
+        context, prompt = await service._search_scripture(request, "kjv", [], False)
+
+        # Retried once on a fresh connection rather than degrading to verse-less.
+        assert context is not None
+        assert len(context.verses) == 1
+        assert service.search_service.search_hybrid.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_search_does_not_retry_non_disconnect(self):
+        service, _, embedding = _make_chat_service()
+        service.search_service = AsyncMock()
+        service.search_service.search_hybrid = AsyncMock(side_effect=ValueError("bad query"))
+
+        request = ChatRequest(message="test")
+        context, prompt = await service._search_scripture(request, "kjv", [], False)
+
+        # Non-transient errors fail open immediately (no retry).
+        assert context is None
+        assert service.search_service.search_hybrid.await_count == 1
+
+
+class TestIsDisconnectionError:
+    """Tests for chat.service._is_disconnection_error()."""
+
+    def test_matches_asyncpg_connection_dropped_by_name(self):
+        from chat.service import _is_disconnection_error
+
+        class ConnectionDoesNotExistError(Exception):
+            pass
+
+        assert _is_disconnection_error(ConnectionDoesNotExistError("closed mid-op")) is True
+
+    def test_matches_wrapped_cause(self):
+        from chat.service import _is_disconnection_error
+
+        class InterfaceError(Exception):
+            pass
+
+        wrapper = RuntimeError("DBAPIError")
+        wrapper.__cause__ = InterfaceError("connection lost")
+        assert _is_disconnection_error(wrapper) is True
+
+    def test_ignores_unrelated_errors(self):
+        from chat.service import _is_disconnection_error
+
+        assert _is_disconnection_error(ValueError("bad query")) is False
+
 
 class TestChatServiceLookupDirectVerses:
     """Tests for ChatService._lookup_direct_verses()."""

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -82,6 +82,33 @@ class TestCheckDatabaseHealth:
         assert result.error is not None
         assert result.latency_ms is not None
 
+    @pytest.mark.asyncio
+    @patch("routes.health.logger")
+    @patch("routes.health.async_session_factory")
+    async def test_timeout_logs_warning(self, mock_factory, mock_logger):
+        """A stalled DB check must log a warning so a dependency stall is visible to
+        the log-scan even though the platform probe gives up silently."""
+        import asyncio
+
+        from routes.health import check_database_health
+
+        mock_session = AsyncMock()
+
+        async def slow_execute(*args, **kwargs):
+            await asyncio.sleep(100)
+
+        mock_session.execute = slow_execute
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_factory.return_value = mock_session
+
+        with patch("routes.health.settings") as mock_settings:
+            mock_settings.health_check_timeout = 0.001
+            result = await check_database_health()
+
+        assert result.status == "unhealthy"
+        mock_logger.warning.assert_called_once()
+
 
 class TestCheckLlmHealth:
     """Tests for check_llm_health()."""
@@ -325,13 +352,19 @@ class TestReadinessProbe:
     async def test_ready(self, mock_db_health, mock_llm_health, mock_embedding_health):
         from routes.health import ComponentHealth, readiness_probe
 
+        from config import settings
+
         mock_db_health.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
-        mock_llm_health.return_value = ComponentHealth(status="healthy", latency_ms=10.0)
-        mock_embedding_health.return_value = ComponentHealth(status="healthy", latency_ms=8.0)
         result = await readiness_probe()
         assert result["status"] == "ready"
         assert result["database_latency_ms"] == 5.0
-        assert result["dependencies"]["database"] == "healthy"
+        assert result["dependencies"] == {"database": "healthy"}
+        # Readiness must be cheap and bounded: only the DB is probed, with the short
+        # readiness timeout. The LLM/embedding providers are deliberately NOT called
+        # here (probing them every scrape flapped the pod for weeks).
+        mock_db_health.assert_awaited_once_with(timeout=settings.readiness_check_timeout)
+        mock_llm_health.assert_not_called()
+        mock_embedding_health.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("routes.health.check_embedding_health")
@@ -343,12 +376,13 @@ class TestReadinessProbe:
         mock_db_health.return_value = ComponentHealth(
             status="unhealthy", error="Connection refused"
         )
-        mock_llm_health.return_value = ComponentHealth(status="healthy")
-        mock_embedding_health.return_value = ComponentHealth(status="healthy")
         result = await readiness_probe()
         assert result.status_code == 503
         body = result.body
         assert b"not_ready" in body
+        assert b"database_unavailable" in body
+        mock_llm_health.assert_not_called()
+        mock_embedding_health.assert_not_called()
 
 
 # ==================== Main App Tests ====================

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -350,9 +350,8 @@ class TestReadinessProbe:
     @patch("routes.health.check_llm_health")
     @patch("routes.health.check_database_health")
     async def test_ready(self, mock_db_health, mock_llm_health, mock_embedding_health):
-        from routes.health import ComponentHealth, readiness_probe
-
         from config import settings
+        from routes.health import ComponentHealth, readiness_probe
 
         mock_db_health.return_value = ComponentHealth(status="healthy", latency_ms=5.0)
         result = await readiness_probe()

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -285,6 +285,53 @@ resource "azurerm_monitor_metric_alert" "backend_restarts" {
   tags = local.tags
 }
 
+# Backend probe-failure alert.
+#
+# Container Apps logs readiness/liveness probe failures to ContainerAppSystemLogs_CL
+# as ReplicaUnhealthy events. These never reach ContainerAppConsoleLogs_CL (so
+# backend_errors can't see them) and do NOT increment RestartCount when the pod keeps
+# failing readiness without being restarted (so backend_restarts can't see them either).
+# That blind spot let a multi-week readiness incident — /health/ready timing out on slow
+# upstream dependencies — run with no alert. This watches the platform probe signal
+# directly. The query gates on a burst (> 10 in 15m) so single-replica blips during a
+# deploy (a few "connection refused" at container start) do not page.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_probe_failures" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-backend-probe-failures"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT15M"
+  scopes               = [azurerm_log_analytics_workspace.main.id]
+  severity             = 2
+  description          = "The backend container failed its readiness/liveness probe (ReplicaUnhealthy) more than 10 times in the last 15 minutes. Usually /health/ready timing out on a slow dependency, or the container is unhealthy. These ContainerAppSystemLogs_CL events do not trigger RestartCount, so this is the only alert that covers them. The payload carries a sample probe-failure line."
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppSystemLogs_CL
+      | where ContainerAppName_s == "bible-app-backend"
+      | where Reason_s == "ReplicaUnhealthy"
+      | where Log_s has "probe failed"
+      | summarize cnt = count(), Sample = any(Log_s)
+      | where cnt > 10
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
 # Backend error-log alert (BITB-056).
 #
 # Fires on ERROR-level backend log lines only. The error definition (the level

--- a/docs/BACKLOG_STORIES/BITB-057-upstream-dependency-resilience.md
+++ b/docs/BACKLOG_STORIES/BITB-057-upstream-dependency-resilience.md
@@ -1,0 +1,140 @@
+# BITB-057: Upstream Dependency Resilience — Bounded, Self-Healing, Observable DB + Inference Calls
+
+**Status:** 🚧 In progress (Phase 1 — readiness fix + DB bounding + probe alert — implemented; embedding hardening + infra = follow-up)
+**Priority:** P1 (High) — production availability; caused a multi-week readiness incident with real user impact
+**Size:** M–L (Phase 1 done; follow-up ~2-3 days incl. infra sign-off)
+**Created:** 2026-06-30
+
+## User Story
+
+As the operator of getinspiredbythebible / Vox Quieta, I want every call to an upstream dependency
+(Postgres, the LLM, the embedding provider) to be **bounded** (it can never hang the request or pin
+a pooled connection), to **degrade gracefully instead of breaking** the user experience, and to be
+**loud** (every timeout / retry / fallback / degradation emits a log + metric and is alertable), so
+that a slow or flapping dependency is ridden out and surfaced — not silently swallowed for weeks as
+it was during the readiness incident.
+
+## Problem / Motivation
+
+A synthetic-chat monitor failure investigation (2026-06-30) found that the backend readiness probe
+had been failing **chronically since before 2026-06-16** (continuous `/health/ready` "context
+deadline exceeded" → `ReplicaUnhealthy`, clustering in peak-traffic hours), with real user impact —
+yet **nothing alerted** and there were **only 3 ERROR log lines in 2 weeks** despite hundreds of
+failures. Root causes:
+
+1. **Readiness did heavy, unbounded-for-the-deadline work.** `/health/ready`
+   (`api/routes/health.py`) ran a DB `SELECT 1` **plus a live OpenRouter `health_check()` plus a
+   live `embedding.embed()`** on every scrape, each allowed `health_check_timeout = 15s`, while the
+   Container Apps readiness probe deadline is **5s** (`deployment/main.tf` readiness_probe.timeout).
+   Any slow free-tier upstream → probe timeout → pod flap. The probe also added constant embedding
+   load every 10s.
+2. **DB queries were unbounded.** `pool_pre_ping` validates at *checkout* but cannot save a
+   connection that dies **mid-operation** (`asyncpg ConnectionDoesNotExistError: connection was
+   closed in the middle of operation`, seen 2026-06-26). A slow/hung query could hold a pooled
+   connection up to `db_pool_timeout` (30s) and cascade toward pool exhaustion — the same saturation
+   knee BITB-056 found at concurrency ≈ 32.
+3. **Failures were silent.** The health-check timeout branches returned "unhealthy" without logging;
+   the chat scripture pipeline's fail-open `except` blocks degrade to verse-less without always
+   surfacing. The ERROR-only log-scan (BITB-056) cannot see a timeout that never logs.
+4. **No probe-failure alert.** `ReplicaUnhealthy` lives in `ContainerAppSystemLogs_CL`, never
+   reaches `ContainerAppConsoleLogs_CL`, and does not increment `RestartCount` (the pod kept failing
+   readiness without restarting) — so neither `backend_errors` nor `backend_restarts` covered it.
+5. **The telemetry pipeline itself dropped data.** The OTel → App Insights exporter timed out
+   (2026-06-29, "Envelopes could not be exported … Read timed out"), so the metric-based alerts
+   (`scripture.pipeline.errors`, `chat.responses.verseless`) can have blind spots.
+
+The unifying principle the system was missing: **bound → degrade → make it loud.** A delay must
+never break the service, but it must always be visible.
+
+## Acceptance Criteria
+
+### Phase 1 — readiness fix, DB bounding, probe alert — **implemented in this PR**
+
+- [x] **Readiness is cheap and correctly bounded.** `/health/ready` checks only the DB with
+      `readiness_check_timeout = 3s` (under the 5s platform deadline); the LLM and embedding providers
+      are no longer probed on every scrape (still covered by the comprehensive `/health` and the
+      LLM/embedding fallback metric alerts). (`api/routes/health.py`, `api/config.py`)
+- [x] **DB queries are bounded at driver and server.** `db_command_timeout` (asyncpg, 10s) +
+      server `statement_timeout` (8s) so a stalled query fails fast and frees its pooled connection
+      instead of pinning it to `db_pool_timeout`. Sized ~4x above the 2s search-saturation SLO so it
+      never cancels a legitimately slow query (`api/scripture/database.py`, `api/config.py`).
+- [x] **Scripture search retries once on a transient mid-operation disconnect**
+      (`_is_disconnection_error`); non-transient errors still fail open. (`api/chat/service.py`)
+- [x] **Stalls are loud.** DB/LLM/embedding health-check timeout branches now log a warning.
+- [x] **Probe-failure alert** on `ContainerAppSystemLogs_CL` `ReplicaUnhealthy` (`backend_probe_failures`
+      in `deployment/monitoring.tf`) — the missing signal that hid the incident.
+- [x] **Synthetic-chat probe sends a real scripture prompt** (not `"hi"`) so the verse-citation
+      assertion is meaningful (`.github/workflows/prod-monitor.yml`).
+
+### Phase 2 — harden the embedding/inference path (backend code) — **follow-up**
+
+- [ ] **Embedding provider resilience parity with the LLM path.** Give the embedding client the same
+      treatment OpenRouter/Llama Guard already have (`utils/circuit_breaker.py`): a **circuit
+      breaker**, a **request-path timeout** tighter than the current 60s Ollama embed client, and a
+      bounded **retry-with-jittered-backoff** on transient 429/5xx. Emit a fallback/circuit-open
+      metric and alert on a sustained fallback rate.
+- [ ] **Embedding cache.** Cache embeddings for hot/repeated queries (in-process LRU and/or Redis) to
+      cut upstream call volume and smooth latency — the embedding call is on the chat critical path
+      and was the load the readiness probe amplified.
+- [ ] **Generalize the bounded-timeout + retry-on-disconnect pattern** beyond `_search_scripture` to
+      the other request-path DB users (`_resolve_cited_verses`, feedback/blocked-samples writes) via a
+      small shared helper, so no request-path query is unbounded.
+
+### Phase 3 — upstream reliability at the source (infra) — **follow-up, needs owner sign-off**
+
+- [ ] **Enable Azure Postgres built-in PgBouncer (transaction pooling).** Highest-leverage item:
+      absorbs connection churn and mid-operation drops at the server edge and supports far more
+      clients than raw `max_connections`. App-side `QueuePool` + server PgBouncer is the robust combo.
+- [ ] **`min_replicas ≥ 1` on the backend Container App** to avoid scale-to-zero cold starts (the
+      brief "connection refused" probe failures at container start) and so one slow readiness can't
+      pull the only serving pod. (`deployment/main.tf` scale config.)
+- [ ] **DB compute right-sizing.** Readiness timeouts cluster at peak → saturation. Coordinate with
+      the BITB-056 open item (burstable `B_Standard_B2s` → `B4ms`/GP) once `db_cpu`/`connections_failed`
+      confirm the knee; B-series throttles when CPU credits drain. *Cost decision — owner sign-off.*
+
+### Phase 4 — make the observability itself reliable — **follow-up**
+
+- [ ] **Fix telemetry export drops.** Raise the OTel → App Insights exporter timeout / tune batch
+      settings so `scripture.pipeline.errors` / `chat.responses.verseless` alerts have no blind spots.
+- [ ] **Wire pool-saturation metrics.** Connect the `db.connections.active` gauge to SQLAlchemy
+      `checkout`/`checkin` events and alert at ≥80% of the pool ceiling as a leading indicator.
+      *(Shared with BITB-056 Phase 2 — implement once, reference there.)*
+
+## Notes / Reuse
+
+- Circuit-breaker primitive already exists: `api/utils/circuit_breaker.py` (`CircuitBreaker`,
+  `CircuitOpenError`), used by `api/providers/openrouter.py` and `api/providers/llama_guard.py` —
+  the embedding hardening copies this, it does not invent it.
+- OpenRouter already has a fallback-model chain + `openrouter_fallback_total` / `llm_fallback_total`
+  counters (`api/providers/openrouter.py`, `api/providers/factory.py`) — the LLM path is the model
+  to follow; the embedding path is the gap.
+- Latency SLOs to size timeouts against: `slow_query_threshold_ms = 100` (normal), p95 alerts at 1s
+  (`scripture_fetch_latency_p95`, BITB-041) and 2s (`scripture_search_latency_p95`, BITB-056).
+- `azurerm_monitor_scheduled_query_rules_alert_v2` patterns + action group `ops_email` already exist
+  in `deployment/monitoring.tf` — new alerts copy them.
+- Related: **BITB-055** (scripture-pipeline observability) and **BITB-056** (actionable backend error
+  alert + DB saturation detection / tier-bump) — this story is the availability/resilience layer on
+  top of their observability layer; the pool-saturation and DB tier items are shared with BITB-056.
+
+## Out of Scope
+
+- Frontend/Android changes.
+- Multi-region / read-replica DB topology (revisit only if PgBouncer + tier right-sizing is
+  insufficient).
+- Replacing the LLM/embedding provider (a separate product/cost decision); this story hardens the
+  client side and the fallback path.
+
+## Verification
+
+- Post-deploy: re-run the readiness onset KQL (`ContainerAppSystemLogs_CL` `ReplicaUnhealthy` for
+  `bible-app-backend`) and confirm the hourly timeout count flatlines to ~0; the `synthetic-chat`
+  monitor job stays green across several scheduled runs.
+- DB bounding: induce a slow query (e.g. `SELECT pg_sleep(30)`) and confirm it is cancelled at ~8s
+  with a "canceling statement due to statement timeout" error that is logged + retried/degraded, and
+  that the pooled connection is freed (no `pool_timeout` cascade).
+- Embedding hardening: with the embedding provider forced slow/erroring, confirm the breaker opens,
+  the request degrades (not 500s), the fallback/circuit metric increments, and chat still streams.
+- `terraform -chdir=deployment fmt -check` + `validate`; `plan` (no apply) renders the new
+  `backend_probe_failures` alert (Phase 1) and, later, the PgBouncer / min_replicas changes.
+- Telemetry: confirm exporter no longer logs export timeouts and the metric alerts evaluate over a
+  continuous series.


### PR DESCRIPTION
## Summary
Fixes the chronic **readiness-probe flapping** behind the failing `ProdMonitor` synthetic-chat check, hardens the upstream-dependency calls so a slow dependency **degrades-but-doesn't-break**, and closes the monitoring blind spot that hid the incident for 2+ weeks. Follow-up work is captured in **BITB-057**.

## Root cause
`/health/ready` ran live DB + OpenRouter + embedding checks on every scrape with a 15s budget, but the Container Apps readiness probe deadline is **5s** (`deployment/main.tf`), so any slow free-tier upstream tripped "context deadline exceeded" → `ReplicaUnhealthy` → pod flap (chronic since **before 6/16**, clustered in peak-traffic hours). The same upstream slowness emptied the chat verse-retrieval path (real user impact), and **nothing alerted** on the `ReplicaUnhealthy` events — only **3 ERROR lines in 2 weeks** because the failures were on silent timeout / fail-open paths.

## What changed
**Root-cause fix + resilience**
- `/health/ready` → **DB-only** with `readiness_check_timeout=3s` (under the 5s platform deadline); the LLM/embedding providers are no longer probed every scrape (still covered by the comprehensive `/health` and the existing fallback metric alerts).
- **Bounded DB queries**: `db_command_timeout=10s` (asyncpg) + server `statement_timeout=8s`, sized ~4× the 2s search-saturation SLO (normal queries run <100ms) so a hang fails fast and **frees its pooled connection** instead of pinning it to the 30s `pool_timeout` and cascading into pool exhaustion.
- **Retry scripture search once** on a transient mid-operation disconnect (`ConnectionDoesNotExistError` — `pool_pre_ping` only validates at checkout); non-transient errors still fail open.

**Make stalls visible**
- DB/LLM/embedding health-check **timeouts now log a warning** (were silent).
- New **`backend_probe_failures` alert** on `ContainerAppSystemLogs_CL` `ReplicaUnhealthy` — the gap that hid the incident (`RestartCount` and the ERROR log-scan never saw these).
- The synthetic-chat probe now sends a **real scripture prompt** instead of `"hi"` so the verse-citation assertion is meaningful (removes nondeterministic false failures).

**Follow-ups** → `docs/BACKLOG_STORIES/BITB-057-upstream-dependency-resilience.md` (embedding circuit-breaker / cache / tighter timeout, Azure PgBouncer, `min_replicas`, telemetry-export reliability, pool-saturation metrics).

## Testing
- `pytest tests/test_routes_main_coverage.py tests/test_chat_coverage.py tests/test_database_church_coverage.py` → **259 passed**. New coverage: readiness is DB-only and uses the short timeout; DB timeout logs a warning; search retries once on a disconnect and not on other errors; the disconnect classifier.
- `prod-monitor.yml` YAML validated. The Terraform alert mirrors the existing `backend_errors` resource exactly (no `terraform` binary available in CI sandbox to run `validate`).

## Risk / rollout
- Readiness now returns 503 only on **DB-down** (was: DB-down OR both-inference-down) — intentional; single-dependency inference degradation should serve degraded responses, not bounce a single-replica pod.
- The new alert is additive; DB timeouts only fire on genuine stalls (~4× past the saturation SLO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeyzcJhttw3MQjNtbaf5gH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeyzcJhttw3MQjNtbaf5gH)_