### PR TITLE
fix(verse-links): link references everywhere via string-level linkify (web)

### DIFF
--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -9,9 +9,19 @@ import enMessages from "../../../messages/en.json";
 // Mock scrollIntoView
 Element.prototype.scrollIntoView = vi.fn();
 
-// Mock react-markdown to simplify rendering
+// Mock react-markdown to simplify rendering. ChatMessage pre-links verse
+// references via linkifyVerses() (e.g. "John 3:16" -> "[John 3:16](verse://…)"),
+// so reduce markdown links to their display text — what real react-markdown
+// renders — otherwise the raw "[...](...)" syntax leaks into the asserted text.
 vi.mock("react-markdown", () => ({
-  default: ({ children }: { children: string }) => <p>{children}</p>,
+  default: ({ children }: { children: string }) => (
+    <p>
+      {typeof children === "string"
+        ? children.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+        : children}
+    </p>
+  ),
+  defaultUrlTransform: (url: string) => url,
 }));
 
 // Mock the API module
@@ -39,6 +49,10 @@ vi.mock("@/lib/verseExtraction", async (importOriginal) => {
     extractVerseReferences: actual.extractVerseReferences,
     isVerseReferenced: actual.isVerseReferenced,
     LOCALIZED_BOOK_TO_ENGLISH: actual.LOCALIZED_BOOK_TO_ENGLISH,
+    // ChatMessage now pre-links verses via linkifyVerses(), which calls
+    // isKnownBook() at render time (previously only reached through the
+    // react-markdown renderers, which this suite stubs out).
+    isKnownBook: actual.isKnownBook,
   };
 });
 

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { User, BookOpen } from "lucide-react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import { Message } from "@/lib/api";
 import ShareMenu from "./ShareMenu";
 import FeedbackControls from "./FeedbackControls";
@@ -11,6 +11,11 @@ import {
   createVersePatternGlobal,
 } from "@/lib/versePatterns";
 import { isKnownBook } from "@/lib/verseExtraction";
