### PR TITLE
feat(resilience): embedding circuit breaker + fail-closed scripture grounding (BITB-057/058)

### DIFF
--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -1066,3 +1066,54 @@ def get_blocked_response(reason: str, language_code: str = "en") -> str:
         or by_lang.get("en")
         or _BLOCKED_RESPONSE_TEMPLATES["generic"]["en"]
     )
+
+
+# Fail-closed grounding message (BITB-058). When a scripture-seeking request cannot be
+# grounded in any verse, we tell the user instead of answering ungrounded — the whole
+# value of the product is being grounded on the Bible. Localized with an English
+# fallback, mirroring the _BLOCKED_RESPONSE_TEMPLATES shape.
+_SCRIPTURE_UNAVAILABLE_RESPONSES: dict[str, str] = {
+    "en": (
+        "I'm sorry — I can't reach the Scripture library right now, so I can't ground my "
+        "answer in the Bible. Please try again in a moment."
+    ),
+    "it": (
+        "Mi dispiace — al momento non riesco ad accedere alla raccolta delle Scritture, "
+        "quindi non posso fondare la mia risposta sulla Bibbia. Riprova tra poco."
+    ),
+    "de": (
+        "Es tut mir leid — ich kann derzeit nicht auf die Schriftsammlung zugreifen und "
+        "meine Antwort daher nicht in der Bibel verankern. Bitte versuche es gleich noch einmal."
+    ),
+    "es": (
+        "Lo siento — en este momento no puedo acceder a la biblioteca de las Escrituras, "
+        "así que no puedo fundamentar mi respuesta en la Biblia. Inténtalo de nuevo en un momento."
+    ),
+    "fr": (
+        "Je suis désolé — je n'arrive pas à accéder à la bibliothèque des Écritures pour le "
+        "moment, je ne peux donc pas fonder ma réponse sur la Bible. Veuillez réessayer dans un instant."
+    ),
+    "pt": (
+        "Desculpe — não consigo aceder à biblioteca das Escrituras neste momento, por isso "
+        "não posso fundamentar a minha resposta na Bíblia. Por favor, tente novamente daqui a pouco."
+    ),
+    "ar": (
+        "أعتذر، لا يمكنني الوصول إلى مكتبة الكتاب المقدس الآن، لذا لا أستطيع تأسيس إجابتي على "
+        "الكتاب المقدس. من فضلك حاول مرة أخرى بعد قليل."
+    ),
+}
+
+
+def get_scripture_unavailable_response(language_code: str = "en") -> str:
+    """Return the localized fail-closed message used when scripture cannot be retrieved.
+
+    Args:
+        language_code: ISO 639-1 language code (en, it, de, es, fr, pt, ar).
+
+    Returns:
+        Localized message string; falls back to English.
+    """
+    return (
+        _SCRIPTURE_UNAVAILABLE_RESPONSES.get(language_code)
+        or _SCRIPTURE_UNAVAILABLE_RESPONSES["en"]
+    )

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -30,6 +30,7 @@ from utils.language import (
 )
 from utils.logging_config import get_logger
 from utils.metrics import (
+    chat_scripture_unavailable_counter,
     chat_verseless_responses_counter,
     scripture_pipeline_errors_counter,
     verse_grounding_corrections_counter,
@@ -52,6 +53,7 @@ from .prompts import (
     get_blocked_response,
     get_compassionate_addendum,
     get_prayer_lookup_prompt,
+    get_scripture_unavailable_response,
     get_system_prompt,
     get_verse_lookup_prompt,
 )
@@ -64,6 +66,13 @@ logger = get_logger(__name__)
 # resolving cited verses for the client "Cited" panel. Guards against an LLM
 # emitting an absurd range (e.g. "Psalm 119:1-176") triggering a huge fetch.
 MAX_RANGE_SPAN = 50
+
+
+# Intents that indicate the user is actually seeking scripture/biblical guidance, as
+# opposed to greetings or small talk (GENERAL) or off-topic (OFF_TOPIC, handled
+# separately). Used by the fail-closed grounding guard (BITB-058): we only tell the
+# user "scripture unavailable" for requests that genuinely expect verses.
+SCRIPTURE_SEEKING_INTENTS = frozenset({"COMFORT", "GUIDANCE", "CURIOSITY", "VERSE_LOOKUP"})
 
 
 # Re-exported from utils.db_retry for backward compatibility — this used to be
@@ -451,6 +460,7 @@ Keep it under 100 words."""
             )
 
         # Intent detection: classify before scripture search
+        detected_intent = "GENERAL"
         if settings.content_filter_intent_detection:
             detected_intent = await self._detect_intent(request.message, model_override)
             if detected_intent == "OFF_TOPIC":
@@ -486,6 +496,30 @@ Keep it under 100 words."""
             detected_language=effective_language,
             model_override=model_override,
         )
+
+        # Fail-closed grounding guard (BITB-058): a scripture-seeking request that
+        # could not be grounded in any verse gets an honest "try again" message
+        # instead of an ungrounded answer.
+        if self._scripture_grounding_unavailable(
+            request, detected_intent, is_verse_lookup, scripture_context
+        ):
+            chat_scripture_unavailable_counter.add(1, {"language": effective_language})
+            logger.warning(
+                "Scripture unavailable for a grounding-required request; returning a "
+                "fail-closed message instead of an ungrounded answer",
+                extra={"intent": detected_intent, "language": effective_language},
+            )
+            record_stage(timings, "total", (time.time() - total_start) * 1000, stage_attrs)
+            return ChatResponse(
+                message_id=str(uuid.uuid4()),
+                message=get_scripture_unavailable_response(effective_language),
+                scripture_context=None,
+                provider=settings.llm_provider,
+                model=settings.llm_model,
+                detected_translation=translation,
+                translation_info=translation_info,
+                language_suggestion=language_suggestion,
+            )
 
         # Step 2: Build the message list
         prompt_type = self._determine_prompt_type(is_verse_lookup, prayer_ref)
@@ -569,6 +603,33 @@ Keep it under 100 words."""
             detected_translation=translation,
             translation_info=translation_info,
             language_suggestion=language_suggestion,
+        )
+
+    def _scripture_grounding_unavailable(
+        self,
+        request: ChatRequest,
+        detected_intent: str,
+        is_verse_lookup: bool,
+        scripture_context: SearchResults | None,
+    ) -> bool:
+        """True when a scripture-seeking request could not be grounded in any verse.
+
+        Fail-closed guard (BITB-058): for a request that genuinely seeks scripture we
+        would rather tell the user retrieval is unavailable than answer without any
+        verses — the product's value is being grounded on the Bible. Hard failures
+        (``scripture_context is None``) and successful-but-empty retrieval both count
+        as unavailable. Greetings / small talk (GENERAL) and off-topic messages are
+        exempt so we never nag when no citation was expected.
+        """
+        if not settings.require_scripture_grounding:
+            return False
+        if not request.include_search:
+            return False
+        scripture_seeking = is_verse_lookup or detected_intent in SCRIPTURE_SEEKING_INTENTS
+        if not scripture_seeking:
+            return False
+        return scripture_context is None or not (
+            scripture_context.verses or scripture_context.passages
         )
 
     async def _handle_off_topic(
@@ -1085,6 +1146,7 @@ Keep it under 100 words."""
             return
 
         # Intent detection: short-circuit off-topic before scripture search
+        detected_intent = "GENERAL"
         if settings.content_filter_intent_detection:
             detected_intent = await self._detect_intent(request.message, model_override)
             if detected_intent == "OFF_TOPIC":
