### PR TITLE
fix(api): resolve _IncludedRouter 500 on CORS preflight (FastAPI 0.137 vs OTel)

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,12 @@ openai==1.109.1
 # Azure Monitor (Application Insights via OpenTelemetry)
 # azure-monitor-opentelemetry pins its opentelemetry-sdk and instrumentation
 # versions exactly, so we let it manage those transitive dependencies.
-azure-monitor-opentelemetry==1.8.8
+# NOTE: keep this >= 1.8.9. 1.8.8 pinned opentelemetry-instrumentation-fastapi==0.61b0,
+# whose _get_route_details does `route.path` on every app.routes entry and crashes on the
+# `_IncludedRouter` object that FastAPI 0.137 / starlette 1.3.1 now stores there
+# ('_IncludedRouter' object has no attribute 'path' → HTTP 500 on every CORS preflight).
+# 1.8.9 pulls 0.64b0, which handles _IncludedRouter. See BITB-064.
+azure-monitor-opentelemetry==1.8.9
 
 # Azure Content Safety (for multi-language harm detection)
 azure-ai-contentsafety==1.0.0

--- a/api/tests/test_otel_routing.py
+++ b/api/tests/test_otel_routing.py
@@ -1,0 +1,97 @@
+"""Regression test for the 2026-07-05 `_IncludedRouter` 500 incident.
+
+FastAPI 0.137 / starlette 1.3.1 store an internal ``_IncludedRouter`` object in
+``app.routes`` for every ``include_router(...)`` call. Older
+``opentelemetry-instrumentation-fastapi`` (0.61b0, pinned transitively by
+``azure-monitor-opentelemetry==1.8.8``) walked ``app.routes`` and did
+``route.path`` on every entry, crashing with
+``'_IncludedRouter' object has no attribute 'path'`` and returning **HTTP 500 on
+every CORS preflight** (``OPTIONS /api/v1/*``). Direct GET/POST were unaffected,
+so the break was browser-only.
+
+Production applies this instrumentation only when
+``APPLICATIONINSIGHTS_CONNECTION_STRING`` is set (``main.py``), so no unit or
+integration test previously exercised the instrumented request path. This test
+closes that gap deterministically — it forces instrumentation on regardless of
+environment and would fail against the old pin.
+
+See BITB-064 for the production smoke-test / alerting follow-up.
+"""
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+# Skip cleanly where the OpenTelemetry FastAPI instrumentation isn't installed
+# (it ships transitively via azure-monitor-opentelemetry, present in CI).
+FastAPIInstrumentor = pytest.importorskip(
+    "opentelemetry.instrumentation.fastapi"
+).FastAPIInstrumentor
+
+ALLOWED_ORIGIN = "https://voxquieta.org"
+
+
+def _build_instrumented_app() -> FastAPI:
+    """Mirror production route registration: an included router under /api/v1,
+    CORS middleware, and FastAPIInstrumentor applied — the exact combination that
+    regressed. ``include_router`` is what puts an ``_IncludedRouter`` in
+    ``app.routes``."""
+    app = FastAPI()
+
+    router = APIRouter(prefix="/chat", tags=["chat"])
+
+    @router.post("/stream")
+    async def chat_stream():  # pragma: no cover - trivial handler
+        return {"ok": True}
+
+    @router.get("/verse")
+    async def chat_verse():  # pragma: no cover - trivial handler
+        return {"ok": True}
+
+    FastAPIInstrumentor.instrument_app(app)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[ALLOWED_ORIGIN],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(router, prefix="/api/v1")
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def instrumented_client() -> TestClient:
+    # raise_server_exceptions=False so a 500 is returned as a response we can
+    # assert on, rather than re-raised into the test.
+    return TestClient(_build_instrumented_app(), raise_server_exceptions=False)
+
+
+def test_cors_preflight_on_included_route_does_not_500(instrumented_client):
+    """The exact failing request from the incident: a browser CORS preflight to
+    an included-router route must not 500 under OTel instrumentation."""
+    resp = instrumented_client.options(
+        "/api/v1/chat/stream",
+        headers={
+            "Origin": ALLOWED_ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type,x-turnstile-token",
+        },
+    )
+    assert resp.status_code != 500, (
+        "CORS preflight to an included route returned 500 — the "
+        "'_IncludedRouter' object has no attribute 'path' regression "
+        "(FastAPI vs opentelemetry-instrumentation-fastapi version skew)."
+    )
+    # A correct preflight is a 2xx that echoes the CORS allow headers.
+    assert resp.status_code < 400
+    assert resp.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+
+
+def test_real_requests_on_included_route_do_not_500(instrumented_client):
+    """Direct POST/GET stayed working even under the broken pin; assert they keep
+    working so the fix doesn't regress the non-preflight path."""
+    assert instrumented_client.post("/api/v1/chat/stream").status_code != 500
+    assert instrumented_client.get("/api/v1/chat/verse").status_code != 500

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -182,6 +182,36 @@ positives on Bible queries. This unblocks it.
 > `docs/TURBOVEC_EVALUATION.md` (turbovec evaluated and rejected — relevance, not infra,
 > is the lever).
 
