### PR TITLE
fix(api): repair weekly report 500 and harden its workflow

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -10,6 +10,9 @@ name: Weekly Report
 # Postgres cannot send email, so the schedule lives here rather than in
 # pg_cron; the backend (which already has DB + SMTP configured) does the work.
 #
+# Full architecture, configuration, and troubleshooting guide:
+#   docs/WEEKLY_REPORT.md
+#
 # Required repo secrets:
 #   MONITOR_PROBE_SECRET - shared secret; must match settings.monitor_probe_secret
 #                          in the deployed backend (same one prod-monitor uses).
@@ -45,7 +48,7 @@ jobs:
   weekly-report:
     name: Send weekly digest
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Trigger weekly report
         env:
@@ -53,17 +56,69 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
         run: |
           set -o pipefail
-          resp=$(curl -fsS --max-time 60 -X POST \
-            "${BACKEND_URL%/}/api/v1/admin/weekly-report?dry_run=${DRY_RUN}" \
-            -H "X-Monitor-Probe-Secret: ${MONITOR_PROBE_SECRET}")
-          echo "$resp" | jq '{dry_run, email_sent}' || echo "$resp"
-          # Fail the job if a live run did not actually send the email
-          # (e.g. SMTP disabled/misconfigured in the backend).
+
+          if [ -z "$MONITOR_PROBE_SECRET" ]; then
+            echo "::error::MONITOR_PROBE_SECRET secret is not set on the repository;" \
+              "the backend would reject the request with 401. See docs/WEEKLY_REPORT.md."
+            exit 1
+          fi
+
+          url="${BACKEND_URL%/}/api/v1/admin/weekly-report?dry_run=${DRY_RUN}"
+
+          # Retry only transient failures: connection errors (curl exit != 0 ->
+          # http_code=000) and 502/503/504 (gateway / Container Apps cold start).
+          # A 500 is a real backend bug and is NOT retried, both to fail loudly
+          # and to avoid any duplicate-email edge case.
+          attempt=1
+          max_attempts=3
+          while :; do
+            http_code=$(curl -sS -o resp.json -w '%{http_code}' --max-time 60 -X POST \
+              "$url" -H "X-Monitor-Probe-Secret: ${MONITOR_PROBE_SECRET}") || http_code=000
+
+            if [ "$http_code" = "200" ]; then
+              break
+            fi
+
+            case "$http_code" in
+              000|502|503|504)
+                if [ "$attempt" -lt "$max_attempts" ]; then
+                  echo "Attempt ${attempt}/${max_attempts} got HTTP ${http_code}; retrying in $((attempt * 15))s..."
+                  sleep $((attempt * 15))
+                  attempt=$((attempt + 1))
+                  continue
+                fi
+                ;;
+            esac
+
+            echo "::error::weekly-report request failed with HTTP ${http_code} (see docs/WEEKLY_REPORT.md)"
+            echo "Response body:"
+            cat resp.json 2>/dev/null || echo "(no response body)"
+            exit 1
+          done
+
+          echo "Backend response:"
+          jq '{dry_run, email_sent}' resp.json
+
+          {
+            echo "### Weekly report"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| HTTP status | ${http_code} |"
+            echo "| dry_run | $(jq -r '.dry_run' resp.json) |"
+            echo "| email_sent | $(jq -r '.email_sent' resp.json) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
           if [ "$DRY_RUN" = "true" ]; then
-            echo "$resp" | jq -e '.dry_run == true' > /dev/null
+            jq -e '.dry_run == true' resp.json > /dev/null || {
+              echo "::error::backend did not honor dry_run=true"
+              exit 1
+            }
           else
-            echo "$resp" | jq -e '.email_sent == true' > /dev/null || {
-              echo "::error::weekly report did not send (email_sent != true)"
+            # Fail the job if a live run did not actually send the email
+            # (e.g. SMTP disabled/misconfigured in the backend).
+            jq -e '.email_sent == true' resp.json > /dev/null || {
+              echo "::error::weekly report did not send (email_sent != true) — check backend SMTP configuration"
               exit 1
             }
           fi

--- a/api/reports/weekly_report.py
+++ b/api/reports/weekly_report.py
@@ -258,6 +258,10 @@ async def build_weekly_report(
     except ProgrammingError as exc:
         if not _is_missing_sessions_schema(exc):
             raise
+        # The failed statement leaves the transaction aborted (SQLSTATE 25P02);
+        # without a rollback the remaining queries in this session would all
+        # fail with InFailedSQLTransaction and turn into a 500.
+        await db.rollback()
         logger.warning(
             "Weekly report sessions analytics unavailable; falling back to zero engagement stats",
             extra={"error": str(exc)},

--- a/api/tests/test_weekly_report.py
+++ b/api/tests/test_weekly_report.py
@@ -150,6 +150,7 @@ async def test_build_report_falls_back_when_sessions_schema_is_missing(
         return action
 
     db.execute = AsyncMock(side_effect=execute)
+    db.rollback = AsyncMock()
 
     report = await build_weekly_report(db, now=NOW)
 
@@ -161,6 +162,9 @@ async def test_build_report_falls_back_when_sessions_schema_is_missing(
     assert report.engagement.top_languages == []
     assert report.new_sessions_prev == 0
     assert db.execute.await_count == 5
+    # The failed sessions query aborts the transaction; the fallback must roll
+    # it back or the remaining queries die with InFailedSQLTransaction.
+    db.rollback.assert_awaited_once()
 
 
 def _report_with_comment(comment: str) -> WeeklyReport:

--- a/api/tests/test_weekly_report_integration.py
+++ b/api/tests/test_weekly_report_integration.py
@@ -1,0 +1,142 @@
+"""
+Integration test that runs ``build_weekly_report`` against a live Postgres
+instead of mocking ``db.execute``.
+
+Why this file exists
+--------------------
+The weekly digest broke in production twice in ways mocks cannot catch:
+
+* The production database predates the ``sessions`` table (it was only in
+  ``scripts/init.sql``, never a migration), so the engagement queries failed
+  with ``UndefinedTable`` and the endpoint returned 500.
+* The first fix (PR #811) caught the error but did not roll back the aborted
+  transaction, so the *next* query died with ``InFailedSQLTransaction`` — an
+  error state that only exists on a real connection, which is exactly what the
+  mock-based tests in ``test_weekly_report.py`` could not reproduce.
+
+These tests run the builder in an isolated schema, first *without* a
+``sessions`` table (must fall back to zero engagement, not raise) and then
+*with* it, created from the real migration file so the DDL is exercised too.
+
+Skips automatically when no Postgres is reachable (e.g. local runs without a
+DB). CI's ``backend-tests`` job provides a service container with
+``DATABASE_URL`` set, so these run on every PR.
+"""
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from feedback.models import Base, ContactSubmission, Feedback
+from reports.weekly_report import build_weekly_report
+from scripture.database import get_async_database_url
+
+# Dedicated schema so the test never touches (or depends on) real tables.
+_SCHEMA = "zz_weekly_report_itest"
+
+_MIGRATION_008 = (
+    Path(__file__).resolve().parents[2] / "scripts" / "migrations" / "008_add_sessions_table.sql"
+)
+
+
+@pytest_asyncio.fixture
+async def reporting_session():
+    """An ``AsyncSession`` whose search_path is an isolated, empty schema
+    containing only the ``feedback`` and ``contact_submissions`` tables —
+    deliberately *no* ``sessions`` table. Skips when Postgres is unreachable."""
+    url, connect_args = get_async_database_url()
+
+    setup_engine = create_async_engine(url, poolclass=NullPool, connect_args=connect_args)
+    try:
+        async with setup_engine.begin() as conn:
+            await conn.execute(text(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE"))
+            await conn.execute(text(f"CREATE SCHEMA {_SCHEMA}"))
+    except Exception as exc:  # connection refused, auth failure, etc.
+        await setup_engine.dispose()
+        pytest.skip(f"Postgres not reachable: {exc}")
+
+    # search_path is set at the connection level (server_settings) rather than
+    # via ``SET`` so the rollback inside build_weekly_report cannot revert it.
+    schema_connect_args = {
+        **connect_args,
+        "server_settings": {"search_path": _SCHEMA},
+    }
+    engine = create_async_engine(url, poolclass=NullPool, connect_args=schema_connect_args)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all,
+            tables=[Feedback.__table__, ContactSubmission.__table__],
+        )
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    session = factory()
+    try:
+        yield session
+    finally:
+        await session.close()
+        await engine.dispose()
+        async with setup_engine.begin() as conn:
+            await conn.execute(text(f"DROP SCHEMA IF EXISTS {_SCHEMA} CASCADE"))
+        await setup_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_build_report_survives_missing_sessions_table(reporting_session: AsyncSession):
+    """Regression for the production 500: with no ``sessions`` table, the
+    builder must fall back to zero engagement and still complete the
+    remaining queries on the same (rolled-back) session."""
+    await reporting_session.execute(
+        text(
+            "INSERT INTO feedback (message_id, rating, created_at)"
+            " VALUES (gen_random_uuid(), 'positive', NOW() - INTERVAL '1 day'),"
+            "        (gen_random_uuid(), 'negative', NOW() - INTERVAL '2 days'),"
+            "        (gen_random_uuid(), 'positive', NOW() - INTERVAL '10 days')"
+        )
+    )
+    await reporting_session.commit()
+
+    report = await build_weekly_report(reporting_session)
+
+    assert report.feedback.total == 2
+    assert report.feedback.positive == 1
+    assert report.feedback.negative == 1
+    # Ran after the failed sessions query — proves the transaction was usable.
+    assert report.feedback_total_prev == 1
+    assert report.engagement.active_sessions == 0
+    assert report.engagement.top_languages == []
+    assert report.new_sessions_prev == 0
+
+
+@pytest.mark.asyncio
+async def test_build_report_with_sessions_table_from_migration(reporting_session: AsyncSession):
+    """With the ``sessions`` table created from the real migration 008 DDL,
+    the engagement queries run for real and count seeded sessions."""
+    # asyncpg runs one statement per execute, so apply the file statement-wise.
+    for statement in _MIGRATION_008.read_text().split(";"):
+        if statement.strip():
+            await reporting_session.execute(text(statement))
+    await reporting_session.execute(
+        text(
+            "INSERT INTO sessions"
+            " (session_token, created_at, last_activity, message_count, language, is_mobile)"
+            " VALUES"
+            " ('web-1', NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 hour', 5, 'en', FALSE),"
+            " ('mob-1', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 hours', 3, 'it', TRUE),"
+            " ('old-1', NOW() - INTERVAL '30 days', NOW() - INTERVAL '20 days', 9, 'en', FALSE)"
+        )
+    )
+    await reporting_session.commit()
+
+    report = await build_weekly_report(reporting_session)
+
+    assert report.engagement.active_sessions == 2
+    assert report.engagement.new_sessions == 2
+    assert report.engagement.total_messages == 8
+    assert report.engagement.web_sessions == 1
+    assert report.engagement.mobile_sessions == 1
+    assert {lc.language for lc in report.engagement.top_languages} == {"en", "it"}

--- a/docs/USAGE_TRACKING.md
+++ b/docs/USAGE_TRACKING.md
@@ -15,8 +15,11 @@ us a stable "user" identifier for DAU/MAU counting without requiring sign-up.
 
 ### Sessions Table
 
-Each chat request upserts a row in the `sessions` table
-(`scripts/init.sql`). Columns:
+Each chat request upserts a row in the `sessions` table. The table is created
+by `scripts/init.sql` on fresh databases and by
+`scripts/migrations/008_add_sessions_table.sql` on existing ones (production
+predates the table, so only the migration creates it there). It also feeds the
+weekly digest email — see [WEEKLY_REPORT.md](WEEKLY_REPORT.md). Columns:
 
 | Column | Type | Purpose |
 |--------|------|---------|

--- a/docs/WEEKLY_REPORT.md
+++ b/docs/WEEKLY_REPORT.md
@@ -1,0 +1,125 @@
+# Weekly Activity Report
+
+Automated weekly digest email covering feedback, contact submissions, and
+session engagement over the last 7 days. Covers both the web app and the
+Android app, since both hit the same API.
+
+## Architecture
+
+```
+GitHub Actions cron (Sunday 18:00 UTC)
+  .github/workflows/weekly-report.yml
+        │  POST /api/v1/admin/weekly-report?dry_run=false
+        │  Header: X-Monitor-Probe-Secret: <shared secret>
+        ▼
+Backend (Azure Container Apps)
+  api/routes/admin.py → trigger_weekly_report
+        │
+        ├─ api/reports/weekly_report.py → build_weekly_report(db)
+        │    Queries Postgres: feedback, contact_submissions, sessions
+        │
+        └─ api/utils/email_service.py → send_email(...)
+             SMTP2GO → settings.weekly_report_recipient
+```
+
+Postgres cannot send email, so the schedule lives in GitHub Actions rather
+than `pg_cron`; the backend (which already has DB + SMTP configured) does the
+actual work.
+
+The endpoint is internal (`include_in_schema=False`) and authenticated with
+the same shared-secret probe header the production monitor uses
+(`utils/monitor_probe.py`). It is fail-closed: if the secret is unset on the
+server, every request gets 401.
+
+## What's in the digest
+
+Built by `build_weekly_report` (`api/reports/weekly_report.py`):
+
+| Section | Source table | Contents |
+| --- | --- | --- |
+| Feedback | `feedback` | totals, positive/negative ratio, recent negative comments, week-over-week delta |
+| Contact | `contact_submissions` | totals grouped by subject |
+| Engagement | `sessions` | active/new sessions, messages, web vs. mobile split, top languages, week-over-week delta |
+
+If the `sessions` table (or one of its analytics columns) is missing, the
+digest degrades gracefully to zero engagement stats instead of failing — see
+[Incident history](#incident-history) below.
+
+## Configuration
+
+### GitHub repository (Actions)
+
+| Kind | Name | Purpose |
+| --- | --- | --- |
+| Secret | `MONITOR_PROBE_SECRET` | Shared secret; must match `settings.monitor_probe_secret` in the deployed backend (same one `prod-monitor.yml` uses) |
+| Variable | `BACKEND_URL` | Backend base URL; the workflow falls back to the hardcoded production URL when unset |
+
+### Backend settings (`api/config.py`)
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `monitor_probe_secret` | unset (fail-closed) | Authenticates the probe header |
+| `weekly_report_recipient` | `support@voxquieta.org` | Digest recipient |
+| SMTP2GO settings | — | Used by `email_service` to actually send |
+
+## Running it manually
+
+**Actions → Weekly Report → Run workflow.** Set `dry_run=true` to compute the
+digest and return it as JSON without sending an email — useful to validate
+config after a deploy.
+
+Or directly with curl:
+
+```bash
+curl -X POST \
+  "https://<backend>/api/v1/admin/weekly-report?dry_run=true" \
+  -H "X-Monitor-Probe-Secret: $MONITOR_PROBE_SECRET" | jq .
+```
+
+## Troubleshooting
+
+The workflow prints the HTTP status and the response body on failure, and
+writes a result table to the run's step summary.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Job fails before curl: "MONITOR_PROBE_SECRET secret is not set" | Repo secret missing | Add the secret under repo Settings → Secrets → Actions |
+| HTTP 401 | Secret mismatch with `settings.monitor_probe_secret`, or unset on the backend | Align the repo secret with the deployed backend config |
+| HTTP 500 | Unhandled backend exception | Check Container Apps logs (`az containerapp logs show` or Log Analytics); see incident history below |
+| HTTP 000 / 502 / 503 / 504 | Backend unreachable / cold start / gateway | The workflow retries these 3× with backoff; persistent failures mean the backend is down — check `prod-monitor` |
+| `email_sent != true` | SMTP disabled or misconfigured in the backend | Verify SMTP2GO settings/key in the deployed environment |
+| Engagement section all zeros | `sessions` table missing or empty | Ensure migration `008_add_sessions_table.sql` has been applied |
+
+## Incident history
+
+**2026-06 → 2026-07: every run failed with HTTP 500.** Two stacked causes:
+
+1. The production database predates the `sessions` table — it was only
+   defined in `scripts/init.sql`, which runs solely on fresh DB
+   initialization, and was never shipped as a migration. The digest's
+   engagement queries (`FROM sessions`) failed with `UndefinedTable`.
+   Fixed by `scripts/migrations/008_add_sessions_table.sql`.
+2. The first fallback fix (PR #811) caught that error but did not roll back
+   the aborted Postgres transaction, so the next query on the same session
+   died with `InFailedSQLTransaction` — still a 500. Fixed by an explicit
+   `db.rollback()` in the fallback path of `build_weekly_report`, with a
+   real-Postgres regression test in
+   `api/tests/test_weekly_report_integration.py` (mock-based tests cannot
+   reproduce transaction state).
+
+The workflow originally used `curl -f`, which discards the response body and
+made every failure look identical; it now prints status + body and retries
+transient errors.
+
+## Tests
+
+```bash
+cd api
+pytest tests/test_weekly_report.py               # unit (mocked DB)
+pytest tests/test_weekly_report_integration.py   # real Postgres; skips if unreachable
+pytest tests/test_admin_report.py                # endpoint auth/wiring
+```
+
+The integration tests run in CI (the backend-tests job provides a Postgres
+service container) and exercise both the missing-table fallback and the
+migration DDL.

--- a/scripts/migrations/008_add_sessions_table.sql
+++ b/scripts/migrations/008_add_sessions_table.sql
@@ -1,0 +1,27 @@
+-- Migration 008: Add sessions table for usage tracking (DAU/MAU)
+-- Date: 2026-07-04
+-- Purpose: The sessions table was only defined in scripts/init.sql, which runs
+--   solely on fresh database initialization. Databases created before the
+--   table was introduced (including production) never got it, which silently
+--   broke per-request session tracking (utils/session_tracker.py) and made the
+--   weekly digest engagement queries fail (reports/weekly_report.py), causing
+--   the Weekly Report workflow to receive HTTP 500.
+--
+-- DDL is copied verbatim from scripts/init.sql so fresh and migrated databases
+-- end up identical.
+--
+-- Safe to run multiple times (idempotent)
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id SERIAL PRIMARY KEY,
+    session_token VARCHAR(64) UNIQUE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_activity TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    message_count INTEGER DEFAULT 0,
+    language VARCHAR(10),
+    user_agent TEXT,
+    is_mobile BOOLEAN DEFAULT FALSE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(session_token);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity);


### PR DESCRIPTION
## Summary

The Weekly Report workflow ([weekly-report.yml](https://github.com/zioalex/getinspiredbythebible/actions/workflows/weekly-report.yml)) has failed on **every run since it was added** (3 scheduled + 2 manual). The workflow itself was fine — the backend returned HTTP 500, and `curl -f` discarded the response body so the logs never said why.

Two stacked root causes:

1. **Production DB has no `sessions` table.** It was only defined in `scripts/init.sql`, which runs solely on fresh database initialization — prod predates it. The digest's engagement queries (`FROM sessions`) failed with `UndefinedTable`.
2. **PR #811's fallback was incomplete.** It catches that error and falls back to zero engagement stats, but never rolls back the aborted Postgres transaction — so the next query on the same session dies with `InFailedSQLTransaction` (SQLSTATE 25P02). That's why runs still 500ed after #811 deployed.

## Changes

- **`api/reports/weekly_report.py`** — `await db.rollback()` in the missing-schema fallback so the remaining queries run in a fresh transaction.
- **`scripts/migrations/008_add_sessions_table.sql`** — creates the missing `sessions` table (DDL copied verbatim from `init.sql`, idempotent). Applied automatically by the `run-migrations` job on deploy. Also un-breaks the silently failing per-request session tracking (`utils/session_tracker.py`) in production.
- **`api/tests/test_weekly_report_integration.py`** (new) — real-Postgres regression tests in an isolated schema: the no-`sessions` fallback (reproduces the aborted-transaction failure that mock-based tests cannot) and the migration DDL itself. Skips when no DB is reachable; runs in CI's Postgres service container.
- **`.github/workflows/weekly-report.yml`** — fail fast when `MONITOR_PROBE_SECRET` is unset; print HTTP status + response body on failure; retry connection errors and 502/503/504 up to 3× with backoff (deliberately not 500 — real bug, and avoids duplicate-email edges); write a result table to the step summary.
- **`docs/WEEKLY_REPORT.md`** (new) — architecture, configuration, manual/dry runs, troubleshooting table, incident history. Cross-linked from `docs/USAGE_TRACKING.md`.

## Verification

- 13/13 tests pass (`test_weekly_report.py`, `test_weekly_report_integration.py`, `test_admin_report.py`) against a real Postgres 16.
- Removing the one-line rollback fix makes the new regression test fail with the exact production error (`InFailedSQLTransactionError: current transaction is aborted`).
- Migration 008 applied twice via the same asyncpg call `run_migrations.py` uses — idempotent, resulting schema identical to `init.sql`.
- Workflow bash logic smoke-tested against a fake backend: 503→503→200 retries then succeeds; 500 fails immediately with body shown (single request); missing secret exits before any request.
- yamllint (repo config), ruff, and black all pass.

## Post-merge

1. Deploy applies migration 008 automatically.
2. Actions → Weekly Report → Run workflow with `dry_run=true` should go green.
3. First live email: Sunday 18:00 UTC (or trigger a manual non-dry run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiV7H5tJqx8xW7hyruQMDQ