@@ -1145,6 +1207,30 @@ Keep it under 100 words."""
             "translation_info": translation_info,
             "language_suggestion": language_suggestion,
         }
+
+        # Fail-closed grounding guard (BITB-058): if this scripture-seeking request
+        # could not be grounded in any verse, stream an honest "try again" message
+        # instead of an ungrounded LLM answer. Metadata was already sent above, so the
+        # client renders this like any other assistant message.
+        if self._scripture_grounding_unavailable(
+            request, detected_intent, is_verse_lookup, scripture_context
+        ):
+            chat_scripture_unavailable_counter.add(1, {"language": effective_language})
+            logger.warning(
+                "Scripture unavailable for a grounding-required stream; returning a "
+                "fail-closed message instead of an ungrounded answer",
+                extra={"intent": detected_intent, "language": effective_language},
+            )
+            record_stage(timings, "total", (time.perf_counter() - total_start) * 1000, stage_attrs)
+            unavailable_msg = get_scripture_unavailable_response(effective_language)
+            yield {"type": "content", "content": unavailable_msg}
+            yield {
+                "type": "completion",
+                "verses_cited": [],
+                "resolved_verses": [],
+                "scripture_unavailable": True,
+            }
+            return
 
         # Step 3: Build messages with appropriate prompt type
         prompt_type = self._determine_prompt_type(is_verse_lookup, prayer_ref)

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -17,8 +17,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from providers import ChatMessage, EmbeddingProvider, LLMProvider
+from providers.embedding_resilience import CircuitOpenError as EmbeddingCircuitOpenError
 from scripture import ScriptureSearchService, SearchResults
 from utils.content_safety import get_content_safety_service
+from utils.db_retry import is_disconnection_error, run_with_disconnect_retry
 from utils.language import (
     detect_language,
     detect_language_confident,
@@ -64,30 +66,10 @@ logger = get_logger(__name__)
 MAX_RANGE_SPAN = 50
 
 
-def _is_disconnection_error(exc: Exception) -> bool:
-    """True if ``exc`` indicates a dropped/invalidated Postgres connection.
-
-    ``pool_pre_ping`` validates a connection at checkout, but cannot save one that
-    dies *mid-operation* (e.g. Azure Postgres closing an idle backend, or asyncpg's
-    ``ConnectionDoesNotExistError: connection was closed in the middle of operation``).
-    Those are transient — SQLAlchemy invalidates the connection and the next checkout
-    gets a fresh, pre-pinged one — so the caller can safely retry once.
-    """
-    from sqlalchemy.exc import DBAPIError, DisconnectionError
-
-    transient_names = {
-        "ConnectionDoesNotExistError",
-        "ConnectionResetError",
-        "InterfaceError",
-    }
-    if isinstance(exc, DisconnectionError):
-        return True
-    if isinstance(exc, DBAPIError) and getattr(exc, "connection_invalidated", False):
-        return True
-    if type(exc).__name__ in transient_names:
-        return True
-    cause = getattr(exc, "orig", None) or getattr(exc, "__cause__", None)
-    return cause is not None and type(cause).__name__ in transient_names
+# Re-exported from utils.db_retry for backward compatibility — this used to be
+# defined locally; callers/tests importing `chat.service._is_disconnection_error`
+# keep working unchanged. New call sites should import from utils.db_retry directly.
+_is_disconnection_error = is_disconnection_error
 
 
 class ConversationMessage(BaseModel):
@@ -342,11 +324,22 @@ Keep it under 100 words."""
 
         Returns the extra embeddings to feed into semantic search, or ``None`` when
         expansion produced nothing new. Timed as the ``query_expansion`` stage.
+
+        Fails open to ``None`` (search proceeds on the original-query embedding
+        alone) when the embedding provider's circuit breaker is open — same
+        degrade shape as any other transient failure here, just with a clearer
+        log line so an open breaker isn't confused with a generic embed error.
         """
         expanded_query = await self._expand_query(message, detected_language, model_override)
         if expanded_query == message:
             return None
-        expansion_embed_response = await self.embedding.embed(expanded_query)
+        try:
+            expansion_embed_response = await self.embedding.embed(expanded_query)
+        except EmbeddingCircuitOpenError as e:
+            logger.warning(
+                "Embedding circuit breaker open, skipping query expansion embedding: %s", e
+            )
+            return None
         extra_embeddings = [expansion_embed_response.embedding]
         logger.info(
             "Query expansion embeddings generated",
@@ -364,6 +357,11 @@ Keep it under 100 words."""
         stage makes the embed cost observable and lets us confirm the overlap:
         ``retrieval`` should reflect ``max(embedding, query_expansion)`` rather than
         their sum.
+
+        Raises ``CircuitOpenError`` (providers/embedding_resilience.py) when the
+        embedding provider's breaker is open; the caller (``_search_scripture``)
+        catches this like any other search failure and degrades to a verse-less
+        response.
         """
         response = await self.embedding.embed(text)
         return response.embedding
@@ -681,10 +679,12 @@ Keep it under 100 words."""
         is_verse_lookup: bool,
         detected_language: str = "en",  # NEW
         model_override: str | None = None,  # NEW
-        _allow_retry: bool = True,  # retry once on a transient DB disconnect
     ) -> tuple[SearchResults | None, str]:
         """
         Search for relevant scripture, including direct lookups for specific verse references.
+
+        Retries once on a transient DB disconnect via run_with_disconnect_retry
+        (utils/db_retry.py) before degrading to a verse-less reply.
 
         Returns:
             Tuple of (scripture_context, search_context_prompt)
@@ -693,90 +693,14 @@ Keep it under 100 words."""
             return None, ""
 
         search_start = time.time()
-        scripture_context = None
-        search_context_prompt = ""
 
         try:
-            # Direct verse lookups for specific references
-            direct_verses = await self._lookup_direct_verses(verse_refs, translation)
-
-            # Embed the original query *concurrently* with query expansion (the two are
-            # independent), so the original-query embedding is off the serial critical
-            # path. The precomputed embedding is passed into the search call below so the
-            # search service does not embed the same query a second time.
-            extra_embeddings: list[list[float]] | None = None
-            if settings.query_expansion_enabled:
-                query_embedding, extra_embeddings = await asyncio.gather(
-                    self._embed_query(request.message),
-                    self._build_expansion_embeddings(
-                        request.message, detected_language, model_override
-                    ),
-                )
-            else:
-                query_embedding = await self._embed_query(request.message)
-
-            # Topic detection for boosting (keyword-based, <10ms)
-            boost_topics: list[str] = []
-            if settings.topic_boosting_enabled:
-                boost_topics = self._detect_topics(request.message)
-
-            # Semantic or hybrid search (optionally with topic boosting).
-            # Query-expansion embeddings (when present) feed straight into the hybrid
-            # search so expansion actually widens recall on the result we use — and the
-            # HNSW candidate pool keeps it index-backed (no full-table scan).
-            if settings.hybrid_search_enabled:
-                if settings.topic_boosting_enabled and boost_topics:
-                    scripture_context = await self.search_service.search_hybrid_boosted(
-                        query=request.message,
-                        boost_topics=boost_topics,
-                        max_verses=settings.max_context_verses,
-                        max_passages=2,
-                        similarity_threshold=0.35,
-                        translation=translation,
-                        semantic_weight=settings.hybrid_search_semantic_weight,
-                        keyword_weight=settings.hybrid_search_keyword_weight,
-                        topic_boost_factor=settings.topic_boost_factor,
-                        extra_embeddings=extra_embeddings,
-                        query_embedding=query_embedding,
-                    )
-                else:
-                    scripture_context = await self.search_service.search_hybrid(
-                        query=request.message,
-                        max_verses=settings.max_context_verses,
-                        max_passages=2,
-                        similarity_threshold=0.35,
-                        translation=translation,
-                        semantic_weight=settings.hybrid_search_semantic_weight,
-                        keyword_weight=settings.hybrid_search_keyword_weight,
-                        extra_embeddings=extra_embeddings,
-                        query_embedding=query_embedding,
-                    )
-            else:
-                if settings.topic_boosting_enabled and boost_topics:
-                    scripture_context = await self.search_service.search_boosted(
-                        query=request.message,
-                        boost_topics=boost_topics,
-                        max_verses=settings.max_context_verses,
-                        max_passages=2,
-                        similarity_threshold=0.35,
-                        translation=translation,
-                        topic_boost_factor=settings.topic_boost_factor,
-                        extra_embeddings=extra_embeddings,
-                        query_embedding=query_embedding,
-                    )
-                else:
-                    scripture_context = await self.search_service.search(
-                        query=request.message,
-                        max_verses=settings.max_context_verses,
-                        max_passages=2,
-                        similarity_threshold=0.35,
-                        translation=translation,
-                        extra_embeddings=extra_embeddings,
-                        query_embedding=query_embedding,
-                    )
-
-            # Merge direct lookup results with semantic search
-            self._merge_direct_verses(scripture_context, direct_verses)
+            scripture_context, extra_embeddings, boost_topics = await run_with_disconnect_retry(
+                lambda: self._do_search_scripture(
+                    request, translation, verse_refs, detected_language, model_override
+                ),
+                op_name="Scripture search",
+            )
 
             search_duration = time.time() - search_start
             logger.info(
@@ -792,24 +716,16 @@ Keep it under 100 words."""
                     "boost_topics": boost_topics if boost_topics else [],
                 },
             )
+        except EmbeddingCircuitOpenError as e:
+            # Embedding provider is known-down (breaker open) — degrade the same
+            # way as any other search failure, but without the noisy stack trace
+            # since this is an expected, already-logged condition.
+            scripture_pipeline_errors_counter.add(
+                1, {"stage": "search", "error_type": "EmbeddingCircuitOpenError"}
+            )
+            logger.warning(f"Scripture search skipped: embedding circuit breaker open: {e}")
+            return None, ""
         except Exception as e:
-            # A pooled connection dropped mid-operation is transient (pool_pre_ping
-            # only validates at checkout, not mid-query): retry the whole search once
-            # on a fresh, pre-pinged connection before degrading to a verse-less reply.
-            if _allow_retry and _is_disconnection_error(e):
-                logger.warning(
-                    f"Scripture search hit a transient DB disconnect "
-                    f"({type(e).__name__}); retrying once"
-                )
-                return await self._search_scripture(
-                    request,
-                    translation,
-                    verse_refs,
-                    is_verse_lookup,
-                    detected_language=detected_language,
-                    model_override=model_override,
-                    _allow_retry=False,
-                )
             scripture_pipeline_errors_counter.add(
                 1, {"stage": "search", "error_type": type(e).__name__}
             )
@@ -824,8 +740,106 @@ Keep it under 100 words."""
                     "passages": [p.model_dump() for p in scripture_context.passages],
                 }
             )
+        else:
+            search_context_prompt = ""
 
         return scripture_context, search_context_prompt