+import {
+  linkifyVerses,
+  parseVerseHref,
+  VERSE_SCHEME,
+} from "@/lib/linkifyVerses";
 
 /** Recursively extract the plain-text content of a React node (e.g. link children). */
 function getNodeText(node: React.ReactNode): string {
@@ -200,6 +205,12 @@ export default function ChatMessage({
           <>
             <div className="prose prose-sm max-w-none prose-p:my-2 prose-headings:mt-4 prose-headings:mb-2">
               <ReactMarkdown
+                // Preserve our in-app verse:// links; sanitize everything else
+                // as usual. Without this, react-markdown's defaultUrlTransform
+                // strips the unknown verse:// scheme and the links go dead.
+                urlTransform={(url) =>
+                  url.startsWith(VERSE_SCHEME) ? url : defaultUrlTransform(url)
+                }
                 components={{
                   // Custom paragraph renderer to highlight verse references
                   p: ({ children }) => {
@@ -217,6 +228,23 @@ export default function ChatMessage({
                         {processedChildren}
                       </p>
                     );
+                  },
+                  // List items need the same string processing as paragraphs —
+                  // a tight markdown list puts text directly in <li> (not in a
+                  // <p>), so without this, quotes in bullets go unstyled. Verse
+                  // references are already pre-linked by linkifyVerses(), so
+                  // they arrive as <a> children and pass straight through.
+                  li: ({ children }) => {
+                    const processedChildren = React.Children.map(
+                      children,
+                      (child, idx) => {
+                        if (typeof child === "string") {
+                          return highlightText(child, idx);
+                        }
+                        return child;
+                      },
+                    );
+                    return <li>{processedChildren}</li>;
                   },
                   // Style bold text (often verse references) - make them clickable
                   strong: ({ children }) => (
@@ -247,6 +275,26 @@ export default function ChatMessage({
                   // inline verse marking — amber, clickable, opening the
                   // in-app verse view — not a default blue external link.
                   a: ({ href, children }) => {
+                    // In-app verse:// links injected by linkifyVerses(): parse
+                    // the reference straight from the href so it works anywhere
+                    // (paragraphs, list items, headings, …).
+                    const verse = parseVerseHref(href);
+                    if (verse) {
+                      return (
+                        <span
+                          className="text-amber-800 font-semibold cursor-pointer hover:underline"
+                          onClick={() =>
+                            onVerseClick?.(
+                              verse.book,
+                              verse.chapter,
+                              verse.verse,
+                            )
+                          }
+                        >
+                          {children}
+                        </span>
+                      );
+                    }
                     const linkText = getNodeText(children);
                     const match = linkText.match(createVersePattern());
                     if (match && isKnownBook(match[1].trim())) {
@@ -280,7 +328,7 @@ export default function ChatMessage({
                   ),
                 }}
               >
-                {message.content}
+                {linkifyVerses(message.content)}
               </ReactMarkdown>
             </div>
 

--- a/frontend/src/components/ChatMessage.verseMarking.test.tsx
+++ b/frontend/src/components/ChatMessage.verseMarking.test.tsx
@@ -163,3 +163,48 @@ describe("ChatMessage inline verse marking — markdown links", () => {
     expect(anchor!.textContent).toBe("Bible Gateway");
   });
 });
+
+describe("ChatMessage inline verse marking — references inside list items", () => {
+  // Regression: verse refs in a (tight) markdown bullet list used to render as
+  // plain text because only the `p` renderer processed them. linkifyVerses now
+  // pre-links refs anywhere in the markdown string, so list items link too.
+  const listMessage = [
+    "Hier sind einige Bibelstellen:",
+    "",
+    '- Römer 12,14: "Segnet, die euch verfolgen; segnet und flucht nicht!"',
+    '- Matthäus 5,44: "Liebet eure Feinde, segnet, die euch fluchen"',
+    '- Lukas 6,28: "segnet, die euch fluchen"',
+    "",
+    "In **1. Timotheus 2,1-2** heißt es mehr dazu.",
+  ].join("\n");
+
+  it("marks every reference in the bullet list (not just the bold one)", () => {
+    renderAssistant(listMessage);
+    for (const ref of ["Römer 12,14", "Matthäus 5,44", "Lukas 6,28"]) {
+      const span = screen.getByText(ref);
+      expect(span.className).toContain("text-amber-800");
+    }
+  });
+
+  it("makes a list-item reference clickable", () => {
+    const { onVerseClick } = renderAssistant(listMessage);
+    fireEvent.click(screen.getByText("Römer 12,14"));
+    expect(onVerseClick).toHaveBeenCalledWith("Römer", 12, 14);
+  });
+
+  it("highlights a quote inside a list item", () => {
+    const { container } = renderAssistant(listMessage);
+    // The bullet quotes ("Segnet…", "Liebet…", "segnet…") now get the amber
+    // quote styling, which previously only worked inside paragraphs.
+    expect(
+      container.querySelectorAll("span.bg-amber-50").length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it("still marks the bold paragraph reference", () => {
+    renderAssistant(listMessage);
+    expect(screen.getByText("1. Timotheus 2,1-2").className).toContain(
+      "text-amber-800",
+    );
+  });
+});

--- a/frontend/src/lib/linkifyVerses.test.ts
+++ b/frontend/src/lib/linkifyVerses.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { linkifyVerses, parseVerseHref } from "./linkifyVerses";
+
+describe("linkifyVerses", () => {
+  it("links a reference in prose", () => {
+    expect(linkifyVerses("Lies Johannes 3,16 heute.")).toContain(
+      "[Johannes 3,16](verse://Johannes/3/16)",
+    );
+  });
+
+  it("links references inside list items (the reported bug)", () => {
+    const md = [
+      '- Römer 12,14: "Segnet, die euch verfolgen"',
+      '- Matthäus 5,44: "Liebet eure Feinde"',
+      '- Lukas 6,28: "segnet, die euch fluchen"',
+    ].join("\n");
+    const out = linkifyVerses(md);
+    expect(out).toContain("[Römer 12,14](verse://R%C3%B6mer/12/14)");
+    expect(out).toContain("[Matthäus 5,44](verse://Matth%C3%A4us/5/44)");
+    expect(out).toContain("[Lukas 6,28](verse://Lukas/6/28)");
+  });
+
+  it("keeps a comma range in the display text, canonical start in href", () => {
+    expect(linkifyVerses("Siehe Römer 13,1-7 hier.")).toContain(
+      "[Römer 13,1-7](verse://R%C3%B6mer/13/1)",
+    );
+  });
+
+  it("links a numbered book so markdown cannot eat the ordinal as a list marker", () => {
+    // "- 1. Petrus 3,9" would otherwise be parsed as a nested ordered list.
+    // Wrapping it in [ ] first keeps "1." inside the link, not as a marker.
+    const out = linkifyVerses('- 1. Petrus 3,9: "Vergeltet nicht Böses"');
+    expect(out).toContain("[1. Petrus 3,9](verse://1.%20Petrus/3/9)");
+  });
+
+  it("still links colon references", () => {
+    expect(linkifyVerses("See John 3:16.")).toContain(
+      "[John 3:16](verse://John/3/16)",
+    );
+  });
+
+  it("recovers a reference hidden by a greedy connector over-match", () => {
+    const out = linkifyVerses("I remind you of Psalm 56:9 today.");
+    expect(out).toContain("[Psalm 56:9](verse://Psalm/56/9)");
+  });
+
+  it("does not link a decimal amount (not a known book)", () => {
+    const md = "Ich habe 3,50 Euro gespart.";
+    expect(linkifyVerses(md)).toBe(md);
+  });
+
+  it("leaves an existing markdown link untouched", () => {
+    const md = "See [John 3:16](https://example.com/john) here.";
+    expect(linkifyVerses(md)).toBe(md);
+  });
+
+  it("leaves the VERSES html comment untouched", () => {
+    const md = "Antwort.\n<!-- VERSES: Römer 12,14; Matthäus 5,44 -->";
+    expect(linkifyVerses(md)).toBe(md);
+  });
+
+  it("leaves inline code untouched", () => {
+    const md = "Schreibe `John 3:16` wörtlich.";
+    expect(linkifyVerses(md)).toBe(md);
+  });
+
+  it("leaves fenced code untouched", () => {
+    const md = "```\nJohn 3:16\n```";
+    expect(linkifyVerses(md)).toBe(md);
+  });
+});
+
+describe("parseVerseHref", () => {
+  it("parses a verse:// href (with an encoded book)", () => {
+    expect(parseVerseHref("verse://R%C3%B6mer/12/14")).toEqual({
+      book: "Römer",
+      chapter: 12,
+      verse: 14,
+    });
+  });
+
+  it("returns null for external links", () => {
+    expect(parseVerseHref("https://example.com")).toBeNull();
+    expect(parseVerseHref(undefined)).toBeNull();
+  });
+});

--- a/frontend/src/lib/linkifyVerses.ts
+++ b/frontend/src/lib/linkifyVerses.ts
@@ -1,0 +1,115 @@
+/**
+ * String-level verse linkifier — the web analog of the Android
+ * `injectVerseLinks` (ChatMessageItem.kt).
+ *
+ * The web used to highlight verses via per-element React-Markdown renderers,
+ * which only ran inside the `p` renderer's string children.  References inside
+ * list items (and headings, table cells, …) were therefore never linked.  This
+ * rewrites every reference in the raw markdown into a `verse://` link *before*
+ * rendering, so a single `a` renderer can make them clickable no matter where
+ * they appear — the same general approach Android uses.
+ *
+ * The shared verse pattern + `isKnownBook` allowlist (with the rewind-on-reject
+ * behaviour) are reused, so comma separators and greedy-over-match handling come
+ * for free.
+ */
+
+import { createVersePatternGlobal } from "./versePatterns";
+import { isKnownBook } from "./verseExtraction";
+
+/** URL scheme used for in-app verse links (mirrors Android's `verse://`). */
+export const VERSE_SCHEME = "verse://";
+
+/**
+ * Regions copied verbatim — never linkified — so we respect markdown structure:
+ *   - fenced code blocks  ```…```
+ *   - inline code         `…`
+ *   - HTML comments       <!-- … -->   (the `VERSES:` citation marker)
+ *   - existing links      [text](url)
+ * Fenced code is listed before inline code so a ``` fence wins over a single `.
+ */
+const PROTECTED_REGION_SOURCE =
+  "```[\\s\\S]*?```|`[^`]*`|<!--[\\s\\S]*?-->|\\[[^\\]]*\\]\\([^)]*\\)";
+
+/**
+ * Parse a `verse://<book>/<chapter>/<verse>` href back into its parts.
+ * Returns null for any other href (external links, etc.).
+ */
+export function parseVerseHref(
+  href: string | undefined,
+): { book: string; chapter: number; verse: number } | null {
+  if (!href || !href.startsWith(VERSE_SCHEME)) return null;
+  const parts = href.slice(VERSE_SCHEME.length).split("/");
+  if (parts.length < 3) return null;
+  let book: string;
+  try {
+    book = decodeURIComponent(parts[0]);
+  } catch {
+    return null;
+  }
+  const chapter = parseInt(parts[1], 10);
+  const verse = parseInt(parts[2], 10);
+  if (!book.trim() || Number.isNaN(chapter) || Number.isNaN(verse)) return null;
+  return { book: book.trim(), chapter, verse };
+}
+
+/**
+ * Wrap every recognised verse reference in a plain (unprotected) markdown
+ * segment as a `verse://` link, keeping the original display text.
+ */
+function linkifyPlainSegment(text: string): string {
+  const pattern = createVersePatternGlobal();
+
+  let out = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    const book = match[1].trim();
+
+    // Reject non-books and rewind so a valid reference hidden inside a greedy
+    // over-match ("you of Psalm 56:9") is still recovered.  Mirrors
+    // extractVerseReferences()/highlightText().
+    if (!isKnownBook(book)) {
+      pattern.lastIndex = match.index + 1;
+      continue;
+    }
+
+    const chapter = match[2];
+    const verse = match[3];
+    // Keep the reference exactly as written for the display text (e.g. the
+    // German "13,1-2"), but encode a canonical target in the href.
+    const href = `${VERSE_SCHEME}${encodeURIComponent(book)}/${chapter}/${verse}`;
+    out += text.slice(lastIndex, match.index);
+    out += `[${match[0]}](${href})`;
+    lastIndex = match.index + match[0].length;
+  }
+
+  out += text.slice(lastIndex);
+  return out;
+}
+
+/**
+ * Rewrite recognised verse references in `markdown` as `verse://` links,
+ * leaving code, HTML comments, and existing links untouched.
+ */
+export function linkifyVerses(markdown: string): string {
+  const regions = new RegExp(PROTECTED_REGION_SOURCE, "g");
+
+  let out = "";
+  let lastIndex = 0;
+  let region: RegExpExecArray | null;
+
+  while ((region = regions.exec(markdown)) !== null) {
+    // Linkify the plain gap before this protected region …
+    out += linkifyPlainSegment(markdown.slice(lastIndex, region.index));
+    // … then copy the protected region verbatim.
+    out += region[0];
+    lastIndex = region.index + region[0].length;
+    // Guard against a zero-length match (shouldn't happen with these patterns).
+    if (regions.lastIndex === region.index) regions.lastIndex++;
+  }
+
+  out += linkifyPlainSegment(markdown.slice(lastIndex));
+  return out;
+}


### PR DESCRIPTION
## Problem

Follow-up to #801/#804. In a German answer that lists references as bullets, only the **bold** `1. Timotheus 2,1-2` in a paragraph was linked — every reference in the bulleted list (`Römer 12,14`, `Matthäus 5,44`, `Lukas 6,28`, `Apostelgeschichte 7,60`, `Römer 13,1-7`, …) stayed plain text.

## Root cause (proven)

The web highlighted verses via **per-element React-Markdown renderers**, running the logic only inside the custom `p` renderer's string children. A *tight* markdown list puts text directly in `<li>` (not wrapped in `<p>`), so list items — and headings, table cells — were never processed. Confirmed with a `renderToStaticMarkup` repro: `<li>Römer 12,14: "…"</li>` (raw text, no `<p>`), while paragraphs do go through the `p` renderer.

## Fix — adopt Android's general, string-level approach

Android doesn't have this bug because `injectVerseLinks` rewrites references into `verse://` links in the raw markdown **string** *before* rendering. This brings the same model to the web.

- **`frontend/src/lib/linkifyVerses.ts` (new)** — scan the markdown, gate with `isKnownBook`, rewind on rejection (reusing the shared pattern from #801/#804 so comma separators just work), and wrap each reference as `[<original>](verse://<book>/<chapter>/<verse>)`. Protects fenced/inline code, HTML comments (the `VERSES:` marker), and existing links. **Bonus:** wrapping a numbered book in `[ ]` stops CommonMark from parsing the `1.` in `1. Petrus 3,9` as an ordered-list marker, so those link too.
- **`ChatMessage.tsx`** — pre-linkify assistant content; add a `verse://` branch to the `a` renderer (parse book/chapter/verse from the href); add a `urlTransform` that preserves the `verse://` scheme (react-markdown's default sanitizer strips it); add an `li` renderer so quotes inside list items are highlighted too.
- **`page.test.tsx`** — its `react-markdown` mock now reduces `[text](url)` → `text` (what real react-markdown renders), and its `verseExtraction` mock exposes `isKnownBook` (linkify calls it at render time).

**Android:** no change — it already links at the string level. **Backend:** unchanged.

## Testing

- New `linkifyVerses.test.ts` (13 cases): refs in prose and list lines, comma refs, ranges, the numbered-book/list-marker case, greedy-over-match rewind, and that code/HTML-comment/existing-link regions are left untouched.
- `ChatMessage.verseMarking.test.tsx`: renders the reported German message and asserts **every** bullet reference is an amber clickable span (not just the bold one), a list ref click calls `onVerseClick("Römer", 12, 14)`, and bullet quotes are highlighted.
- Full web suite green — **676 tests**. Typecheck + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2TdG9bWoKWzW2jGVfyNuF)_