### PR TITLE
fix: safe-filter false positive on German Bible references

### DIFF
--- a/api/tests/test_security.py
+++ b/api/tests/test_security.py
@@ -215,6 +215,62 @@ class TestContentFilter:
                 assert allowed is False, f"Should block: {msg}"
                 assert violation == ViolationType.URL_DETECTED
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # The exact reported false positive: a German Bible reference written
+            # "<chapter>.<Book>" with no space looks like the domain "1.timotheus".
+            "1.Timotheus 2,1-2 ist eine der Bibel-Stellen in der wir zum "
+            "Grundsätzlichsten aufgefordert sind",
+            "2.Mose 20",
+            "1.Korinther 13",
+            "3.Johannes 4",
+            "Lies 1.Petrus 5,7",
+        ],
+    )
+    def test_allows_bible_references(self, message):
+        """German Bible references must not be mistaken for URLs.
+
+        Regression for the reported false positive where "1.Timotheus 2,1-2 ..."
+        was rejected with HTTP 400 content_blocked because "1.Timotheus" matched
+        the bare-domain URL pattern.
+        """
+        filter = ContentFilter()
+        with patch("utils.security.settings") as mock_settings:
+            mock_settings.content_filter_enabled = True
+            mock_settings.content_filter_block_profanity = False
+            mock_settings.content_filter_block_spam = False
+            mock_settings.content_filter_max_urls = 0
+
+            allowed, violation, _ = filter.check(message)
+            assert allowed is True, f"Should NOT block Bible reference: {message!r}"
+            assert violation is None
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Scheme / www URLs (first alternative) — unchanged behavior.
+            "Check out https://example.com",
+            "Visit www.example.com for more",
+            "Go to http://test.org",
+            # Bare domains (second alternative) — still caught via a real TLD.
+            "buy cheap meds at cheapmeds.ru",
+            "go to spam.com now",
+        ],
+    )
+    def test_blocks_real_urls_and_bare_domains(self, message):
+        """Genuine URLs and bare domains must still be blocked after the fix."""
+        filter = ContentFilter()
+        with patch("utils.security.settings") as mock_settings:
+            mock_settings.content_filter_enabled = True
+            mock_settings.content_filter_block_profanity = False
+            mock_settings.content_filter_block_spam = False
+            mock_settings.content_filter_max_urls = 0
+
+            allowed, violation, _ = filter.check(message)
+            assert allowed is False, f"Should block URL/domain: {message!r}"
+            assert violation == ViolationType.URL_DETECTED
+
     def test_blocks_repeated_chars(self):
         """Excessive repeated characters should be blocked."""
         filter = ContentFilter()
@@ -365,6 +421,21 @@ class TestContentFilterDependency:
         from utils.security import check_content_filter
 
         request = _FakeRequest({"message": "mi manca tanto la....... Anna la mia Amica"})
+        # Must NOT raise HTTPException(400, content_blocked).
+        await check_content_filter(request)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_bible_reference_not_blocked(self):
+        """The reported German Bible-reference message must pass the dependency."""
+        from utils.security import check_content_filter
+
+        request = _FakeRequest(
+            {
+                "message": "1.Timotheus 2,1-2 ist eine der Bibel-Stellen in der wir "
+                "zum Grundsätzlichsten, was wir tun sollen, aufgefordert sind. "
+                "Gib mir alle Bibel-Stellen die in ähnlicher Weise reden"
+            }
+        )
         # Must NOT raise HTTPException(400, content_blocked).
         await check_content_filter(request)  # type: ignore[arg-type]
 

--- a/api/utils/security.py
+++ b/api/utils/security.py
@@ -95,10 +95,24 @@ class ContentFilter:
         r"\bp+i+s+s+",
     ]
 