+
+    async def _do_search_scripture(
+        self,
+        request: ChatRequest,
+        translation: str,
+        verse_refs: list,
+        detected_language: str,
+        model_override: str | None,
+    ) -> tuple[SearchResults | None, list[list[float]] | None, list[str]]:
+        """One attempt of the scripture search body, run under run_with_disconnect_retry.
+
+        Returns (scripture_context, extra_embeddings, boost_topics) so the caller can
+        log the same fields it always has without re-deriving them.
+        """
+        # Direct verse lookups for specific references
+        direct_verses = await self._lookup_direct_verses(verse_refs, translation)
+
+        # Embed the original query *concurrently* with query expansion (the two are
+        # independent), so the original-query embedding is off the serial critical
+        # path. The precomputed embedding is passed into the search call below so the
+        # search service does not embed the same query a second time.
+        extra_embeddings: list[list[float]] | None = None
+        if settings.query_expansion_enabled:
+            query_embedding, extra_embeddings = await asyncio.gather(
+                self._embed_query(request.message),
+                self._build_expansion_embeddings(
+                    request.message, detected_language, model_override
+                ),
+            )
+        else:
+            query_embedding = await self._embed_query(request.message)
+
+        # Topic detection for boosting (keyword-based, <10ms)
+        boost_topics: list[str] = []
+        if settings.topic_boosting_enabled:
+            boost_topics = self._detect_topics(request.message)
+
+        # Semantic or hybrid search (optionally with topic boosting).
+        # Query-expansion embeddings (when present) feed straight into the hybrid
+        # search so expansion actually widens recall on the result we use — and the
+        # HNSW candidate pool keeps it index-backed (no full-table scan).
+        if settings.hybrid_search_enabled:
+            if settings.topic_boosting_enabled and boost_topics:
+                scripture_context = await self.search_service.search_hybrid_boosted(
+                    query=request.message,
+                    boost_topics=boost_topics,
+                    max_verses=settings.max_context_verses,
+                    max_passages=2,
+                    similarity_threshold=0.35,
+                    translation=translation,
+                    semantic_weight=settings.hybrid_search_semantic_weight,
+                    keyword_weight=settings.hybrid_search_keyword_weight,
+                    topic_boost_factor=settings.topic_boost_factor,
+                    extra_embeddings=extra_embeddings,
+                    query_embedding=query_embedding,
+                )
+            else:
+                scripture_context = await self.search_service.search_hybrid(
+                    query=request.message,
+                    max_verses=settings.max_context_verses,
+                    max_passages=2,
+                    similarity_threshold=0.35,
+                    translation=translation,
+                    semantic_weight=settings.hybrid_search_semantic_weight,
+                    keyword_weight=settings.hybrid_search_keyword_weight,
+                    extra_embeddings=extra_embeddings,
+                    query_embedding=query_embedding,
+                )
+        else:
+            if settings.topic_boosting_enabled and boost_topics:
+                scripture_context = await self.search_service.search_boosted(
+                    query=request.message,
+                    boost_topics=boost_topics,
+                    max_verses=settings.max_context_verses,
+                    max_passages=2,
+                    similarity_threshold=0.35,
+                    translation=translation,
+                    topic_boost_factor=settings.topic_boost_factor,
+                    extra_embeddings=extra_embeddings,
+                    query_embedding=query_embedding,
+                )
+            else:
+                scripture_context = await self.search_service.search(
+                    query=request.message,
+                    max_verses=settings.max_context_verses,
+                    max_passages=2,
+                    similarity_threshold=0.35,
+                    translation=translation,
+                    extra_embeddings=extra_embeddings,
+                    query_embedding=query_embedding,
+                )
+
+        # Merge direct lookup results with semantic search
+        self._merge_direct_verses(scripture_context, direct_verses)
+
+        return scripture_context, extra_embeddings, boost_topics
 
     async def _lookup_direct_verses(self, verse_refs: list, translation: str | None = None) -> list:
         """Look up specific verses from references, filtered by translation."""
@@ -862,7 +876,9 @@ Keep it under 100 words."""
         verses — so clients can merge them into their verse panel and the "Cited"
         tab is populated even for verses outside the pool. Dedupes by canonical
         reference and never raises: a DB miss or lookup error is skipped so the
-        stream is never broken.
+        stream is never broken. Each per-reference lookup retries once on a
+        transient DB disconnect via run_with_disconnect_retry (utils/db_retry.py)
+        before being skipped.
         """
         resolved: dict[str, object] = {}
         for ref in verse_refs:
@@ -871,16 +887,27 @@ Keep it under 100 words."""
                     # Cap pathological ranges (e.g. an LLM emitting "Psalm
                     # 119:1-176") so we never issue a huge fetch.
                     end = min(ref.verse_end, ref.verse_start + MAX_RANGE_SPAN - 1)
-                    range_verses = await self.search_service.get_verse_range(
-                        ref.book, ref.chapter, ref.verse_start, end, translation
+
+                    async def _fetch_range() -> list:
+                        return await self.search_service.get_verse_range(
+                            ref.book, ref.chapter, ref.verse_start, end, translation
+                        )
+
+                    range_verses = await run_with_disconnect_retry(
+                        _fetch_range, op_name="Cited verse range resolution"
                     )
                     for verse in range_verses:
                         resolved.setdefault(verse.reference.lower(), verse)
                 else:
                     # Single verse — also covers chapter-spanning ranges where the
                     # parser leaves verse_end < verse_start.
-                    verse = await self.search_service.get_verse(
-                        ref.book, ref.chapter, ref.verse_start, translation
+                    async def _fetch_single():
+                        return await self.search_service.get_verse(
+                            ref.book, ref.chapter, ref.verse_start, translation
+                        )
+
+                    verse = await run_with_disconnect_retry(
+                        _fetch_single, op_name="Cited verse resolution"
                     )
                     if verse:
                         resolved.setdefault(verse.reference.lower(), verse)

--- a/api/config.py
+++ b/api/config.py
@@ -57,6 +57,16 @@ class Settings(BaseSettings):
     embedding_model: str = "mxbai-embed-large"  # Multilingual model (100+ languages)
     embedding_dimensions: int = 1024  # mxbai-embed-large dimension (was 768 for nomic)
 
+    # Embedding resilience (BITB-057 Phase 2). Mirrors the circuit-breaker/timeout
+    # pattern already used for OpenRouter (providers/openrouter.py) and Llama Guard
+    # (providers/llama_guard.py), applied to the embedding call path via
+    # providers/embedding_resilience.py::ResilientEmbeddingProvider.
+    embedding_request_timeout: float = 15.0  # Seconds before an embed() call is abandoned
+    embedding_breaker_failure_threshold: int = 5  # Consecutive failures before the breaker opens
+    embedding_breaker_cooldown_seconds: float = 30.0  # Time before a half-open probe is allowed
+    embedding_retry_max_attempts: int = 2  # Total attempts (including the first) per embed call
+    embedding_retry_base_delay_seconds: float = 0.5  # Base for jittered exponential backoff
+
     # Azure OpenAI Settings (optional - for Azure deployment)
     azure_openai_endpoint: str | None = None
     azure_openai_api_key: str | None = None

--- a/api/config.py
+++ b/api/config.py
@@ -103,6 +103,12 @@ class Settings(BaseSettings):
     # Chat Settings
     max_context_verses: int = 10  # Max verses to include in context
     max_conversation_history: int = 10  # Max messages to keep in context
+    # BITB-058: fail closed when a scripture-seeking request cannot be grounded in any
+    # verse (hard retrieval failure OR zero results). Rather than answer without
+    # scripture — which undercuts a Bible-grounded product — return a localized
+    # "try again" message. Greetings / off-topic / GENERAL chit-chat are exempt so we
+    # never nag when no citation was expected.
+    require_scripture_grounding: bool = True
 
     # Query Expansion Settings
     query_expansion_enabled: bool = (

--- a/api/feedback/blocked_samples.py
+++ b/api/feedback/blocked_samples.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import delete, select, update
 
 from config import settings
+from utils.db_retry import run_with_disconnect_retry
 
 from .models import BlockedMessageSample
 
@@ -71,41 +72,50 @@ async def record_blocked_sample(
         now = datetime.now(UTC)
         expires = now + timedelta(days=settings.blocked_sample_retention_days)
 
-        async with async_session_factory() as db:
-            try:
-                existing = await db.execute(
-                    select(BlockedMessageSample).where(
-                        BlockedMessageSample.message_sha256 == text_hash
-                    )
-                )
-                row = existing.scalar_one_or_none()
-                if row is not None:
-                    # Dedup: bump counter, refresh TTL, do not store text again.
-                    await db.execute(
-                        update(BlockedMessageSample)
-                        .where(BlockedMessageSample.id == row.id)
-                        .values(hit_count=row.hit_count + 1, expires_at=expires)
-                    )
-                else:
-                    db.add(
-                        BlockedMessageSample(
-                            created_at=now,
-                            expires_at=expires,
-                            stage=stage,
-                            categories=categories,
-                            severity=severity,
-                            language=language,
-                            message_text=capped,
-                            message_sha256=text_hash,
-                            session_id_hash=session_hash,
-                            hit_count=1,
-                            reviewed=False,
+        async def _do_record() -> None:
+            # Opens a fresh session per attempt (required by
+            # run_with_disconnect_retry: a connection that died mid-operation
+            # cannot be reused, so each retry needs its own session).
+            async with async_session_factory() as db:
+                try:
+                    existing = await db.execute(
+                        select(BlockedMessageSample).where(
+                            BlockedMessageSample.message_sha256 == text_hash
                         )
                     )
-                await db.commit()
-            except Exception:
-                await db.rollback()
-                raise
+                    row = existing.scalar_one_or_none()
+                    if row is not None:
+                        # Dedup: bump counter, refresh TTL, do not store text again.
+                        await db.execute(
+                            update(BlockedMessageSample)
+                            .where(BlockedMessageSample.id == row.id)
+                            .values(hit_count=row.hit_count + 1, expires_at=expires)
+                        )
+                    else:
+                        db.add(
+                            BlockedMessageSample(
+                                created_at=now,
+                                expires_at=expires,
+                                stage=stage,
+                                categories=categories,
+                                severity=severity,
+                                language=language,
+                                message_text=capped,
+                                message_sha256=text_hash,
+                                session_id_hash=session_hash,
+                                hit_count=1,
+                                reviewed=False,
+                            )
+                        )
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    raise
+
+        # The helper's own final failure (after exhausting retries) is still
+        # caught by the outer except below — record_blocked_sample's contract
+        # is to never raise back to the caller.
+        await run_with_disconnect_retry(_do_record, op_name="record_blocked_sample")
     except Exception:
         # Capture must never break the user response. Swallow silently;
         # the caller already logged the violation through normal channels.

--- a/api/feedback/repository.py
+++ b/api/feedback/repository.py
@@ -9,6 +9,8 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from utils.db_retry import run_with_disconnect_retry
+
 from .models import ContactRequest, ContactSubmission, Feedback, FeedbackRequest
 
 
@@ -22,35 +24,52 @@ class FeedbackRepository:
         """
         Save message feedback to the database.
 