+### 🎯 BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
+
+**Status:** 🎯 Todo — follow-up from the 2026-07-05 `_IncludedRouter` 500 incident
+**Size:** M (one new synthetic probe + Telegram wiring; optional Azure availability test)
+**Created:** 2026-07-05
+
+**As** the operator, **I want** a synthetic monitor that hits the API the way a browser does (a
+cross-origin CORS preflight) and the production request path exercised with OpenTelemetry
+instrumentation on, **so that** a browser-only outage pages me on Telegram in minutes instead of
+waiting for a user report.
+
+**Why P1:** A total browser-facing chat outage shipped to production (FastAPI 0.137's `_IncludedRouter`
+crashed the pinned OpenTelemetry instrumentation, returning HTTP 500 on every `OPTIONS /api/v1/*`
+preflight) and **no monitor, Azure alert, or Telegram notification fired**. The break was browser-only:
+`OPTIONS` preflight → 500, but direct `GET`/`POST` → 200. Every safety net (Azure `/health/ready` test,
+the `synthetic-chat` and `verse-search` probes) sends non-browser requests, so all stayed green — the
+same reason native Android kept working.
+
+**Acceptance Criteria (summary — full story has detail):**
+
+- [ ] New CORS-preflight synthetic probe (`OPTIONS /api/v1/chat/stream` with `Origin` +
+      `Access-Control-Request-*` headers) asserts 2xx/204 and the `Access-Control-Allow-*` response headers
+- [ ] Wired into `prod-monitor.yml` on the 5-min schedule via the shared `notify-telegram` action
+- [ ] (Recommended) Azure availability test parity so the always-on path also alerts
+- [ ] Troubleshooting runbook note: "browser 500 but curl/app fine" ⇒ CORS-preflight / OTel path
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md`
+
+---
+
 ### 🚧 BITB-061: Make the Abuse-Control Stack Fail Closed (Turnstile, Rate Limits, Content Safety)
 
 **Status:** 🚧 In Progress — Turnstile phase complete; rate-limiter and content-safety phases remain

--- a/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
+++ b/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
@@ -1,0 +1,101 @@
+# BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
+
+**Status:** 🎯 Todo (follow-up carved out of the 2026-07-05 `_IncludedRouter` 500 incident)
+**Priority:** P1 (High) — a total browser-facing chat outage shipped to production and **no monitor,
+alert, or Telegram notification fired**; only a user report surfaced it.
+**Size:** M (1-2 days — one new synthetic probe + wiring; optional Azure availability test)
+**Created:** 2026-07-05
+**Incident ref:** FastAPI 0.137 / starlette 1.3.1 put an `_IncludedRouter` in `app.routes`; the pinned
+OpenTelemetry FastAPI instrumentation (`azure-monitor-opentelemetry==1.8.8` → `opentelemetry-instrumentation-fastapi==0.61b0`)
+did `route.path` on it and raised `'_IncludedRouter' object has no attribute 'path'` on **every CORS
+preflight**, returning HTTP 500 for `OPTIONS /api/v1/*`. Code fix tracked separately (requirements bump
+to `azure-monitor-opentelemetry==1.8.9` + an instrumented-routing regression test).
+
+## User Story
+
+As the operator of Vox Quieta, I want a synthetic monitor that hits the API **the way a browser does**
+— a cross-origin CORS preflight — and I want the production request path exercised **with
+OpenTelemetry instrumentation on**, so that an outage which only affects browser traffic pages me on
+Telegram within minutes instead of waiting for a user to report a broken site.
+
+## Problem / Motivation
+
+The `_IncludedRouter` 500 broke **only the browser CORS preflight** (`OPTIONS` with `Origin` +
+`Access-Control-Request-Method`). The actual `GET`/`POST` requests returned 200. Reproduced locally
+under the exact production pins:
+
+| Request                                              | Broken pin (0.61b0) | Fixed pin (0.64b0) |
+| ---------------------------------------------------- | ------------------- | ------------------ |
+| `OPTIONS /api/v1/chat/stream` (browser preflight)    | **500**             | 200                |
+| `POST /api/v1/chat/stream` (native app / curl)       | 200                 | 200                |
+| `GET /health/ready`                                  | 200                 | 200                |
+
+Every existing safety net sends requests the *non-browser* way, so all of them stayed green:
+
+1. **Azure availability test** pings `GET /health/ready` (`deployment/main.tf:267-286`) → 200 → green.
+2. **`synthetic-chat` probe** (`scripts/monitor/synthetic_chat.py`, run by
+   `.github/workflows/prod-monitor.yml` every 5 min) POSTs directly via `httpx` with the
+   `MONITOR_PROBE_SECRET` bypass → 200 → green. `httpx`/curl never send a CORS preflight; that is
+   browser-only behavior.
+3. **`verse-search` probe** — same, a direct `GET`/`POST`.
+
+Net: the browser is the *only* client that broke, and **no probe ever behaves like a browser**, so
+`prod-monitor.yml` never failed, the `notify-telegram` action never fired, and Azure Monitor never
+alerted. The `android works good` observation during triage was the tell — native Android sends no
+preflight, so it was unaffected, exactly like every monitor.
+
+A second, deeper gap: the crashing layer (`FastAPIInstrumentor.instrument_app`) runs **only in
+production**, gated on `APPLICATIONINSIGHTS_CONNECTION_STRING` (`api/main.py:266-273`). No unit or
+integration test sets that var, so the instrumented request path — the exact thing that failed —
+had zero automated coverage before this incident. (Closing the unit/CI half is tracked in the code
+fix; this story covers the *production* smoke + alert half.)
+
+## Acceptance Criteria
+
+- [ ] **Browser-preflight synthetic probe.** New probe (e.g. `scripts/monitor/synthetic_preflight.py`)
+      sends a real cross-origin CORS preflight to a representative included-router route — at minimum
+      `OPTIONS /api/v1/chat/stream` with `Origin: https://voxquieta.org`,
+      `Access-Control-Request-Method: POST`, `Access-Control-Request-Headers: content-type,x-turnstile-token`
+      (mirror the failing request from the incident) — and **asserts 2xx/204 AND the presence of the
+      expected `Access-Control-Allow-Origin` / `Access-Control-Allow-Methods` headers**. It fails on
+      the 500 this incident produced.
+- [ ] **Wired into `prod-monitor.yml`** as its own job on the existing `*/5 * * * *` schedule, using
+      the shared `./.github/actions/notify-telegram` action so a failure pages the same Telegram chat
+      as the other probes. Reuse the existing state-branch / de-dup mechanism the other jobs use.
+- [ ] **(Recommended) Azure availability test parity.** Add a second `azurerm_application_insights_web_test`
+      (or upgrade the existing one) that issues the CORS preflight, so the always-on Azure-native path
+      also alerts — not just the 5-min GitHub cron. *If cost/complexity is a concern, the GitHub probe
+      alone satisfies the story; note the decision.*
+- [ ] **Runbook note** in `docs/TROUBLESHOOTING.md`: "browser 500 but native app / curl fine" ⇒ suspect
+      the CORS-preflight / OTel-instrumentation path and a FastAPI-vs-instrumentation version skew.
+
+## Notes / Reuse
+
+- Notification plumbing already exists and is the model to copy: `.github/actions/notify-telegram/action.yml`,
+  the per-job `Notify Telegram` steps, and the `STATE_BRANCH` de-dup in `.github/workflows/prod-monitor.yml`.
+- Probe scaffolding to mirror: `scripts/monitor/synthetic_chat.py` and `scripts/monitor/synthetic_search.py`
+  (arg parsing, `--detail-out`, `httpx`, `MONITOR_PROBE_SECRET`). The preflight probe is simpler — no auth,
+  no body; it only needs to send the `OPTIONS` with the three CORS request headers and assert the response.
+- Azure availability test to mirror/extend: `deployment/main.tf:267-286` (`/health/ready` web test) and the
+  alert wiring in `deployment/monitoring.tf`. The Telegram bridge (`ops_email` action group +
+  `logic_app_workflow.telegram_alert`, BITB-056) already reposts Azure alerts to Telegram.
+- Related: **BITB-055 / BITB-056 / BITB-057** — this is the same "make it loud" observability thread; the
+  new signal here is *browser-shaped* traffic, which none of those covered.
+
+## Out of Scope
+
+- The code fix for the `_IncludedRouter` 500 itself (requirements bump + instrumented-routing regression
+  test) — shipped separately alongside this story's creation.
+- Full browser-automation / Playwright synthetic against the deployed frontend (heavier; a raw CORS
+  preflight is enough to catch this class of failure).
+- Rate-limiter / content-safety observability (tracked under BITB-061).
+
+## Verification
+
+- Point the new probe at a backend still running the broken `1.8.8` pin (or the local repro) and confirm it
+  **fails** (500 / missing CORS headers) and produces a Telegram alert; point it at the fixed `1.8.9` build
+  and confirm it **passes** (2xx + `Access-Control-Allow-*` headers present).
+- Trigger `prod-monitor.yml` via `workflow_dispatch` with `force_alert` and confirm the preflight job's
+  Telegram message renders through `notify-telegram`.
+- If the Azure web test is added: `terraform -chdir=deployment fmt -check` + `validate`, and `plan` (no
+  apply) renders the new availability test + its alert.


### PR DESCRIPTION
## Summary

The frontend broke with **HTTP 500 on `OPTIONS /api/v1/chat/stream`** (the browser CORS preflight). Root cause is a FastAPI-vs-OpenTelemetry version skew, **not** the Turnstile change that shipped in the same release (1.39.0).

- **FastAPI 0.137.0 / starlette 1.3.1** (bumped in #748) now store an internal **`_IncludedRouter`** object in `app.routes` for every `include_router(...)`.
- The `opentelemetry-instrumentation-fastapi==0.61b0` pinned transitively by `azure-monitor-opentelemetry==1.8.8` does `route.path` on every route entry → `'_IncludedRouter' object has no attribute 'path'` → **HTTP 500 on every CORS preflight**.
- The break was **browser-only**: direct `GET`/`POST` returned 200 (native Android and every synthetic monitor stayed green); only the browser preflight failed.

Reproduced the exact production traceback (`asgi/__init__.py:755` → `fastapi/__init__.py:503` → `:490`) locally under the same pins.

| Request | broken 0.61b0 | fixed 0.64b0 |
|---|---|---|
| `OPTIONS /api/v1/chat/stream` (browser preflight) | **500** | 200 |
| `POST /api/v1/chat/stream` (Android / curl) | 200 | 200 |
| `GET /health/ready` | 200 | 200 |

## Changes

- **`api/requirements.txt`** — bump `azure-monitor-opentelemetry` `1.8.8 → 1.8.9`, which pulls `opentelemetry-instrumentation-fastapi==0.64b0` (handles `_IncludedRouter`). Full requirements verified to resolve cleanly on Python 3.12.
- **`api/tests/test_otel_routing.py`** (new) — forces `FastAPIInstrumentor.instrument_app` onto an app with an included `/api/v1` router (the production combination unit tests never exercised, because instrumentation is gated on `APPLICATIONINSIGHTS_CONNECTION_STRING`) and asserts a CORS preflight does not 500. **Proven guard: fails against 0.61b0, passes against 0.64b0.**
- **`docs/BACKLOG_STORIES/BITB-064-…md`** + **`docs/BACKLOG.md`** — follow-up story for the observability gap: no synthetic probe sends a browser CORS preflight and none exercises the instrumented request path, so nothing alerted and no Telegram notification fired during the outage.

## Why we missed it

1. **No test covered the instrumented path** — `FastAPIInstrumentor.instrument_app` runs only when `APPLICATIONINSIGHTS_CONNECTION_STRING` is set (production-only); no unit/CI/integration env sets it. The new test closes this.
2. **No monitor behaves like a browser** — the Azure `/health/ready` test is a GET, and the `synthetic-chat`/`verse-search` probes POST directly via `httpx`; none sends a CORS preflight, the only request that broke. Tracked in BITB-064.

## Test plan

- [x] Reproduced the exact 500 under `fastapi==0.137.0` + `azure-monitor-opentelemetry==1.8.8`; confirmed 1.8.9 returns 200 on the preflight.
- [x] New regression test fails on 0.61b0, passes on 0.64b0; `ruff` + `black` clean.
- [x] `pip install --dry-run -r api/requirements.txt` resolves cleanly on Python 3.12.
- [ ] Post-deploy: confirm `OPTIONS /api/v1/chat/stream` returns 2xx and the frontend chat streams again. **Note:** the fix only takes effect once the backend image is rebuilt against the updated `requirements.txt` — the running container still has 0.61b0 until redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPLbZLWXnRZeHUCCx2gwzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPLbZLWXnRZeHUCCx2gwzR)_