+    # Recognized TLDs for detecting *bare* domains (no scheme). Requiring a real
+    # TLD prevents false positives on run-together text and abbreviations — most
+    # importantly German Bible references such as "1.Timotheus" or "2.Mose", where
+    # "<chapter>.<Book>" looks like "label.label". (Scheme/www URLs are matched by
+    # the first alternative below and are unaffected.)
+    _COMMON_TLDS = (
+        "com|org|net|edu|gov|mil|int|io|co|info|biz|app|dev|ai|xyz|online|site|"
+        "shop|store|me|tv|cc|"
+        # ccTLDs for supported locales / common regions
+        "de|it|es|fr|pt|uk|us|ca|eu|ru|cn|in|kr|jp|br|mx|ch|at|nl|be|pl|se|no|"
+        "dk|fi|sa|ae|eg|au"
+    )
+
     # URL patterns
     URL_PATTERN = re.compile(
-        r"(?:https?://|www\.|ftp://)"  # Protocol or www
-        r"|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}",  # Domain pattern
+        r"(?:https?://|www\.|ftp://)"  # Protocol or www — always treated as a URL
+        r"|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+"  # one or more domain labels
+        rf"(?:{_COMMON_TLDS})\b",  # …ending in a recognized TLD (bare-domain spam)
         re.IGNORECASE,
     )
 


### PR DESCRIPTION
## Problem

A legitimate German message was blocked by the safety system:

> `1.Timotheus 2,1-2 ist eine der Bibel-Stellen ... Gib mir alle Bibel-Stellen die in ähnlicher Weise reden`

The user only saw the generic *"safety system held it back / it may have misread your words / please rephrase"* notice (`contentBlockedMessage` / `error_content_blocked`).

## Root cause

The block did **not** come from the multi-stage content-safety pipeline (Llama Guard / OpenAI Moderation). It came from the basic `ContentFilter` URL detector in `api/utils/security.py`:

- `check_content_filter` (FastAPI dependency on the chat routes) runs `ContentFilter.check()`.
- With the default `content_filter_max_urls = 0`, any substring matching `URL_PATTERN` is rejected with HTTP 400 `content_blocked`.
- The bare-domain branch `(?:[a-z0-9]...\.)+[a-z]{2,}` matches any `label.label` where the last label is ≥2 letters.
- German Bible references are written `<chapter>.<Book>` **without a space** (`1.Timotheus`, `2.Mose`, `1.Korinther`, `1.Petrus`, `3.Johannes`), so `1.Timotheus` reads as the domain `1.timotheus` and is blocked. Every numbered German book reference is affected.

The frontend and Android client both map HTTP 400 `content_blocked` to the generic "safety system" message the user saw.

## Fix

Narrow the schemeless bare-domain branch of `URL_PATTERN` to require a recognized TLD. Book names (`Timotheus`, `Mose`, `Korinther`, …) are not TLDs, so numbered references no longer register as domains, while scheme/`www.` URLs and genuine bare domains (`spam.com`, `cheapmeds.ru`) are still blocked. This mirrors the existing ellipsis false-positive fix in the same file.

Known, accepted limitation: run-together text where a word ends in a short real ccTLD after a missing space (e.g. `...gut.Es`) can still match — rarer than Bible references and no worse than today's behavior.

## Changes

- `api/utils/security.py` — add `_COMMON_TLDS`; restrict the bare-domain alternative of `URL_PATTERN` to end in a recognized TLD.
- `api/tests/test_security.py` — regression tests: the reported message and several German Bible references must pass; scheme/`www.` URLs and bare domains must still be blocked; plus an end-to-end `check_content_filter` dependency test.

## Verification

The full pytest suite can't run in the sandbox (its import chain pulls the whole ML stack, and `lingua-language-detector==2.2.0` has no Python 3.11 wheel). Instead the real production code was exercised directly:

- `ContentFilter.check()` — all Bible references allowed (`violation=None`); all URLs/bare domains blocked (`URL_DETECTED`).
- The async `check_content_filter` dependency — the exact reported message passes with no HTTP 400, while `spam.com` still yields `content_blocked`.

Out of scope: the LLM content-safety pipeline and frontend/Android wording (server-side block simply stops firing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaNC5AGqpenidQedGfZNuN)_