+        The commit/refresh is retried once on a transient DB disconnect via
+        run_with_disconnect_retry (utils/db_retry.py). Note: this repository is
+        constructed with a single request-scoped session (self.db), so a retry
+        re-runs add/commit/refresh against the same session object rather than a
+        fresh one — SQLAlchemy's pool_pre_ping + connection invalidation means the
+        session transparently gets a new underlying connection on the next
+        operation, which is sufficient here since nothing was flushed before the
+        failure.
+
         Args:
             request: FeedbackRequest with rating and message details
 
         Returns:
             Created Feedback record
         """
-        feedback = Feedback(
-            message_id=UUID(request.message_id),
-            session_id=request.session_id,
-            rating=request.rating,
-            comment=request.comment,
-            user_message=request.user_message,
-            assistant_response=request.assistant_response,
-            verses_cited=request.verses_cited,
-            model_used=request.model_used,
-            response_time_ms=request.response_time_ms,
-            reason=request.reason,
-            created_at=datetime.now(UTC),
-        )
 
-        self.db.add(feedback)
-        await self.db.commit()
-        await self.db.refresh(feedback)
+        async def _do_save() -> Feedback:
+            feedback = Feedback(
+                message_id=UUID(request.message_id),
+                session_id=request.session_id,
+                rating=request.rating,
+                comment=request.comment,
+                user_message=request.user_message,
+                assistant_response=request.assistant_response,
+                verses_cited=request.verses_cited,
+                model_used=request.model_used,
+                response_time_ms=request.response_time_ms,
+                reason=request.reason,
+                created_at=datetime.now(UTC),
+            )
 
-        return feedback
+            self.db.add(feedback)
+            await self.db.commit()
+            await self.db.refresh(feedback)
+
+            return feedback
+
+        return await run_with_disconnect_retry(_do_save, op_name="save_feedback")
 
     async def save_contact(self, request: ContactRequest) -> ContactSubmission:
         """
         Save contact form submission to the database.
+
+        The commit/refresh is retried once on a transient DB disconnect via
+        run_with_disconnect_retry (utils/db_retry.py); see save_feedback's
+        docstring for the same-session retry note.
 
         Args:
             request: ContactRequest with message details
@@ -58,21 +77,25 @@ class FeedbackRepository:
         Returns:
             Created ContactSubmission record
         """
-        contact = ContactSubmission(
-            email=request.email,
-            subject=request.subject,
-            message=request.message,
-            session_id=request.session_id,
-            user_agent=request.user_agent,
-            status="new",
-            created_at=datetime.now(UTC),
-        )
 
-        self.db.add(contact)
-        await self.db.commit()
-        await self.db.refresh(contact)
+        async def _do_save() -> ContactSubmission:
+            contact = ContactSubmission(
+                email=request.email,
+                subject=request.subject,
+                message=request.message,
+                session_id=request.session_id,
+                user_agent=request.user_agent,
+                status="new",
+                created_at=datetime.now(UTC),
+            )
 
-        return contact
+            self.db.add(contact)
+            await self.db.commit()
+            await self.db.refresh(contact)
+
+            return contact
+
+        return await run_with_disconnect_retry(_do_save, op_name="save_contact")
 
     async def get_feedback_by_message_id(self, message_id: str) -> Feedback | None:
         """

--- a/api/providers/embedding_resilience.py
+++ b/api/providers/embedding_resilience.py
@@ -1,0 +1,165 @@
+"""
+Resilience wrapper for embedding providers (BITB-057 Phase 2).
+
+Gives the embedding call path the same circuit-breaker/timeout/retry treatment
+already applied to OpenRouter (providers/openrouter.py) and Llama Guard
+(providers/llama_guard.py) via utils/circuit_breaker.py. Wraps any concrete
+EmbeddingProvider instance so callers (chat/service.py, scripture/search.py)
+keep using the same EmbeddingProvider interface unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+
+import httpx
+
+from config import Settings
+from utils.circuit_breaker import CircuitBreaker, CircuitOpenError
+from utils.logging_config import get_logger
+from utils.metrics import embedding_fallback_counter
+
+from .base import EmbeddingProvider, EmbeddingResponse
+
+logger = get_logger(__name__)
+
+# Re-exported so callers can `except CircuitOpenError` without importing
+# utils.circuit_breaker directly (matches llama_guard.py's usage pattern).
+__all__ = ["ResilientEmbeddingProvider", "CircuitOpenError"]
+
+
+def _is_transient(exc: Exception) -> bool:
+    """Categorize a failure as transient (worth retrying) or not.
+
+    Mirrors the classification openrouter.py uses for its own retry/fallback
+    decisions: timeouts, connection failures, and HTTP 429/5xx are treated as
+    transient; everything else (4xx client errors, programming errors) is not.
+    """
+    if isinstance(exc, asyncio.TimeoutError | httpx.TimeoutException | httpx.ConnectError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status == 429 or status >= 500
+    # openai SDK errors (used by AzureOpenAIEmbeddingProvider) carry a
+    # status_code attribute without necessarily being httpx exceptions.
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code == 429 or status_code >= 500
+    return False
+
+
+class ResilientEmbeddingProvider(EmbeddingProvider):
+    """
+    Wraps a concrete EmbeddingProvider with a circuit breaker, per-call timeout,
+    and jittered-exponential-backoff retry.
+
+    - If the breaker is open, `embed()`/`embed_batch()` raise CircuitOpenError
+      immediately so callers can degrade without paying the request timeout.
+    - Each call is bounded by `settings.embedding_request_timeout`.
+    - On timeout or a transient error (`_is_transient`), retries with jittered
+      exponential backoff up to `settings.embedding_retry_max_attempts` total
+      attempts. Non-transient errors are raised immediately, no retry.
+    - `embed_batch()` wraps the whole batch call as a single unit (no
+      per-item retry within a batch) when the underlying provider exposes a
+      native batch method.
+    """
+
+    def __init__(self, wrapped: EmbeddingProvider, settings: Settings):
+        self._wrapped = wrapped
+        self._settings = settings
+        # Trip after `embedding_breaker_failure_threshold` consecutive failures;
+        # cooldown `embedding_breaker_cooldown_seconds`. When open, embed()/
+        # embed_batch() raise CircuitOpenError immediately so callers (chat/
+        # service.py) can degrade to a verse-less response without paying the
+        # per-call timeout during a sustained outage.
+        self._breaker = CircuitBreaker(
+            name="embedding",
+            failure_threshold=settings.embedding_breaker_failure_threshold,
+            cooldown_seconds=settings.embedding_breaker_cooldown_seconds,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return self._wrapped.provider_name
+
+    @property
+    def dimensions(self) -> int:
+        return self._wrapped.dimensions
+
+    async def _call_with_resilience(self, coro_factory, *, op: str):
+        """Run `coro_factory()` under the breaker/timeout/retry policy.
+
+        `coro_factory` is a zero-arg callable returning a fresh coroutine per
+        attempt (a coroutine object can only be awaited once).
+        """
+        if self._breaker.is_open():
+            embedding_fallback_counter.add(1, {"reason": "breaker_open", "op": op})
+            raise CircuitOpenError("embedding circuit breaker open")
+
+        max_attempts = self._settings.embedding_retry_max_attempts
+        base_delay = self._settings.embedding_retry_base_delay_seconds
+        last_error: Exception | None = None
+
+        for attempt in range(max_attempts):
+            try:
+                result = await asyncio.wait_for(
+                    coro_factory(), timeout=self._settings.embedding_request_timeout
+                )
+                self._breaker.record_success()
+                return result
+            except TimeoutError as e:
+                last_error = e
+                self._breaker.record_failure()
+                embedding_fallback_counter.add(1, {"reason": "timeout", "op": op})
+                logger.warning(
+                    "Embedding call timed out (attempt %d/%d, op=%s)",
+                    attempt + 1,
+                    max_attempts,
+                    op,
+                )
+            except Exception as e:
+                if not _is_transient(e):
+                    self._breaker.record_failure()
+                    embedding_fallback_counter.add(1, {"reason": "non_transient", "op": op})
+                    raise
+                last_error = e
+                self._breaker.record_failure()
+                embedding_fallback_counter.add(1, {"reason": type(e).__name__, "op": op})
+                logger.warning(
+                    "Embedding call failed transiently (attempt %d/%d, op=%s): %s",
+                    attempt + 1,
+                    max_attempts,
+                    op,
+                    e,
+                )
+
+            if attempt < max_attempts - 1:
+                delay = base_delay * (2**attempt) + random.uniform(0, base_delay)
+                await asyncio.sleep(delay)
+
+        logger.error("Embedding call exhausted retries (op=%s, attempts=%d)", op, max_attempts)
+        assert last_error is not None
+        raise last_error
+
+    async def embed(self, text: str) -> EmbeddingResponse:
+        """Generate embedding for a single text, with breaker/timeout/retry."""
+        return await self._call_with_resilience(lambda: self._wrapped.embed(text), op="embed")
+
+    async def embed_batch(self, texts: list[str]) -> list[EmbeddingResponse]:
+        """Generate embeddings for multiple texts, with breaker/timeout/retry.
+
+        Wraps the whole batch call as one unit — a batch is retried in full on
+        a transient failure rather than retrying individual items.
+        """
+        return await self._call_with_resilience(
+            lambda: self._wrapped.embed_batch(texts), op="embed_batch"
+        )
+
+    async def health_check(self) -> bool:
+        """Delegate health checks to the wrapped provider (not breaker-gated)."""
+        return await self._wrapped.health_check()
+
+    async def close(self) -> None:
+        """Close the wrapped provider's resources."""
+        await self._wrapped.close()

