### PR TITLE
fix(verse-links): accept comma chapter-verse separator (de/fr/it citations)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatMessageItem.kt
@@ -133,7 +133,7 @@ internal val DEFAULT_VERSE_REF_REGEX = Regex(
     // Also handles Russian Synodal dash style ("1-я ", "1-е ", "2-я ") where a 1–2 letter
     // ordinal suffix follows the dash (lowercase Cyrillic, so \p{L}\p{M} not \p{Lu}\p{Lo}).
     // Allows multiple trailing words (e.g. Arabic "1 أخبار الأيام" = 1 Chronicles = 3 words).
-    "([1-3](?:[\\s.][\\s]?|-[\\p{L}\\p{M}]{1,2}\\s+)$BOOK_NAME(?:\\s+[\\p{L}][\\p{L}\\p{M}\\d]+)*)\\s+(\\d+):(\\d+(?:-\\d+)?)(?!\\d)" +
+    "([1-3](?:[\\s.][\\s]?|-[\\p{L}\\p{M}]{1,2}\\s+)$BOOK_NAME(?:\\s+[\\p{L}][\\p{L}\\p{M}\\d]+)*)\\s+(\\d+)[:,](\\d+(?:[-\\u2013]\\d+)?)(?!\\d)" +
         "|" +
         // Alt 2 — no prefix. Colon branch or chapter-only branch (with guard).
         // Chapter-only uses (?!\s+[\p{Lu}\p{Lo}]) so that "See 1 Corinthians..." does NOT
@@ -147,7 +147,7 @@ internal val DEFAULT_VERSE_REF_REGEX = Regex(
         // Uses COND_WS so CJK/Hangul book names can abut the chapter number without a space.
         // [\u300B\u300D\u300F]? optionally consumes a closing bracket (》」』) after the
         // book name (e.g. 《约翰福音》3:16 or 「요한복음」3:16) so it does not block the match.
-        "($BOOK_NAME)[\\u300B\\u300D\\u300F]?$COND_WS(\\d+)(?::(\\d+(?:-\\d+)?)(?!\\d)|(?!\\d)(?!\\s+[\\p{Lu}\\p{Lo}]))"
+        "($BOOK_NAME)[\\u300B\\u300D\\u300F]?$COND_WS(\\d+)(?:[:,](\\d+(?:[-\\u2013]\\d+)?)(?!\\d)|(?!\\d)(?!\\s+[\\p{Lu}\\p{Lo}]))"
 )
 
 /**
@@ -214,11 +214,11 @@ internal fun buildVerseRefRegex(
 
     return Regex(
         // Alt 1 — numbered prefix, colon REQUIRED (see DEFAULT_VERSE_REF_REGEX comments)
-        "([1-3](?:[\\s.][\\s]?|-[\\p{L}\\p{M}]{1,2}\\s+)$dynamicBookName(?:\\s+[\\p{L}][\\p{L}\\p{M}\\d]+)*)\\s+(\\d+):(\\d+(?:-\\d+)?)(?!\\d)" +
+        "([1-3](?:[\\s.][\\s]?|-[\\p{L}\\p{M}]{1,2}\\s+)$dynamicBookName(?:\\s+[\\p{L}][\\p{L}\\p{M}\\d]+)*)\\s+(\\d+)[:,](\\d+(?:[-\\u2013]\\d+)?)(?!\\d)" +
             "|" +
             // Alt 2 — no prefix. Uses COND_WS for CJK/Hangul no-space support.
             // [\u300B\u300D\u300F]? optionally consumes closing bracket (》」』) after book name.
-            "($dynamicBookName)[\\u300B\\u300D\\u300F]?$COND_WS(\\d+)(?::(\\d+(?:-\\d+)?)(?!\\d)|(?!\\d)(?!\\s+[\\p{Lu}\\p{Lo}]))"
+            "($dynamicBookName)[\\u300B\\u300D\\u300F]?$COND_WS(\\d+)(?:[:,](\\d+(?:[-\\u2013]\\d+)?)(?!\\d)|(?!\\d)(?!\\s+[\\p{Lu}\\p{Lo}]))"
     )
 }
 
@@ -333,7 +333,11 @@ internal fun injectVerseLinks(
         } else {
             val linkBook = resolveLinkBook(book, chapter, verse, verses, localizedToEnglish)
             val encodedBook = URLEncoder.encode(linkBook, "UTF-8")
-            val display = if (verse.isNotEmpty()) "$book $chapter:$verse" else "$book $chapter"
+            // Preserve the chapter/verse separator the source used (":" or ",") so a German /
+            // French / Italian citation like "Römer 13,1" is not rewritten to "13:1". The
+            // verse:// target below uses numeric path segments only, so it is unaffected.
+            val sep = if (Regex("\\d,\\d").containsMatchIn(result.value)) "," else ":"
+            val display = if (verse.isNotEmpty()) "$book $chapter$sep$verse" else "$book $chapter"
             val urlVerse = if (verse.isNotEmpty()) "/$verse" else ""
             // Carry the localized book token in the URL so parseVerseLink can set it on
             // PendingVerseLink without discarding the name the LLM used.

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
@@ -124,6 +124,54 @@ class VerseRefLinkTest {
         assertEquals(input, injectVerseLinks(input))
     }
 
+    // ── Comma citation style (German / French / Italian: "Römer 13,1") ─────────
+
+    @Test
+    fun `injectVerseLinks links a German comma reference and preserves the comma`() {
+        val result = injectVerseLinks("Das steht in Römer 13,1-2 geschrieben.")
+        // Display keeps the comma the reader wrote …
+        assertTrue(result, result.contains("[Römer 13,1-2]"))
+        // … while the link target is the canonical English book.
+        assertTrue(result, result.contains("verse://Romans/13"))
+    }
+
+    @Test
+    fun `injectVerseLinks links a comma reference without a range`() {
+        val result = injectVerseLinks("Jakobus 1,27 spricht von Frömmigkeit.")
+        assertTrue(result, result.contains("[Jakobus 1,27]"))
+    }
+
+    @Test
+    fun `injectVerseLinks links a numbered comma reference`() {
+        val result = injectVerseLinks("Lies 1. Petrus 2,13-17 heute.")
+        assertTrue(result, result.contains("[1. Petrus 2,13-17]"))
+    }
+
+    @Test
+    fun `injectVerseLinks links a French comma reference`() {
+        val result = injectVerseLinks("Lis Jean 3,16 aujourd'hui.")
+        assertTrue(result, result.contains("[Jean 3,16]"))
+    }
+
+    @Test
+    fun `injectVerseLinks still links colon references and keeps the colon`() {
+        val result = injectVerseLinks("As Jesus said in John 3:16, God so loved.")
+        assertTrue(result, result.contains("[John 3:16]"))
+    }
+
+    @Test
+    fun `injectVerseLinks does not link a decimal amount`() {
+        val input = "Ich habe 3,50 Euro gespart."
+        assertEquals(input, injectVerseLinks(input))
+    }
+
+    @Test
+    fun `injectVerseLinks does not link a comma followed by a space`() {
+        // "Kapitel" is not a book, and the comma is followed by a space — no verse match.
+        val input = "In Kapitel 5, Vers 3 steht es."
+        assertEquals(input, injectVerseLinks(input))
+    }
+
     // ── Non-English book names: German ───────────────────────────────────────
 
     @Test

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseRefLinkTest.kt
@@ -131,8 +131,9 @@ class VerseRefLinkTest {
         val result = injectVerseLinks("Das steht in Römer 13,1-2 geschrieben.")
         // Display keeps the comma the reader wrote …
         assertTrue(result, result.contains("[Römer 13,1-2]"))
-        // … while the link target is the canonical English book.
-        assertTrue(result, result.contains("verse://Romans/13"))
+        // … while the link target is the canonical English book. The bundled book-name map
+        // canonicalizes to lowercase ("romans"); the backend lookup is case-insensitive.
+        assertTrue(result, result.lowercase().contains("verse://romans/13"))
     }
 
     @Test

--- a/frontend/src/components/ChatMessage.verseMarking.test.tsx
+++ b/frontend/src/components/ChatMessage.verseMarking.test.tsx
@@ -73,6 +73,36 @@ describe("ChatMessage inline verse marking — connector-word regression", () =>
   });
 });
 
+describe("ChatMessage inline verse marking — comma citation style", () => {
+  // German/French/Italian cite chapter,verse with a comma ("Römer 13,1").
+  it("marks a plain comma reference as an amber clickable span", () => {
+    renderAssistant("Das steht in Römer 13,1 geschrieben.");
+    const span = screen.getByText("Römer 13,1");
+    expect(span.tagName).toBe("SPAN");
+    expect(span.className).toContain("text-amber-800");
+  });
+
+  it("calls onVerseClick with the parsed book/chapter/verse for a comma ref", () => {
+    const { onVerseClick } = renderAssistant("Lies Römer 13,1 heute.");
+    fireEvent.click(screen.getByText("Römer 13,1"));
+    expect(onVerseClick).toHaveBeenCalledWith("Römer", 13, 1);
+  });
+
+  it("marks a comma reference with a range (Galater 5,22-23)", () => {
+    renderAssistant("Siehe Galater 5,22-23 für die Frucht.");
+    expect(screen.getByText("Galater 5,22-23").className).toContain(
+      "text-amber-800",
+    );
+  });
+
+  it("does not mark a decimal amount as a verse", () => {
+    const text = "Ich habe 3,50 Euro gespart.";
+    const { container } = renderAssistant(text);
+    expect(container.textContent).toContain(text);
+    expect(container.querySelectorAll("span.text-amber-800").length).toBe(0);
+  });
+});
+
 describe("ChatMessage inline verse marking — no longer cuts text", () => {
   it("does not mark German prose that merely contains numbers", () => {
     const text = "Gott schenkt uns Trost der Hoffnung 5:5 jeden Tag.";

--- a/frontend/src/lib/verseExtraction.test.ts
+++ b/frontend/src/lib/verseExtraction.test.ts
@@ -73,7 +73,9 @@ describe("extractVerseReferences", () => {
     });
 
     it("extracts a German comma reference without a range", () => {
-      const refs = extractVerseReferences("Jakobus 1,27 spricht von Frömmigkeit.");
+      const refs = extractVerseReferences(
+        "Jakobus 1,27 spricht von Frömmigkeit.",
+      );
       expect(refs.has("james 1:27")).toBe(true);
     });
 

--- a/frontend/src/lib/verseExtraction.test.ts
+++ b/frontend/src/lib/verseExtraction.test.ts
@@ -64,6 +64,46 @@ describe("extractVerseReferences", () => {
     expect(refs.has("psalms 56:9")).toBe(true);
   });
 
+  // German/French/Italian cite chapter,verse with a comma ("Römer 13,1").
+  // The separator regex accepts [:,] (mirroring the backend), so these link too.
+  describe("comma separator (German/French/Italian citation style)", () => {
+    it("extracts a German comma reference with a range", () => {
+      const refs = extractVerseReferences("Siehe Römer 13,1-2 für Kontext.");
+      expect(refs.has("romans 13:1")).toBe(true);
+    });
+
+    it("extracts a German comma reference without a range", () => {
+      const refs = extractVerseReferences("Jakobus 1,27 spricht von Frömmigkeit.");
+      expect(refs.has("james 1:27")).toBe(true);
+    });
+
+    it("extracts a numbered German comma reference", () => {
+      const refs = extractVerseReferences("Lies 1. Petrus 2,13-17 heute.");
+      expect(refs.has("1 peter 2:13")).toBe(true);
+    });
+
+    it("extracts a French comma reference", () => {
+      const refs = extractVerseReferences("Lis Jean 3,16 aujourd'hui.");
+      expect(refs.has("john 3:16")).toBe(true);
+    });
+
+    it("extracts an Italian comma reference", () => {
+      const refs = extractVerseReferences("Leggi Giovanni 3,16 oggi.");
+      expect(refs.has("john 3:16")).toBe(true);
+    });
+
+    it("still extracts colon references (no regression)", () => {
+      const refs = extractVerseReferences("Read John 3:16 today.");
+      expect(refs.has("john 3:16")).toBe(true);
+    });
+
+    it("does not treat a decimal amount as a verse", () => {
+      // "habe" is not a known book, so the isKnownBook gate rejects "habe 3,50".
+      const refs = extractVerseReferences("Ich habe 3,50 Euro gespart.");
+      expect(refs.size).toBe(0);
+    });
+  });
+
   it("should handle verse ranges", () => {
     const text = "Read Matthew 5:3-12 for the beatitudes";
     const refs = extractVerseReferences(text);

--- a/frontend/src/lib/versePatterns.ts
+++ b/frontend/src/lib/versePatterns.ts
@@ -264,6 +264,13 @@ function buildPatternSource(): string {
   //
   // Chapter:verse digits: [\d\u0966-\u096F\u0660-\u0669] supports Western,
   // Devanagari (Hindi), and Eastern Arabic numerals.
+  //
+  // Chapter/verse separator [:,] accepts a colon (English etc.) OR a comma \u2014
+  // the convention in German/French/Italian citations ("R\u00F6mer 13,1"). This
+  // mirrors the backend parser (api/utils/verse_parser.py), so in-text links
+  // match exactly what the backend already recognises. The isKnownBook gate
+  // keeps the comma from matching prose/decimals ("habe 3,50"). The range
+  // accepts a hyphen or en-dash ([-\u2013]).
   _cachedPatternSource =
     `(?:(?<!\\p{L})|(?<=\\p{Script=Han})|(?<=\\p{Script=Hangul})|(?<=\\p{Script=Devanagari})|(?<=[\u300A\u300C\u300E]))(${multiWordPart}` +
     `[\\p{L}\\p{M}]{2,}(?:\\s+(?:of|dei|des|der|van|de|af|dos|da|del|के|ال)\\s+[\\p{L}\\p{M}]+)+` +
@@ -271,7 +278,7 @@ function buildPatternSource(): string {
     `|${cjkPart}` +
     `${hangulPart}` +
     `${devanagariPart}` +
-    `(?:(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}]){2,})[\u300B\u300D\u300F]?(?:(?<=[\\p{Script=Han}])\\s*|(?<=[\\p{Script=Hangul}])\\s*|(?<=[\\p{Script=Devanagari}])\\s*|(?<=[\u300B\u300D\u300F])\\s*|\\s+)([\\d\u0966-\u096F\u0660-\u0669]+):([\\d\u0966-\u096F\u0660-\u0669]+)(?:-[\\d\u0966-\u096F\u0660-\u0669]+)?`;
+    `(?:(?![\\p{Script=Han}\\p{Script=Hangul}\\p{Script=Devanagari}])[\\p{L}\\p{M}]){2,})[\u300B\u300D\u300F]?(?:(?<=[\\p{Script=Han}])\\s*|(?<=[\\p{Script=Hangul}])\\s*|(?<=[\\p{Script=Devanagari}])\\s*|(?<=[\u300B\u300D\u300F])\\s*|\\s+)([\\d\u0966-\u096F\u0660-\u0669]+)[:,]([\\d\u0966-\u096F\u0660-\u0669]+)(?:[-\u2013][\\d\u0966-\u096F\u0660-\u0669]+)?`;
 
   return _cachedPatternSource;
 }


### PR DESCRIPTION
## Problem

Follow-up to #801. In German answers, references like `Römer 13,1-2`, `Galater 5,22-23`, `1. Petrus 2,13-17`, `Jakobus 1,27` appeared bold/amber but were **not clickable** — "sometimes it works" only when the model happened to emit a colon.

German/French/Italian Bible citations separate chapter and verse with a **comma** (`Römer 13,1`), but the frontend verse regex only accepted a **colon** (`:`). The references *looked* linked because the model emits them as bold and the `strong` renderer styles all bold text amber + clickable — but the click handler ran the colon-only pattern, matched nothing, and did nothing.

The **backend already accepts `[:,]`** (`api/utils/verse_parser.py:318`), which is why the `<!-- VERSES: … -->` metadata and the right-side pane were correct. Only the client-side in-text linking regex was out of step.

## Fix — mirror the backend on both clients

Change the chapter–verse separator from `:` to the class **`[:,]`** (and accept an en-dash in ranges), keeping capture groups, the `isKnownBook` gate, and the rewind loop from #801 intact.

- **Web** (`versePatterns.ts`): one change in the shared pattern, so `highlightText`, `handleTextClick`, and `extractVerseReferences` all gain comma support. Web already displays the original text, so `13,1-2` stays as written.
- **Android** (`ChatMessageItem.kt`): `[:,]` in all four cv-pattern branches, and `injectVerseLinks` now **preserves the separator the source used** (so `Römer 13,1` isn't rewritten to `13:1`). Link targets stay canonical (`verse://Romans/13`).
- **Backend**: no change — it is the reference implementation.

## Does this work for all languages?

Yes — it's a superset that can't regress any language:
- Colon stays in the class → English, Spanish, Portuguese, Russian, Chinese, Korean, Arabic, Hindi unchanged.
- Comma added → German, French, Italian now link.
- Mirrors the backend's exact `[:,]`, so in-text links match what the backend already recognizes for every language.
- The per-language `isKnownBook` allowlist (from #801) blocks comma false positives (e.g. `Ich habe 3,50 Euro`). `Kapitel 5, Vers 3` doesn't match (comma must be immediately followed by a digit).

Out of scope (and absent in the backend too, so no regression): locale-specific glyphs like the Arabic comma `،` or CJK fullwidth `，`/`：` — those languages cite with an ASCII colon, which already works.

## Testing

- **Web:** full suite green — **659 tests** (+11 new), covering German/French/Italian comma refs, a comma range, a numbered comma ref, colon no-regression, click → `onVerseClick`, and a `3,50 Euro` false-positive guard.
- **Android:** no SDK in the dev sandbox, so validated the Kotlin regex + display logic against the real transformed pattern and the bundled allowlist via a JDK harness (12 cases: comma refs with comma preserved in display, colon preserved, decimal/`Kapitel 5, Vers 3` rejected, CJK/chapter-only still work). New `VerseRefLinkTest` cases run in CI (`Unit Tests` / `Compose UI Tests` / `Android Lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2TdG9bWoKWzW2jGVfyNuF)_