--- a/api/providers/factory.py
+++ b/api/providers/factory.py
@@ -14,6 +14,7 @@ from config import Settings, settings
 from .azure_openai import AzureOpenAIEmbeddingProvider
 from .base import EmbeddingProvider, LLMProvider
 from .claude import ClaudeProvider
+from .embedding_resilience import ResilientEmbeddingProvider
 from .ollama import OllamaEmbeddingProvider, OllamaProvider
 from .openrouter import OpenRouterProvider
 
@@ -75,6 +76,23 @@ def create_llm_provider(config: Settings) -> LLMProvider:
 def create_embedding_provider(config: Settings) -> EmbeddingProvider:
     """
     Create an embedding provider based on configuration.
+
+    Wraps the raw provider in ResilientEmbeddingProvider (BITB-057 Phase 2) so
+    every embedding call path gets the same circuit-breaker/timeout/retry
+    treatment already applied to OpenRouter and Llama Guard.
+
+    Args:
+        config: Application settings
+
+    Returns:
+        Configured embedding provider instance, wrapped for resilience
+    """
+    return ResilientEmbeddingProvider(_build_raw_embedding_provider(config), config)
+
+
+def _build_raw_embedding_provider(config: Settings) -> EmbeddingProvider:
+    """
+    Create the underlying (non-resilient) embedding provider based on configuration.
 
     Args:
         config: Application settings

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -1461,6 +1461,34 @@ class TestChatServiceResolveCitedVerses:
         assert end - start + 1 <= 50
         assert end < 176
 
+    @pytest.mark.asyncio
+    async def test_retries_once_on_db_disconnect_then_succeeds(self):
+        """BITB-057 Phase 2: per-reference lookups now go through
+        run_with_disconnect_retry (utils/db_retry.py), so a transient disconnect
+        on the single-verse lookup is retried once instead of being skipped."""
+        service, _, _ = _make_chat_service()
+        service.search_service = AsyncMock()
+
+        class ConnectionDoesNotExistError(Exception):
+            pass
+
+        verse = VerseResult(
+            reference="John 3:16",
+            text="For God so loved the world...",
+            book="John",
+            chapter=3,
+            verse=16,
+        )
+        service.search_service.get_verse = AsyncMock(
+            side_effect=[ConnectionDoesNotExistError("closed mid-operation"), verse]
+        )
+
+        result = await service._resolve_cited_verses([_make_ref("John", 3, 16)], "kjv")
+
+        assert len(result) == 1
+        assert result[0].reference == "John 3:16"
+        assert service.search_service.get_verse.await_count == 2
+
 
 class TestChatServiceGetVerseContext:
     """Tests for ChatService.get_verse_context()."""

--- a/api/tests/test_chat_coverage.py
+++ b/api/tests/test_chat_coverage.py
@@ -1342,6 +1342,172 @@ class TestChatServiceChatStream:
         assert "corrections" not in completion
 
 
+class TestScriptureGroundingGuardHelper:
+    """Unit tests for ChatService._scripture_grounding_unavailable() (BITB-058)."""
+
+    def _svc(self):
+        service, _, _ = _make_chat_service()
+        return service
+
+    def _ctx(self, verses=(), passages=()):
+        return SearchResults(query="q", verses=list(verses), passages=list(passages))
+
+    def test_flag_off_never_fires(self):
+        service = self._svc()
+        with patch("chat.service.settings") as s:
+            s.require_scripture_grounding = False
+            result = service._scripture_grounding_unavailable(
+                ChatRequest(message="x", include_search=True), "VERSE_LOOKUP", True, None
+            )
+        assert result is False
+
+    def test_include_search_false_never_fires(self):
+        service = self._svc()
+        result = service._scripture_grounding_unavailable(
+            ChatRequest(message="x", include_search=False), "VERSE_LOOKUP", True, None
+        )
+        assert result is False
+
+    def test_scripture_seeking_hard_failure_fires(self):
+        service = self._svc()
+        result = service._scripture_grounding_unavailable(
+            ChatRequest(message="x"), "COMFORT", False, None
+        )
+        assert result is True
+
+    def test_scripture_seeking_empty_results_fires(self):
+        service = self._svc()
+        result = service._scripture_grounding_unavailable(
+            ChatRequest(message="x"), "GUIDANCE", False, self._ctx()
+        )
+        assert result is True
+
+    def test_scripture_seeking_with_verses_does_not_fire(self):
+        service = self._svc()
+        ctx = self._ctx(
+            verses=[VerseResult(reference="John 3:16", text="t", book="John", chapter=3, verse=16)]
+        )
+        result = service._scripture_grounding_unavailable(
+            ChatRequest(message="x"), "VERSE_LOOKUP", True, ctx
+        )
+        assert result is False
+
+    def test_general_intent_not_fail_closed(self):
+        # A greeting (GENERAL, not a verse lookup) that hard-fails search must NOT nag.
+        service = self._svc()
+        result = service._scripture_grounding_unavailable(
+            ChatRequest(message="x"), "GENERAL", False, None
+        )
+        assert result is False
+
+    def test_verse_lookup_forces_scripture_seeking(self):
+        # Even with GENERAL intent, an explicit verse lookup is scripture-seeking.
+        service = self._svc()
+        result = service._scripture_grounding_unavailable(
+            ChatRequest(message="x"), "GENERAL", True, None
+        )
+        assert result is True
+
+
+class TestScriptureGroundingFailClosed:
+    """BITB-058: scripture-seeking requests that cannot be grounded fail closed —
+    the user is told to retry instead of receiving an ungrounded answer."""
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=True)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_stream_fail_closed_on_hard_failure(self, *_mocks):
+        from chat.prompts import get_scripture_unavailable_response
+
+        service, llm, _ = _make_chat_service()
+        service._detect_intent = AsyncMock(return_value="VERSE_LOOKUP")
+        service._search_scripture = AsyncMock(return_value=(None, ""))
+        llm.chat_stream = MagicMock(
+            side_effect=AssertionError("LLM must not run when scripture is unavailable")
+        )
+
+        req = ChatRequest(message="What does John 3:16 say?")
+        chunks = [c async for c in service.chat_stream(req)]
+
+        content = "".join(c["content"] for c in chunks if c["type"] == "content")
+        assert content == get_scripture_unavailable_response("en")
+        completion = next(c for c in chunks if c["type"] == "completion")
+        assert completion["scripture_unavailable"] is True
+        assert completion["verses_cited"] == []
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_stream_fail_closed_on_zero_verses_scripture_seeking(self, *_mocks):
+        from chat.prompts import get_scripture_unavailable_response
+
+        service, llm, _ = _make_chat_service()
+        service._detect_intent = AsyncMock(return_value="COMFORT")
+        service._search_scripture = AsyncMock(
+            return_value=(SearchResults(query="q", verses=[], passages=[]), "")
+        )
+        llm.chat_stream = MagicMock(
+            side_effect=AssertionError("LLM must not run when scripture is unavailable")
+        )
+
+        req = ChatRequest(message="I feel anxious")
+        chunks = [c async for c in service.chat_stream(req)]
+
+        content = "".join(c["content"] for c in chunks if c["type"] == "content")
+        assert content == get_scripture_unavailable_response("en")
+        completion = next(c for c in chunks if c["type"] == "completion")
+        assert completion["scripture_unavailable"] is True
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=False)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_stream_greeting_not_fail_closed(self, *_mocks):
+        from chat.prompts import get_scripture_unavailable_response
+
+        service, llm, _ = _make_chat_service()
+        service._detect_intent = AsyncMock(return_value="GENERAL")
+        # Even a hard failure must NOT fail-closed for a non-scripture-seeking greeting.
+        service._search_scripture = AsyncMock(return_value=(None, ""))
+        service._ground_streamed_answer = AsyncMock(return_value=([], "Hello there!", []))
+
+        async def mock_stream(*_a, **_k):
+            yield "Hello there!"
+
+        llm.chat_stream = mock_stream
+
+        req = ChatRequest(message="hi")
+        chunks = [c async for c in service.chat_stream(req)]
+
+        content = "".join(c["content"] for c in chunks if c["type"] == "content")
+        assert content == "Hello there!"
+        assert content != get_scripture_unavailable_response("en")
+        completion = next(c for c in chunks if c["type"] == "completion")
+        assert "scripture_unavailable" not in completion
+
+    @pytest.mark.asyncio
+    @patch("chat.service.detect_language", return_value="en")
+    @patch("chat.service.resolve_translation", return_value="kjv")
+    @patch("chat.service.is_verse_lookup_request", return_value=True)
+    @patch("chat.service.extract_references", return_value=([], None))
+    async def test_chat_nonstream_fail_closed_on_hard_failure(self, *_mocks):
+        from chat.prompts import get_scripture_unavailable_response
+
+        service, llm, _ = _make_chat_service()
+        service._detect_intent = AsyncMock(return_value="VERSE_LOOKUP")
+        service._search_scripture = AsyncMock(return_value=(None, ""))
+        llm.chat = AsyncMock(side_effect=AssertionError("LLM must not run (fail-closed)"))
+
+        response = await service.chat(ChatRequest(message="What does John 3:16 say?"))
+        assert response.message == get_scripture_unavailable_response("en")
+        assert response.scripture_context is None
+
+
 def _make_ref(book, chapter, verse_start, verse_end=None):
     """Build a mock VerseReference-like object for resolver tests."""
     ref = MagicMock()

--- a/api/tests/test_db_retry.py
+++ b/api/tests/test_db_retry.py
@@ -1,0 +1,99 @@
+"""
+Tests for utils/db_retry.py (BITB-057 Phase 2).
+
+Generalizes the retry-on-transient-disconnect pattern previously bespoke to
+chat/service.py::_search_scripture. These tests mirror the disconnect-error
+classification tests in test_chat_coverage.py::TestIsDisconnectionError, plus
+new coverage for the run_with_disconnect_retry loop itself.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from utils.db_retry import is_disconnection_error, run_with_disconnect_retry
+
+
+class TestIsDisconnectionError:
+    """Tests for is_disconnection_error() — mirrors chat/service.py's original suite."""
+
+    def test_matches_asyncpg_connection_dropped_by_name(self):
+        class ConnectionDoesNotExistError(Exception):
+            pass
+
+        assert is_disconnection_error(ConnectionDoesNotExistError("closed mid-op")) is True
+
+    def test_matches_wrapped_cause(self):
+        class InterfaceError(Exception):
+            pass
+
+        wrapper = RuntimeError("DBAPIError")
+        wrapper.__cause__ = InterfaceError("connection lost")
+        assert is_disconnection_error(wrapper) is True
+
+    def test_ignores_unrelated_errors(self):
+        assert is_disconnection_error(ValueError("bad query")) is False
+
+
+class TestRunWithDisconnectRetry:
+    """Tests for run_with_disconnect_retry()."""
+
+    @pytest.mark.asyncio
+    async def test_transient_error_retries_once_then_succeeds(self):
+        class ConnectionDoesNotExistError(Exception):
+            pass
+
+        fn = AsyncMock(side_effect=[ConnectionDoesNotExistError("dropped"), "ok"])
+
+        result = await run_with_disconnect_retry(fn, op_name="test_op")
+
+        assert result == "ok"
+        assert fn.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_raises_immediately_without_retry(self):
+        fn = AsyncMock(side_effect=ValueError("bad query"))
+
+        with pytest.raises(ValueError):
+            await run_with_disconnect_retry(fn, op_name="test_op")
+
+        assert fn.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries_raise_the_last_error(self):
+        class FakeTransientError(Exception):
+            pass
+
+        # Name the class ConnectionResetError to match the transient-name set
+        # is_disconnection_error() matches on (utils/db_retry.py).
+        FakeTransientError.__name__ = "ConnectionResetError"
+
+        errors = [FakeTransientError("1"), FakeTransientError("2")]
+        fn = AsyncMock(side_effect=errors)
+
+        with pytest.raises(FakeTransientError) as exc_info:
+            await run_with_disconnect_retry(fn, max_attempts=2, op_name="test_op")
+
+        assert exc_info.value is errors[-1]
+        assert fn.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt_no_retry(self):
+        fn = AsyncMock(return_value="value")
+
+        result = await run_with_disconnect_retry(fn, op_name="test_op")
+
+        assert result == "value"
+        assert fn.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_respects_custom_max_attempts(self):
+        class InterfaceError(Exception):
+            pass
+
+        fn = AsyncMock(side_effect=[InterfaceError("1"), InterfaceError("2"), "ok"])
+
+        result = await run_with_disconnect_retry(fn, max_attempts=3, op_name="test_op")
+
+        assert result == "ok"
+        assert fn.await_count == 3

--- a/api/tests/test_embedding_resilience.py
+++ b/api/tests/test_embedding_resilience.py
@@ -1,0 +1,215 @@
+"""
+Tests for ResilientEmbeddingProvider (BITB-057 Phase 2).
+
+Mirrors the mocking approach used in test_llama_guard.py's timeout/error tests:
+mock the wrapped provider's methods directly (no real network calls) and assert
+on breaker/retry/metric behaviour.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from config import settings
+from providers.base import EmbeddingResponse
+from providers.embedding_resilience import CircuitOpenError, ResilientEmbeddingProvider
+
+
+def _make_settings(**overrides):
+    """Settings with fast retry/timeout knobs so tests don't sleep for real."""
+    defaults = dict(
+        embedding_request_timeout=0.2,
+        embedding_breaker_failure_threshold=2,
+        embedding_breaker_cooldown_seconds=30.0,
+        embedding_retry_max_attempts=2,
+        embedding_retry_base_delay_seconds=0.01,
+    )
+    defaults.update(overrides)
+    return settings.model_copy(update=defaults)
+
+
+class _FakeProvider:
+    """Minimal stand-in for a concrete EmbeddingProvider."""
+
+    def __init__(self):
+        self.provider_name = "fake"
+        self.dimensions = 4
+        self.embed = AsyncMock()
+        self.embed_batch = AsyncMock()
+        self.health_check = AsyncMock(return_value=True)
+        self.close = AsyncMock()
+
+
+def _resp(vec=None):
+    return EmbeddingResponse(embedding=vec or [0.1, 0.2, 0.3, 0.4], model="fake", provider="fake")
+
+
+@pytest.mark.asyncio
+async def test_embed_success_passthrough():
+    wrapped = _FakeProvider()
+    wrapped.embed.return_value = _resp()
+    provider = ResilientEmbeddingProvider(wrapped, _make_settings())
+
+    result = await provider.embed("hello")
+
+    assert result.embedding == [0.1, 0.2, 0.3, 0.4]
+    wrapped.embed.assert_awaited_once_with("hello")
+
+
+@pytest.mark.asyncio
+async def test_circuit_open_short_circuits_immediately():
+    wrapped = _FakeProvider()
+    wrapped.embed.side_effect = httpx.ConnectError("boom")
+    cfg = _make_settings(embedding_breaker_failure_threshold=1, embedding_retry_max_attempts=1)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    # First call trips the breaker (threshold=1, single attempt).
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed("first")
+    assert wrapped.embed.await_count == 1
+
+    # Second call should short-circuit without calling the wrapped provider.
+    with pytest.raises(CircuitOpenError):
+        await provider.embed("second")
+    assert wrapped.embed.await_count == 1  # unchanged — no new call made
+
+
+@pytest.mark.asyncio
+async def test_timeout_then_successful_retry():
+    wrapped = _FakeProvider()
+
+    call_count = 0
+
+    async def slow_then_fast(text):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            await asyncio.sleep(1.0)  # exceeds the 0.2s timeout
+        return _resp()
+
+    wrapped.embed.side_effect = slow_then_fast
+    provider = ResilientEmbeddingProvider(wrapped, _make_settings())
+
+    result = await provider.embed("hello")
+
+    assert result.embedding == [0.1, 0.2, 0.3, 0.4]
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion_raises():
+    wrapped = _FakeProvider()
+    wrapped.embed.side_effect = httpx.ConnectError("still down")
+    cfg = _make_settings(embedding_retry_max_attempts=2, embedding_breaker_failure_threshold=5)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed("hello")
+
+    assert wrapped.embed.await_count == 2  # both attempts used
+
+
+@pytest.mark.asyncio
+async def test_non_transient_error_raises_without_retry():
+    wrapped = _FakeProvider()
+    wrapped.embed.side_effect = ValueError("bad input")
+    cfg = _make_settings(embedding_retry_max_attempts=3, embedding_breaker_failure_threshold=5)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    with pytest.raises(ValueError):
+        await provider.embed("hello")
+
+    assert wrapped.embed.await_count == 1  # no retry for non-transient errors
+
+
+@pytest.mark.asyncio
+async def test_metric_increments_on_timeout(monkeypatch):
+    from providers import embedding_resilience
+
+    calls = []
+    monkeypatch.setattr(
+        embedding_resilience.embedding_fallback_counter,
+        "add",
+        lambda amount, attrs=None: calls.append((amount, attrs)),
+    )
+
+    wrapped = _FakeProvider()
+
+    async def always_slow(text):
+        await asyncio.sleep(1.0)
+
+    wrapped.embed.side_effect = always_slow
+    cfg = _make_settings(embedding_retry_max_attempts=2, embedding_breaker_failure_threshold=5)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await provider.embed("hello")
+
+    reasons = [attrs["reason"] for _, attrs in calls]
+    assert reasons.count("timeout") == 2
+
+
+@pytest.mark.asyncio
+async def test_metric_increments_on_circuit_open(monkeypatch):
+    from providers import embedding_resilience
+
+    calls = []
+    monkeypatch.setattr(
+        embedding_resilience.embedding_fallback_counter,
+        "add",
+        lambda amount, attrs=None: calls.append((amount, attrs)),
+    )
+
+    wrapped = _FakeProvider()
+    wrapped.embed.side_effect = httpx.ConnectError("boom")
+    cfg = _make_settings(embedding_breaker_failure_threshold=1, embedding_retry_max_attempts=1)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed("first")
+    with pytest.raises(CircuitOpenError):
+        await provider.embed("second")
+
+    reasons = [attrs["reason"] for _, attrs in calls]
+    assert "breaker_open" in reasons
+
+
+@pytest.mark.asyncio
+async def test_embed_batch_wraps_whole_call_not_per_item():
+    wrapped = _FakeProvider()
+    wrapped.embed_batch.side_effect = httpx.ConnectError("down")
+    cfg = _make_settings(embedding_retry_max_attempts=2, embedding_breaker_failure_threshold=5)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed_batch(["a", "b", "c"])
+
+    # Retried as a whole batch call, not once per item: 2 attempts total.
+    assert wrapped.embed_batch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_health_check_not_breaker_gated():
+    wrapped = _FakeProvider()
+    wrapped.health_check.return_value = True
+    cfg = _make_settings(embedding_breaker_failure_threshold=1, embedding_retry_max_attempts=1)
+    provider = ResilientEmbeddingProvider(wrapped, cfg)
+
+    # Trip the breaker via a failed embed() call.
+    wrapped.embed.side_effect = httpx.ConnectError("boom")
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed("x")
+
+    # health_check() is not gated by the breaker.
+    assert await provider.health_check() is True
+    wrapped.health_check.assert_awaited_once()
+
+
+def test_provider_name_and_dimensions_delegate():
+    wrapped = _FakeProvider()
+    provider = ResilientEmbeddingProvider(wrapped, _make_settings())
+
+    assert provider.provider_name == "fake"
+    assert provider.dimensions == 4

--- a/api/tests/test_feedback_repository.py
+++ b/api/tests/test_feedback_repository.py
@@ -1,0 +1,92 @@
+"""
+Tests for FeedbackRepository's DB disconnect-retry behavior (BITB-057 Phase 2).
+
+save_feedback/save_contact now route their commit/refresh sequence through
+run_with_disconnect_retry (utils/db_retry.py). These tests mock the DB session
+directly (no real database) and assert one retry then success on a transient
+disconnect, mirroring the pattern in test_chat_coverage.py's
+TestChatServiceSearchScripture disconnect-retry test.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from feedback.models import ContactRequest, FeedbackRequest
+from feedback.repository import FeedbackRepository
+
+
+class ConnectionDoesNotExistError(Exception):
+    """Stand-in for asyncpg's transient mid-operation disconnect error."""
+
+
+def _make_feedback_request() -> FeedbackRequest:
+    return FeedbackRequest(
+        message_id=str(uuid.uuid4()),
+        rating="positive",
+        comment=None,
+        user_message="What does the Bible say about hope?",
+        assistant_response="The Bible speaks extensively about hope...",
+        verses_cited=None,
+        model_used=None,
+        response_time_ms=None,
+        session_id=None,
+        reason=None,
+    )
+
+
+def _make_contact_request() -> ContactRequest:
+    return ContactRequest(
+        email="user@example.com",
+        subject="feedback",
+        message="Great app!",
+        session_id=None,
+        user_agent=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_feedback_retries_once_on_disconnect_then_succeeds():
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock(side_effect=[ConnectionDoesNotExistError("closed mid-operation"), None])
+    db.refresh = AsyncMock()
+
+    repo = FeedbackRepository(db)
+    result = await repo.save_feedback(_make_feedback_request())
+
+    assert result is not None
+    assert db.commit.await_count == 2
+    # add() is called once per attempt (rebuilds the ORM object each time).
+    assert db.add.call_count == 2
+    assert db.refresh.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_save_feedback_non_transient_error_raises_without_retry():
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock(side_effect=ValueError("constraint violation"))
+    db.refresh = AsyncMock()
+
+    repo = FeedbackRepository(db)
+
+    with pytest.raises(ValueError):
+        await repo.save_feedback(_make_feedback_request())
+
+    assert db.commit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_save_contact_retries_once_on_disconnect_then_succeeds():
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock(side_effect=[ConnectionDoesNotExistError("closed mid-operation"), None])
+    db.refresh = AsyncMock()
+
+    repo = FeedbackRepository(db)
+    result = await repo.save_contact(_make_contact_request())
+
+    assert result is not None
+    assert db.commit.await_count == 2

--- a/api/tests/test_intent_detection.py
+++ b/api/tests/test_intent_detection.py
@@ -168,6 +168,12 @@ class TestChatOffTopicFlow:
         mock_settings.max_context_verses = 10
         mock_settings.max_conversation_history = 10
         mock_settings.query_expansion_enabled = False  # NEW: disable query expansion
+        # This test isolates intent routing (on-topic proceeds to generation). The
+        # BITB-058 fail-closed grounding guard — which would intercept a scripture-
+        # seeking request that finds zero verses — is covered separately in
+        # test_chat_coverage; keep it non-blocking here so search returning None
+        # still exercises the normal generation path.
+        mock_settings.require_scripture_grounding = False
 
         # First call: intent detection returns COMFORT
         # Second call: main LLM response

--- a/api/tests/test_providers_coverage.py
+++ b/api/tests/test_providers_coverage.py
@@ -778,8 +778,10 @@ class TestProviderFactory:
             create_llm_provider(config)
 
     def test_create_embedding_ollama(self):
-        """Factory should create Ollama embedding provider."""
+        """Factory should create an Ollama embedding provider, wrapped for
+        resilience (BITB-057 Phase 2: ResilientEmbeddingProvider)."""
         from config import Settings
+        from providers.embedding_resilience import ResilientEmbeddingProvider
         from providers.factory import create_embedding_provider
         from providers.ollama import OllamaEmbeddingProvider
 
@@ -792,7 +794,9 @@ class TestProviderFactory:
             _env_file=None,
         )
         provider = create_embedding_provider(config)
-        assert isinstance(provider, OllamaEmbeddingProvider)
+        assert isinstance(provider, ResilientEmbeddingProvider)
+        assert isinstance(provider._wrapped, OllamaEmbeddingProvider)
+        assert provider.provider_name == "ollama"
 
     def test_create_embedding_azure_openai(self):
         """Factory should create Azure OpenAI embedding provider."""

--- a/api/utils/db_retry.py
+++ b/api/utils/db_retry.py
@@ -1,0 +1,89 @@
+"""
+Generalized DB disconnect-retry helper (BITB-057 Phase 2).
+
+Generalizes the retry-on-transient-disconnect pattern that previously lived
+only in chat/service.py::_search_scripture (as a bespoke recursive
+`_allow_retry` mechanism), so other DB-writing/reading call sites (feedback
+repository, blocked-sample capture, cited-verse resolution) can opt in
+without duplicating the classification logic.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable, TypeVar
+
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def is_disconnection_error(exc: Exception) -> bool:
+    """True if ``exc`` indicates a dropped/invalidated Postgres connection.
+
+    ``pool_pre_ping`` validates a connection at checkout, but cannot save one that
+    dies *mid-operation* (e.g. Azure Postgres closing an idle backend, or asyncpg's
+    ``ConnectionDoesNotExistError: connection was closed in the middle of operation``).
+    Those are transient — SQLAlchemy invalidates the connection and the next checkout
+    gets a fresh, pre-pinged one — so the caller can safely retry once.
+    """
+    from sqlalchemy.exc import DBAPIError, DisconnectionError
+
+    transient_names = {
+        "ConnectionDoesNotExistError",
+        "ConnectionResetError",
+        "InterfaceError",
+    }
+    if isinstance(exc, DisconnectionError):
+        return True
+    if isinstance(exc, DBAPIError) and getattr(exc, "connection_invalidated", False):
+        return True
+    if type(exc).__name__ in transient_names:
+        return True
+    cause = getattr(exc, "orig", None) or getattr(exc, "__cause__", None)
+    return cause is not None and type(cause).__name__ in transient_names
+
+
+async def run_with_disconnect_retry(
+    fn: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int = 2,
+    op_name: str = "db_operation",
+) -> T:
+    """Run ``fn()`` and retry once (by default) on a transient DB disconnect.
+
+    IMPORTANT: ``fn`` must be a closure that acquires its OWN db session (or
+    otherwise obtains a fresh connection) on each call. A connection that died
+    mid-operation cannot be reused — the whole point of retrying is to get a
+    new, pre-pinged connection from the pool on the next attempt. Do not
+    capture and reuse a single session across attempts.
+
+    Args:
+        fn: Zero-arg async callable to run, acquiring its own DB session per call.
+        max_attempts: Total attempts (including the first). Default 2 (one retry).
+        op_name: Label used in the warning log on retry, for triage.
+
+    Returns:
+        The return value of the first successful ``fn()`` call.
+
+    Raises:
+        The last exception if all attempts fail (immediately, with no retry,
+        if the exception is not a transient disconnection error).
+    """
+    last_error: Exception | None = None
+    for attempt in range(max_attempts):
+        try:
+            return await fn()
+        except Exception as e:
+            last_error = e
+            is_last_attempt = attempt == max_attempts - 1
+            if not is_disconnection_error(e) or is_last_attempt:
+                raise
+            logger.warning(
+                f"{op_name} hit a transient DB disconnect "
+                f"({type(e).__name__}); retrying (attempt {attempt + 2}/{max_attempts})"
+            )
+    # Unreachable: the loop either returns or raises on every iteration.
+    assert last_error is not None
+    raise last_error

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -200,6 +200,15 @@ openrouter_fallback_counter = meter.create_counter(
     unit="1",
 )
 
+embedding_fallback_counter = meter.create_counter(
+    name="embedding.fallback_total",
+    description=(
+        "Count of embedding provider retries, timeouts, and circuit-open events "
+        "handled by ResilientEmbeddingProvider"
+    ),
+    unit="1",
+)
+
 circuit_breaker_state_counter = meter.create_counter(
     name="circuit_breaker.state_transitions",
     description="Circuit breaker state transitions (open/half_open/closed)",

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -102,6 +102,12 @@ chat_verseless_responses_counter = meter.create_counter(
     unit="1",
 )  # attributes: language
 
+chat_scripture_unavailable_counter = meter.create_counter(
+    name="chat.responses.scripture_unavailable",
+    description="Scripture-seeking chat requests answered fail-closed (BITB-058) because no scripture could be retrieved",
+    unit="1",
+)  # attributes: language
+
 # ── Church metrics ────────────────────────────────────────────────────────
 church_search_counter = meter.create_counter(
     name="church.search.total",

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -44,6 +44,10 @@
 #       error. These code paths swallow exceptions (fail open to a verse-less
 #       answer), so without this alert a broken search can run silently — exactly
 #       how the "# nosec inside SQL" syntax-error regression went unnoticed.
+#   - azurerm_monitor_scheduled_query_rules_alert_v2.embedding_fallback_rate (BITB-057 Phase 2)
+#       Fires when the embedding provider's circuit breaker records any retry,
+#       timeout, or open-circuit event (providers/embedding_resilience.py). Chat
+#       degrades to verse-less responses silently while this persists.
 
 locals {
   alerts_enabled = var.alert_email != "" && var.enable_application_insights
@@ -761,6 +765,49 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "scripture_search_late
       | where name == "db.search.duration_ms"
       | summarize p95 = percentile(value, 95) by bin(timestamp, 5m)
       | where p95 > 2000
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
+# Embedding provider resilience alert (BITB-057 Phase 2).
+# Fires when the embedding.fallback_total custom metric records any retry,
+# timeout, or circuit-open event (providers/embedding_resilience.py) in the
+# last 10 minutes. A sustained rate here means the embedding provider is
+# degraded/down — chat requests degrade to verse-less responses per the
+# EmbeddingCircuitOpenError handling in chat/service.py, which is otherwise
+# silent (no 5xx), so this metric is the signal.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "embedding_fallback_rate" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-embedding-fallback-rate"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 2
+  description          = "Embedding provider retries, timeouts, or circuit-open events (embedding.fallback_total metric) in the last 10 minutes. Chat requests are degrading to verse-less responses while this persists — see providers/embedding_resilience.py."
+
+  criteria {
+    query                   = <<-KQL
+      customMetrics
+      | where timestamp > ago(10m)
+      | where name == "embedding.fallback_total"
+      | summarize total = sum(valueSum) by bin(timestamp, 5m)
+      | where total > 0
     KQL
     time_aggregation_method = "Count"
     threshold               = 0


### PR DESCRIPTION
## Summary

Two related pieces of the "upstream dependency resilience" work:

### BITB-057 Phase 2 — embedding/inference path
Follows Phase 1 (readiness fix + DB timeout bounding + probe-failure alert, merged via #796).

- **`api/providers/embedding_resilience.py`** — `ResilientEmbeddingProvider` wraps the embedding provider with the same circuit-breaker/timeout/bounded-retry treatment `openrouter.py` and `llama_guard.py` already have (reuses `utils/circuit_breaker.py`). On a sustained outage the breaker opens instead of hanging on an unbounded provider call.
- **`api/utils/db_retry.py`** — generalizes the disconnect-retry pattern that previously lived only in `_search_scripture` into a shared `run_with_disconnect_retry` helper, now also covering `_resolve_cited_verses` and the feedback/blocked-sample writers.
- **`deployment/monitoring.tf`** — new `embedding_fallback_rate` alert (additive) so sustained embedding retries/timeouts/circuit-open events are surfaced.
- New embedding config: `embedding_request_timeout`, `embedding_breaker_failure_threshold`, `embedding_breaker_cooldown_seconds`, `embedding_retry_max_attempts`, `embedding_retry_base_delay_seconds`.

**Scope note:** the story's optional "embedding cache" sub-item is intentionally **not** included — no cache infra exists yet and it needs its own key/invalidation design. Recommended as a separate follow-up once the new fallback-rate alert justifies it.

### BITB-058 — fail-closed scripture grounding (user-facing)
The product's value is being grounded in the Bible, so answering a scripture-seeking question with **no** verses undersells it. Previously that path failed **open** (silent, ungrounded answer). Now `chat()` and `chat_stream()` fail **closed**:

- **Trigger:** `include_search` **and** the request is scripture-seeking (a verse lookup, or intent in `COMFORT/GUIDANCE/CURIOSITY/VERSE_LOOKUP`) **and** scripture is unavailable — either a hard retrieval failure (`scripture_context is None`) **or** retrieval succeeded with zero verses/passages. Greetings / small talk (`GENERAL`) and off-topic are exempt, so we never nag when no citation was expected.
- **Behavior:** instead of calling the LLM, stream/return a localized *"I can't reach the Scripture library right now — please try again"* (`en/it/de/es/fr/pt/ar`, English fallback via `prompts.get_scripture_unavailable_response`). The streamed `completion` carries a backward-compatible `scripture_unavailable=True` flag; no frontend change required.
- **Observability + control:** new `chat.responses.scripture_unavailable` metric and a `require_scripture_grounding` feature flag (default on).
- **Interaction:** this supersedes the "degrade to verse-less" outcome for *scripture-seeking* queries — e.g. when the embedding breaker above opens and retrieval returns nothing, a scripture-seeking user now gets the honest retry message rather than an ungrounded answer.

**Risk:** Python changes plus one additive Terraform monitoring alert. No `ForceNew` resources, no DB/network changes.

## Acceptance criteria

- [x] Embedding provider resilience parity with the LLM path (breaker, tighter timeout, bounded jittered-backoff retry)
- [x] Embedding fallback/circuit-open metric (`embedding.fallback_total`) + alert on sustained rate
- [x] Generalized retry-on-disconnect helper adopted by `_search_scripture`, `_resolve_cited_verses`, feedback/blocked-sample writers
- [x] Fail-closed grounding for scripture-seeking requests that can't be grounded (BITB-058)
- [ ] Embedding cache — explicitly descoped (see note)

## Test plan

- [x] New unit tests: `test_embedding_resilience.py`, `test_db_retry.py`, `test_feedback_repository.py`
- [x] New fail-closed tests in `test_chat_coverage.py` (helper decision matrix + streaming/non-streaming short-circuit; a `GENERAL` greeting still generates normally)
- [x] Updated `test_chat_coverage.py`, `test_providers_coverage.py`, `test_intent_detection.py`
- [x] Full touched suites passing locally (ruff/black/mypy clean)
- [ ] CI green (backend tests, tf-validate/tf-plan for the new alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeyzcJhttw3MQjNtbaf5gH