### PR TITLE
feat(observability): browser smoke test + backend/frontend error alerting (BITB-064/065/066)

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -481,6 +481,7 @@ jobs:
       TF_VAR_turnstile_site_key: ${{ vars['TF_VAR_TURNSTILE_SITE_KEY'] }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
+      TF_VAR_smoke_probe_secret: ${{ secrets.SMOKE_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
       # BITB-056: Azure Monitor -> Telegram bridge. Only the chat id is a TF var; the
       # bot token is written to Key Vault out-of-band (see the deploy job's
@@ -755,6 +756,7 @@ jobs:
       TF_VAR_turnstile_site_key: ${{ vars['TF_VAR_TURNSTILE_SITE_KEY'] }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
+      TF_VAR_smoke_probe_secret: ${{ secrets.SMOKE_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
       # BITB-056: Azure Monitor -> Telegram bridge. Only the chat id is a TF var; the
       # bot token is written to Key Vault out-of-band (see the deploy job's
@@ -1230,6 +1232,7 @@ jobs:
       TF_VAR_turnstile_site_key: ${{ vars['TF_VAR_TURNSTILE_SITE_KEY'] }}
       TF_VAR_turnstile_secret_key: ${{ secrets.TF_VAR_TURNSTILE_SECRET_KEY }}
       TF_VAR_monitor_probe_secret: ${{ secrets.MONITOR_PROBE_SECRET }}
+      TF_VAR_smoke_probe_secret: ${{ secrets.SMOKE_PROBE_SECRET }}
       TF_VAR_alert_email: ${{ secrets.TF_VAR_ALERT_EMAIL }}
       # BITB-056: Azure Monitor -> Telegram bridge. Only the chat id is a TF var; the
       # bot token is written to Key Vault out-of-band (see the deploy job's

--- a/.github/workflows/prod-browser-smoke.yml
+++ b/.github/workflows/prod-browser-smoke.yml
@@ -14,7 +14,15 @@ name: Prod Browser Smoke
 #
 # Required repo secrets:
 #   SMOKE_PROBE_SECRET   - matches settings.smoke_probe_secret in the backend
-#                          (wired via TF_VAR_smoke_probe_secret in azure-deploy.yml)
+#                          (wired via TF_VAR_smoke_probe_secret in azure-deploy.yml).
+#                          One-time setup (generate + set, then redeploy so the
+#                          backend picks it up):
+#                            openssl rand -hex 32 | gh secret set SMOKE_PROBE_SECRET
+#                          Deliberately a SEPARATE secret from MONITOR_PROBE_SECRET —
+#                          this one transits an ephemeral CI browser (injected via
+#                          Playwright addInitScript, never shipped in the bundle),
+#                          so keep it independently rotatable. Until it's set, the
+#                          test in prod-chat-smoke.spec.ts skips (no failure).
 #   TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID - alert delivery (shared with prod-monitor)
 #
 # Manual run: Actions → Prod Browser Smoke → Run workflow (+ force_alert to test Telegram).

--- a/.github/workflows/prod-browser-smoke.yml
+++ b/.github/workflows/prod-browser-smoke.yml
@@ -1,0 +1,83 @@
+name: Prod Browser Smoke
+
+# Real-browser production smoke test (BITB-064).
+#
+# A scheduled Playwright/Chromium run against the deployed site
+# (https://voxquieta.org) that loads the page, submits a chat message, and
+# asserts a streamed assistant reply — exercising the full real journey
+# (rendered frontend → cross-origin CORS preflight → instrumented backend →
+# SSE streaming) that the httpx/curl probes in prod-monitor.yml cannot.
+#
+# Runs hourly rather than every 5 min because a Chromium install is heavy.
+# Passes Cloudflare Turnstile via a smoke-scoped secret injected into the
+# browser at runtime (never shipped in the bundle) — see spec + lib/smoke.ts.
+#
+# Required repo secrets:
+#   SMOKE_PROBE_SECRET   - matches settings.smoke_probe_secret in the backend
+#                          (wired via TF_VAR_smoke_probe_secret in azure-deploy.yml)
+#   TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID - alert delivery (shared with prod-monitor)
+#
+# Manual run: Actions → Prod Browser Smoke → Run workflow (+ force_alert to test Telegram).
+
+# yamllint flags the unquoted `on` key as a YAML 1.1 truthy value.
+"on":
+  schedule:
+    - cron: "17 * * * *" # hourly, offset to avoid the top-of-hour rush
+  workflow_dispatch:
+    inputs:
+      force_alert:
+        description: "Send a test alert to Telegram regardless of outcome"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-browser-smoke-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PLAYWRIGHT_BASE_URL: ${{ vars.FRONTEND_URL || 'https://voxquieta.org' }}
+  STATE_BRANCH: gh-monitor-state
+
+jobs:
+  browser-smoke:
+    name: Browser chat smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.x"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser smoke test
+        id: smoke
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ env.PLAYWRIGHT_BASE_URL }}
+          SMOKE_PROBE_SECRET: ${{ secrets.SMOKE_PROBE_SECRET }}
+        run: npx playwright test prod-chat-smoke.spec.ts
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: browser-smoke
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}

--- a/.github/workflows/prod-monitor.yml
+++ b/.github/workflows/prod-monitor.yml
@@ -2,12 +2,17 @@ name: Prod Monitor
 
 # Production monitoring + alerting via Telegram.
 #
-# Five independent jobs run every 5 minutes:
+# Six independent jobs run every 5 minutes:
 #   - health        : cheap liveness check (/health/live, /health/ready)
 #   - synthetic-chat: real chat round-trip via /api/v1/chat/stream — catches
 #                     the failure mode where the backend returns HTTP 200 with
 #                     an in-band {"type":"error", ...} SSE chunk (e.g. a bad
 #                     OpenRouter API key).
+#   - cross-origin-smoke: browser-shaped probe — sends the real CORS preflight
+#                     (OPTIONS with Origin) then a cross-origin POST to
+#                     /api/v1/chat/stream. Catches browser-only outages that
+#                     direct httpx/curl probes miss (e.g. the 2026-07-05
+#                     _IncludedRouter 500 on preflight, BITB-064).
 #   - verse-search  : semantic search probe via /api/v1/scripture/search —
 #                     validates DB + embedding provider + pgvector are healthy.
 #   - frontend      : checks that the frontend (voxquieta.org) serves HTML.
@@ -142,6 +147,45 @@ jobs:
         with:
           job_status: ${{ job.status }}
           job_name: synthetic-chat
+          state_branch: ${{ env.STATE_BRANCH }}
+          telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}
+          force_alert: ${{ github.event.inputs.force_alert }}
+
+  # ---------------------------------------------------------------------------
+  cross-origin-smoke:
+    name: Cross-origin smoke probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install probe deps
+        run: pip install httpx
+
+      - name: Run cross-origin smoke probe
+        id: probe
+        env:
+          BACKEND_URL: ${{ env.BACKEND_URL }}
+          MONITOR_PROBE_SECRET: ${{ secrets.MONITOR_PROBE_SECRET }}
+          # The browser Origin that hits the API. Must be an allowed CORS origin;
+          # the probe fails if the preflight doesn't echo it back.
+          PROBE_ORIGIN: "https://voxquieta.org"
+          PROBE_MESSAGE: "What does John 3:16 say?"
+          PROBE_TIMEOUT_SECONDS: "30"
+          PROBE_FIRST_CHUNK_SECONDS: "20"
+        run: python scripts/monitor/synthetic_preflight.py --detail-out "$RUNNER_TEMP/detail.txt"
+
+      - name: Notify Telegram
+        if: always()
+        uses: ./.github/actions/notify-telegram
+        with:
+          job_status: ${{ job.status }}
+          job_name: cross-origin-smoke
           state_branch: ${{ env.STATE_BRANCH }}
           telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           telegram_chat_id: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/api/config.py
+++ b/api/config.py
@@ -236,6 +236,11 @@ class Settings(BaseSettings):
     # server-to-server probe bypass Turnstile and rate limits via the
     # X-Monitor-Probe-Secret header. Leave None/empty to disable bypass.
     monitor_probe_secret: str | None = None
+    # Separate, rotatable secret for the browser smoke test (BITB-064). Kept
+    # distinct from monitor_probe_secret so a leak (it transits a real, if
+    # ephemeral, CI browser) is revocable without disturbing the server-to-server
+    # probes. Same X-Monitor-Probe-Secret header; leave None/empty to disable.
+    smoke_probe_secret: str | None = None
 
     # Client-side error reporting (BITB-066). The frontend POSTs JS/render/API
     # errors to /api/v1/client-errors; the endpoint records a metric so a spike

--- a/api/config.py
+++ b/api/config.py
@@ -237,6 +237,13 @@ class Settings(BaseSettings):
     # X-Monitor-Probe-Secret header. Leave None/empty to disable bypass.
     monitor_probe_secret: str | None = None
 
+    # Client-side error reporting (BITB-066). The frontend POSTs JS/render/API
+    # errors to /api/v1/client-errors; the endpoint records a metric so a spike
+    # (e.g. a browser-only outage) alerts. Cap the free-text detail to bound
+    # log/metric size and abuse.
+    client_error_reporting_enabled: bool = True
+    client_error_max_detail_chars: int = 500
+
     # Azure Content Safety Settings
     azure_content_safety_enabled: bool = False  # Enable Azure Content Safety API
     azure_content_safety_endpoint: str | None = None  # Azure endpoint URL

--- a/api/main.py
+++ b/api/main.py
@@ -50,9 +50,11 @@ from routes import (  # noqa: E402
 from scripture import check_translation_coverage, close_db, init_db  # noqa: E402
 from utils.local_only import require_local_access  # noqa: E402
 from utils.logging_config import get_logger, setup_logging  # noqa: E402
-from utils.metrics import client_errors_counter  # noqa: E402
+from utils.metrics import (  # noqa: E402
+    client_errors_counter,
+    translation_data_missing_counter,
+)
 from utils.metrics import meter as _metrics_meter  # noqa: F401, E402
-from utils.metrics import translation_data_missing_counter  # noqa: E402
 from utils.security import require_rate_limit  # noqa: E402
 
 # Configure logging before anything else

--- a/api/main.py
+++ b/api/main.py
@@ -33,6 +33,7 @@ if _appinsights_conn:
 from fastapi import Depends, FastAPI, Request  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import JSONResponse  # noqa: E402
+from pydantic import BaseModel, Field  # noqa: E402
 
 from config import settings  # noqa: E402
 from middleware.access_audit import AccessAuditMiddleware  # noqa: E402
@@ -49,8 +50,10 @@ from routes import (  # noqa: E402
 from scripture import check_translation_coverage, close_db, init_db  # noqa: E402
 from utils.local_only import require_local_access  # noqa: E402
 from utils.logging_config import get_logger, setup_logging  # noqa: E402
+from utils.metrics import client_errors_counter  # noqa: E402
 from utils.metrics import meter as _metrics_meter  # noqa: F401, E402
 from utils.metrics import translation_data_missing_counter  # noqa: E402
+from utils.security import require_rate_limit  # noqa: E402
 
 # Configure logging before anything else
 setup_logging()
@@ -356,10 +359,53 @@ async def get_config():
     }
 
 
-@app.post("/api/v1/client-errors", include_in_schema=False)
-async def report_client_error(request: Request):
-    """Receive client-side error reports (Turnstile failures, etc.)."""
-    body = await request.json()
+# Client-error report types the frontend may send. Keeping this a bounded set
+# controls the cardinality of the client.errors_total metric's `type` label;
+# anything else collapses to "other".
+_CLIENT_ERROR_TYPES = {
+    "window_onerror",
+    "unhandledrejection",
+    "api_failure",
+    "react_render",
+}
+
+
+class ClientErrorReport(BaseModel):
+    """Body for POST /api/v1/client-errors. `detail` is truncated server-side."""
+
+    type: str = Field(default="unknown", max_length=64)
+    detail: str = Field(default="", max_length=4096)
+
+
+def _normalize_client_error_type(raw: str) -> str:
+    """Collapse the reported type to a bounded metric label (Turnstile reports
+    prefix their type with `turnstile_`)."""
+    if raw in _CLIENT_ERROR_TYPES:
+        return raw
+    if raw.startswith("turnstile"):
+        return "turnstile"
+    return "other"
+
+
+@app.post(
+    "/api/v1/client-errors",
+    include_in_schema=False,
+    dependencies=[Depends(require_rate_limit)],
+)
+async def report_client_error(report: ClientErrorReport, request: Request):
+    """Receive client-side error reports (JS/render/API failures, Turnstile).
+
+    Records the client.errors_total metric so a spike (e.g. a browser-only
+    outage) alerts, and logs a bounded warning. Gated by
+    client_error_reporting_enabled; rate-limited via the shared dependency.
+    """
+    if not settings.client_error_reporting_enabled:
+        return {"status": "disabled"}
+
+    metric_type = _normalize_client_error_type(report.type)
+    client_errors_counter.add(1, {"type": metric_type})
+
+    detail = report.detail[: settings.client_error_max_detail_chars]
     client_ip = request.headers.get(
         "CF-Connecting-IP",
         request.headers.get(
@@ -368,11 +414,12 @@ async def report_client_error(request: Request):
     )
     logger.warning(
         "Client error report: %s — %s",
-        body.get("type", "unknown"),
-        body.get("detail", ""),
+        report.type,
+        detail,
         extra={
-            "error_type": body.get("type"),
-            "error_detail": body.get("detail"),
+            "error_type": report.type,
+            "error_metric_type": metric_type,
+            "error_detail": detail,
             "user_agent": request.headers.get("user-agent"),
             "ip": client_ip,
         },

--- a/api/middleware/access_audit.py
+++ b/api/middleware/access_audit.py
@@ -17,7 +17,7 @@ from starlette.responses import Response
 
 from config import settings
 from utils.logging_config import get_logger
-from utils.metrics import api_access_counter
+from utils.metrics import api_access_counter, preflight_errors_counter
 from utils.turnstile import _get_client_ip
 
 logger = get_logger(__name__)
@@ -140,9 +140,28 @@ class AccessAuditMiddleware(BaseHTTPMiddleware):
         if not path.startswith("/api/"):
             return await call_next(request)
 
-        # Skip preflight and HEAD
+        # Skip preflight and HEAD from the official/unofficial classification,
+        # but still observe OPTIONS 5xx: a browser CORS preflight that returns
+        # 5xx is a browser-only outage (the _IncludedRouter incident) that no
+        # other signal here catches. Count it, then pass the real response
+        # through untouched so CORS handling is unaffected.
         if request.method in ("OPTIONS", "HEAD"):
-            return await call_next(request)
+            response = await call_next(request)
+            if request.method == "OPTIONS" and response.status_code >= 500:
+                normalized = _normalize_path(path)
+                preflight_errors_counter.add(
+                    1, {"status": str(response.status_code), "path": normalized}
+                )
+                logger.warning(
+                    "CORS preflight returned %s — browser-only failure signature",
+                    response.status_code,
+                    extra={
+                        "path": path,
+                        "normalized_path": normalized,
+                        "status_code": response.status_code,
+                    },
+                )
+            return response
 
         # ── Classify ─────────────────────────────────────────────────
         origin = request.headers.get("origin", "")

--- a/api/tests/test_client_errors.py
+++ b/api/tests/test_client_errors.py
@@ -1,0 +1,45 @@
+"""Tests for the client-error reporting endpoint (BITB-066)."""
+
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from main import _normalize_client_error_type, app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_client_errors_accepts_valid_report():
+    resp = client.post(
+        "/api/v1/client-errors",
+        json={"type": "window_onerror", "detail": "boom"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_client_errors_defaults_missing_fields():
+    # Empty body is valid — both fields default.
+    resp = client.post("/api/v1/client-errors", json={})
+    assert resp.status_code == 200
+
+
+def test_client_errors_rejects_oversized_detail():
+    # detail has a max_length of 4096 on the model → 422.
+    resp = client.post(
+        "/api/v1/client-errors",
+        json={"type": "api_failure", "detail": "x" * 5000},
+    )
+    assert resp.status_code == 422
+
+
+def test_normalize_client_error_type_bounds_cardinality():
+    assert _normalize_client_error_type("window_onerror") == "window_onerror"
+    assert _normalize_client_error_type("unhandledrejection") == "unhandledrejection"
+    # Turnstile reports (prefixed) collapse to a single label.
+    assert _normalize_client_error_type("turnstile_error") == "turnstile"
+    # Anything unknown collapses to "other" to bound metric cardinality.
+    assert _normalize_client_error_type("some_random_type") == "other"

--- a/api/tests/test_monitor_probe.py
+++ b/api/tests/test_monitor_probe.py
@@ -6,6 +6,14 @@ must match what's deployed in the backend. These tests cover the critical
 fail-closed paths (header without server config, mismatched value, empty
 strings) since a bug here lets unauthenticated clients bypass bot
 protection.
+
+Two independent secrets are supported (BITB-064): monitor_probe_secret (the
+server-to-server GitHub Actions probes) and smoke_probe_secret (the browser
+smoke test). Every test explicitly sets both to a concrete value (usually
+None) rather than relying on MagicMock's attribute auto-creation, since an
+unset MagicMock attribute is a truthy non-string and would blow up
+hmac.compare_digest — that shape can't happen with the real Settings object
+(both fields default to None), but must be modeled correctly here.
 """
 
 import sys
@@ -32,26 +40,31 @@ class TestIsMonitorProbe:
         """Empty/None server secret = bypass disabled, even if header matches."""
         with patch("utils.monitor_probe.settings") as s:
             s.monitor_probe_secret = server_secret
+            s.smoke_probe_secret = None
             assert is_monitor_probe(_request_with_header("anything")) is False
 
     def test_missing_header_does_not_bypass(self):
         with patch("utils.monitor_probe.settings") as s:
             s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
+            s.smoke_probe_secret = None
             assert is_monitor_probe(_request_with_header(None)) is False
 
     def test_empty_header_does_not_bypass(self):
         with patch("utils.monitor_probe.settings") as s:
             s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
+            s.smoke_probe_secret = None
             assert is_monitor_probe(_request_with_header("")) is False
 
     def test_mismatched_header_does_not_bypass(self):
         with patch("utils.monitor_probe.settings") as s:
             s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
+            s.smoke_probe_secret = None
             assert is_monitor_probe(_request_with_header("wrong-secret")) is False
 
     def test_matching_header_bypasses(self):
         with patch("utils.monitor_probe.settings") as s:
             s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
+            s.smoke_probe_secret = None
             assert is_monitor_probe(_request_with_header("configured-secret")) is True
 
     def test_compare_is_constant_time(self):
@@ -61,5 +74,34 @@ class TestIsMonitorProbe:
         equal-length strings and False otherwise."""
         with patch("utils.monitor_probe.settings") as s:
             s.monitor_probe_secret = "abc-123"  # pragma: allowlist secret
+            s.smoke_probe_secret = None
             assert is_monitor_probe(_request_with_header("abc-124")) is False
             assert is_monitor_probe(_request_with_header("abc-1230")) is False
+
+
+class TestSmokeProbeSecret:
+    """BITB-064: the browser smoke test bypasses via a second, independent secret."""
+
+    def test_smoke_secret_bypasses_when_monitor_secret_unset(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = None
+            s.smoke_probe_secret = "smoke-secret"  # pragma: allowlist secret
+            assert is_monitor_probe(_request_with_header("smoke-secret")) is True
+
+    def test_smoke_secret_bypasses_when_monitor_secret_mismatches(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
+            s.smoke_probe_secret = "smoke-secret"  # pragma: allowlist secret
+            assert is_monitor_probe(_request_with_header("smoke-secret")) is True
+
+    def test_mismatched_header_does_not_bypass_either_secret(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = "configured-secret"  # pragma: allowlist secret
+            s.smoke_probe_secret = "smoke-secret"  # pragma: allowlist secret
+            assert is_monitor_probe(_request_with_header("wrong-secret")) is False
+
+    def test_unconfigured_smoke_secret_never_bypasses(self):
+        with patch("utils.monitor_probe.settings") as s:
+            s.monitor_probe_secret = None
+            s.smoke_probe_secret = ""
+            assert is_monitor_probe(_request_with_header("anything")) is False

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -253,3 +253,15 @@ turnstile_fail_open_counter = meter.create_counter(
     description="Count of Turnstile siteverify transient failures that were allowed through (failed open)",
     unit="1",
 )  # attributes: reason (timeout|http_<status>|http_error|<exc_name>)
+
+client_errors_counter = meter.create_counter(
+    name="client.errors_total",
+    description="Client-side error reports received at /api/v1/client-errors (BITB-066)",
+    unit="1",
+)  # attributes: type (window_onerror|unhandledrejection|api_failure|react_render|turnstile|other)
+
+preflight_errors_counter = meter.create_counter(
+    name="api.preflight_errors_total",
+    description="CORS preflight (OPTIONS) requests that returned HTTP 5xx — browser-only failure signal (BITB-066)",
+    unit="1",
+)  # attributes: status, path

--- a/api/utils/monitor_probe.py
+++ b/api/utils/monitor_probe.py
@@ -7,13 +7,20 @@ authorized probes opt-in via a shared secret header. The probe sends:
 
     X-Monitor-Probe-Secret: <value>
 
-If the value matches `settings.monitor_probe_secret` (constant-time compare),
-Turnstile and per-IP/session rate limits are skipped for the request. Other
-guardrails (content filter, request validation, application logic) still
-apply, so the probe exercises the same code path as a real user.
+If the value matches `settings.monitor_probe_secret` OR the separate,
+rotatable `settings.smoke_probe_secret` (constant-time compare), Turnstile and
+per-IP/session rate limits are skipped for the request. Other guardrails
+(content filter, request validation, application logic) still apply, so the
+probe exercises the same code path as a real user.
 
-Bypass is fail-closed: if `settings.monitor_probe_secret` is unset/empty,
-the header is ignored regardless of value.
+The two secrets serve different callers: `monitor_probe_secret` is for the
+server-to-server GitHub Actions probes; `smoke_probe_secret` (BITB-064) is for
+the browser smoke test, which injects it into the ephemeral CI browser only —
+never into the shipped bundle. Keeping them distinct makes the browser-facing
+one independently revocable.
+
+Bypass is fail-closed: if both secrets are unset/empty, the header is ignored
+regardless of value.
 """
 
 import hmac
@@ -26,11 +33,15 @@ PROBE_HEADER = "X-Monitor-Probe-Secret"  # noqa: S105 - header name, not a secre
 
 
 def is_monitor_probe(request: Request) -> bool:
-    """Return True iff the request is an authorized synthetic monitor probe."""
-    expected = settings.monitor_probe_secret
-    if not expected:
-        return False
+    """Return True iff the request is an authorized synthetic monitor probe
+    (server-to-server monitor secret) or the browser smoke test (smoke secret)."""
     provided = request.headers.get(PROBE_HEADER)
     if not provided:
         return False
-    return hmac.compare_digest(expected, provided)
+    # Compare against every configured secret; constant-time per candidate.
+    # `or ""` keeps the compare_digest call shape even when a secret is unset,
+    # and an empty expected never matches a non-empty provided value.
+    for expected in (settings.monitor_probe_secret, settings.smoke_probe_secret):
+        if expected and hmac.compare_digest(expected, provided):
+            return True
+    return False

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -816,6 +816,64 @@ max_message_length             = 200
    - Check logs for rate limit and content filter violations
    - Review Azure Log Analytics for suspicious patterns
 
+## 🔍 Synthetic Monitor Probe Secrets
+
+Two independent shared secrets let an automated probe send the `X-Monitor-Probe-Secret` header to
+bypass Turnstile and rate limits (`api/utils/monitor_probe.py`), so probes exercise the real request
+path without needing to solve a CAPTCHA. Everything else (content filter, validation, application
+logic) still applies. Bypass is fail-closed: if a secret is unset, the matching header is ignored.
+
+| Secret | Used by | Why it's separate |
+|--------|---------|--------------------|
+| `MONITOR_PROBE_SECRET` | Server-to-server GitHub Actions probes: `prod-monitor.yml` (health/chat/search/cross-origin-smoke jobs) and `weekly-report.yml` | Never leaves GitHub-hosted runners |
+| `SMOKE_PROBE_SECRET` | The production **browser** smoke test: `prod-browser-smoke.yml` → `frontend/e2e/prod-chat-smoke.spec.ts` | Transits an ephemeral CI Chromium session (injected via Playwright `addInitScript`, never shipped in the deployed frontend bundle — verify with `grep` on a build if in doubt), so it's kept independently rotatable from the server-to-server secret |
+
+### Setup Steps
+
+1. **Generate a value** for each secret you want to enable (either can be set independently; skip
+   the ones you don't need). Any high-entropy random string works — this is a bearer-style shared
+   secret, not a signing key:
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. **Set as GitHub repo secrets** (Settings → Secrets and variables → Actions → New repository
+   secret, or via the CLI):
+
+   ```bash
+   openssl rand -hex 32 | gh secret set MONITOR_PROBE_SECRET
+   openssl rand -hex 32 | gh secret set SMOKE_PROBE_SECRET
+   ```
+
+3. **Redeploy** (or re-run `azure-deploy.yml`). Both secrets are already wired end-to-end — repo
+   secret → `TF_VAR_monitor_probe_secret` / `TF_VAR_smoke_probe_secret` (`azure-deploy.yml`) →
+   Terraform variable (`deployment/variables.tf`) → Container App secret (`deployment/main.tf`) →
+   `settings.monitor_probe_secret` / `settings.smoke_probe_secret` (`api/config.py`). No manual Azure
+   Key Vault step is needed (unlike the Telegram bot token).
+
+### Verifying Setup
+
+```bash
+# Server-to-server bypass (MONITOR_PROBE_SECRET)
+curl -X POST "https://<backend>/api/v1/chat/stream" \
+  -H "Content-Type: application/json" \
+  -H "X-Monitor-Probe-Secret: $MONITOR_PROBE_SECRET" \
+  -d '{"message":"What does John 3:16 say?","conversation_history":[],"include_search":true}'
+```
+
+For `SMOKE_PROBE_SECRET`, trigger **Actions → Prod Browser Smoke → Run workflow** — once the secret
+is set, the Chromium test actually runs (rather than skipping) and should report a streamed assistant
+reply.
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `prod-chat-smoke.spec.ts` reports 0 tests run (skipped) | `SMOKE_PROBE_SECRET` repo secret not set | Set it (Setup Steps above); the job itself still reports success while skipped |
+| 403 from Turnstile even with the header set | Secret mismatch, or the repo secret was set but the backend hasn't been redeployed yet | Confirm the value matches `settings.monitor_probe_secret` / `settings.smoke_probe_secret` in the deployed environment; redeploy |
+| `prod-monitor.yml` probes suddenly start failing with 403 | `MONITOR_PROBE_SECRET` rotated in GitHub but not redeployed (or vice versa) | Keep the repo secret and the deployed backend in sync; redeploy after rotating |
+
 ## 📧 Email Notifications (SMTP2GO)
 
 The application can send email notifications for contact form submissions and negative feedback.

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -293,6 +293,56 @@ resource "azurerm_application_insights_standard_web_test" "backend_availability"
   tags = local.tags
 }
 
+# Browser CORS-preflight availability test (BITB-064). The /health/ready GET
+# test above stayed green through the 2026-07-05 _IncludedRouter outage because
+# that crash only hit the browser's cross-origin OPTIONS preflight — GET/POST
+# returned 200. This test issues that exact preflight (OPTIONS + Origin +
+# Access-Control-Request-*) against the instrumented backend and expects a 200,
+# so an always-on Azure-native alert fires on a preflight-only failure — not
+# just the 5-minute GitHub cross-origin-smoke probe. Complements it as the
+# second, independent channel.
+resource "azurerm_application_insights_standard_web_test" "backend_preflight" {
+  count                   = var.enable_application_insights ? 1 : 0
+  name                    = "${local.name_prefix}-preflight"
+  resource_group_name     = azurerm_resource_group.main.name
+  location                = azurerm_resource_group.main.location
+  application_insights_id = azurerm_application_insights.main[0].id
+
+  geo_locations = [
+    "emea-nl-ams-azr", # West Europe
+    "emea-gb-db3-azr", # UK South
+    "us-va-ash-azr",   # East US
+  ]
+
+  frequency = 300 # every 5 minutes
+
+  request {
+    url       = "https://${azurerm_container_app.backend.ingress[0].fqdn}/api/v1/chat/stream"
+    http_verb = "OPTIONS"
+
+    header {
+      name  = "Origin"
+      value = "https://voxquieta.org"
+    }
+    header {
+      name  = "Access-Control-Request-Method"
+      value = "POST"
+    }
+    header {
+      name  = "Access-Control-Request-Headers"
+      value = "content-type,x-turnstile-token"
+    }
+  }
+
+  validation_rules {
+    # A healthy CORS layer answers the preflight with 200; the _IncludedRouter
+    # crash returned 500 here.
+    expected_status_code = 200
+  }
+
+  tags = local.tags
+}
+
 # -----------------------------------------------------------------------------
 # Container Apps Environment
 # -----------------------------------------------------------------------------

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -207,6 +207,13 @@ locals {
       "MONITOR_PROBE_SECRET" = {
         secret_name = "monitor-probe-secret" # pragma: allowlist secret
       }
+    } : {},
+
+    # Browser smoke-test bypass (only when secret is provided) — BITB-064
+    var.smoke_probe_secret != "" ? {
+      "SMOKE_PROBE_SECRET" = {
+        secret_name = "smoke-probe-secret" # pragma: allowlist secret
+      }
     } : {}
   )
 
@@ -531,6 +538,7 @@ resource "terraform_data" "backend_secret_trigger" {
   triggers_replace = sha256(join("|", [
     var.openrouter_api_key,
     var.monitor_probe_secret,
+    var.smoke_probe_secret,
   ]))
 }
 
@@ -657,6 +665,15 @@ resource "azurerm_container_app" "backend" {
     content {
       name  = "monitor-probe-secret"
       value = var.monitor_probe_secret
+    }
+  }
+
+  # Browser smoke-test secret (only when set) — BITB-064
+  dynamic "secret" {
+    for_each = var.smoke_probe_secret != "" ? [1] : []
+    content {
+      name  = "smoke-probe-secret"
+      value = var.smoke_probe_secret
     }
   }
 
@@ -795,7 +812,7 @@ resource "null_resource" "frontend_custom_domain" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = <<-EOT
+    command     = <<-EOT
       set -euo pipefail
       DOMAIN="${var.custom_domain_frontend}"
       APP="${azurerm_container_app.frontend.name}"
@@ -827,7 +844,7 @@ resource "null_resource" "backend_custom_domain" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = <<-EOT
+    command     = <<-EOT
       set -euo pipefail
       DOMAIN="${var.custom_domain_backend}"
       APP="${azurerm_container_app.backend.name}"
@@ -873,7 +890,7 @@ resource "null_resource" "frontend_ssl_cert_upload" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = <<-EOT
+    command     = <<-EOT
       set -euo pipefail
       echo "Uploading Cloudflare Origin Certificate for frontend..."
       az containerapp env certificate upload \
@@ -902,7 +919,7 @@ resource "null_resource" "frontend_ssl_cert_bind" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = <<-EOT
+    command     = <<-EOT
       set -euo pipefail
       DOMAIN="${var.custom_domain_frontend}"
       # Wildcard SAN one level up, e.g. api.voxquieta.org -> *.voxquieta.org.
@@ -957,7 +974,7 @@ resource "null_resource" "backend_ssl_cert_upload" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = <<-EOT
+    command     = <<-EOT
       set -euo pipefail
       echo "Uploading Cloudflare Origin Certificate for backend..."
       az containerapp env certificate upload \
@@ -986,7 +1003,7 @@ resource "null_resource" "backend_ssl_cert_bind" {
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
-    command = <<-EOT
+    command     = <<-EOT
       set -euo pipefail
       DOMAIN="${var.custom_domain_backend}"
       PARENT_WILDCARD="*.$(echo "$DOMAIN" | cut -d. -f2-)"

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -269,6 +269,36 @@ resource "azurerm_monitor_metric_alert" "backend_availability" {
   tags = local.tags
 }
 
+# Wire the CORS-preflight web test (BITB-064) to the action group so a
+# browser-only preflight failure (like the 2026-07-05 _IncludedRouter 500)
+# pages via the always-on Azure-native path, independent of the GitHub cron
+# cross-origin-smoke probe.
+resource "azurerm_monitor_metric_alert" "backend_preflight_availability" {
+  count               = local.alerts_enabled ? 1 : 0
+  name                = "${local.name_prefix}-preflight-failed"
+  resource_group_name = azurerm_resource_group.main.name
+  scopes = [
+    azurerm_application_insights_standard_web_test.backend_preflight[0].id,
+    azurerm_application_insights.main[0].id,
+  ]
+  description = "Backend CORS-preflight (OPTIONS /api/v1/chat/stream) availability test failing from one or more regions — the browser-only failure signature of the _IncludedRouter/OTel incident."
+  severity    = 1
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id           = azurerm_application_insights_standard_web_test.backend_preflight[0].id
+    component_id          = azurerm_application_insights.main[0].id
+    failed_location_count = 2
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ops_email[0].id
+  }
+
+  tags = local.tags
+}
+
 # Backend container app restart alert. Restarts are normal during deploys but
 # unexpected ones often signal OOM/crash-loop.
 resource "azurerm_monitor_metric_alert" "backend_restarts" {

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -890,3 +890,145 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "embedding_fallback_ra
 
   tags = local.tags
 }
+
+# ---------------------------------------------------------------------------
+# Backend catch-all error alerts (BITB-065).
+#
+# Before this, no alert keyed on backend HTTP 5xx or unhandled exceptions —
+# the existing rules watch DB metrics, custom counters, and specific app ERROR
+# log strings, but never the App Insights requests/exceptions tables or a
+# generic 500. The 2026-07-05 _IncludedRouter incident (HTTP 500 on every CORS
+# preflight) fell straight through that net. These three rules are the
+# catch-all layer.
+#
+# IMPORTANT nuance from that incident: the crash was inside the OpenTelemetry
+# ASGI middleware, in default_span_details(), BEFORE the request span is
+# started — so App Insights recorded NO requests row for it. A requests-table
+# 5xx alert therefore cannot see that specific class; the reliable signal is
+# the uvicorn "Exception in ASGI application" console line (backend_asgi_exceptions
+# below). All three are kept as defence-in-depth for the broader 5xx surface.
+# ---------------------------------------------------------------------------
+
+# HTTP 5xx rate (App Insights requests table). Catches any endpoint/method the
+# app layer answers with a 5xx (or success == false). KQL mirrors the workbook
+# "Failed Requests" tile. Threshold is conservative (a handful in 10m) to avoid
+# single-blip noise; tune once a baseline is observed. Severity 1: a 5xx spike
+# is a user-facing outage.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_5xx_rate" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-backend-5xx-rate"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 1
+  description          = "Backend returned HTTP 5xx (or success == false) on 3+ requests in the last 10 minutes. Broad catch-all for server-side failures not covered by the specific metric/log alerts. NOTE: a crash inside the OTel ASGI middleware records no requests row — see backend_asgi_exceptions for that class."
+
+  criteria {
+    query                   = <<-KQL
+      requests
+      | where timestamp > ago(10m)
+      | where success == false or toint(resultCode) >= 500
+      | summarize total = count() by bin(timestamp, 5m)
+      | where total >= 3
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
+# Unhandled exceptions (App Insights exceptions table). Catches unhandled server
+# exceptions OTel records (e.g. a regression in a route handler surfaced by
+# ServerErrorMiddleware). KQL source: workbook "Exception Summary" tile.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_unhandled_exceptions" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-backend-unhandled-exceptions"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 2
+  description          = "3+ unhandled server exceptions recorded in App Insights in the last 10 minutes (exceptions table). Surfaces regressions that raise past route handlers. Threshold is conservative; tune once a baseline is observed."
+
+  criteria {
+    query                   = <<-KQL
+      exceptions
+      | where timestamp > ago(10m)
+      | summarize total = count() by bin(timestamp, 5m)
+      | where total >= 3
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
+# ASGI-layer exceptions (backend console logs). The in-telemetry catch for the
+# _IncludedRouter class: a crash above the app (OTel/CORS middleware) never
+# reaches a bible_app logger, so it produces no "| ERROR |"-formatted line (the
+# backend_errors filter misses it) and no requests row (backend_5xx_rate misses
+# it). It DOES produce a uvicorn.error "Exception in ASGI application" console
+# line — which is what this rule keys on. Severity 1: any ASGI exception is a
+# request the server could not handle.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_asgi_exceptions" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-backend-asgi-exceptions"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_log_analytics_workspace.main.id]
+  severity             = 1
+  description          = "An ASGI-layer exception ('Exception in ASGI application' from uvicorn, or a bare Traceback) appeared in backend logs in the last 10 minutes. This is the signature of a crash ABOVE the app — OTel/CORS middleware — that the | ERROR | log filter and the requests-table alert both miss. The 2026-07-05 _IncludedRouter 500 on CORS preflight emitted exactly this line."
+
+  criteria {
+    query                   = <<-KQL
+      ContainerAppConsoleLogs_CL
+      | where TimeGenerated > ago(10m)
+      | where ContainerAppName_s == "${azurerm_container_app.backend.name}"
+      | where Log_s has "Exception in ASGI application"
+          or Log_s contains "Traceback (most recent call last)"
+      | summarize cnt = count(), Sample = any(Log_s) by bin(TimeGenerated, 5m)
+      | where cnt > 0
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -1062,3 +1062,46 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "backend_asgi_exceptio
 
   tags = local.tags
 }
+
+# Frontend client-error spike (BITB-066). The web frontend reports JS/render/API
+# errors to /api/v1/client-errors, which emits the client.errors_total metric.
+# A spike means many real browsers are failing at once (e.g. a browser-only
+# outage the backend request path can't see) — the client-side complement to the
+# backend catch-all alerts. Threshold is deliberately a spike, not per-error, so
+# individual users' transient network blips don't page; tune once a baseline
+# exists.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "frontend_client_errors" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-frontend-client-errors"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 2
+  description          = "More than 20 client-side error reports (client.errors_total) received in the last 10 minutes — a spike of browser-side JS/render/API failures, e.g. a browser-only outage. Emitted by the frontend error reporter (BITB-066)."
+
+  criteria {
+    query                   = <<-KQL
+      customMetrics
+      | where timestamp > ago(10m)
+      | where name == "client.errors_total"
+      | summarize total = sum(valueSum) by bin(timestamp, 5m)
+      | where total > 20
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -266,6 +266,19 @@ variable "monitor_probe_secret" {
   sensitive   = true
 }
 
+variable "smoke_probe_secret" {
+  description = <<-EOT
+    Separate, rotatable secret for the browser smoke test (BITB-064). Same
+    X-Monitor-Probe-Secret header, but kept distinct from monitor_probe_secret
+    so a leak (it transits an ephemeral CI browser) is revocable independently.
+    Must match the repo secret SMOKE_PROBE_SECRET sent by
+    .github/workflows/prod-browser-smoke.yml. Leave empty to disable.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "telegram_chat_id" {
   description = <<-EOT
     Telegram chat/group ID for the Azure Monitor -> Telegram bridge (BITB-056),

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Prioritized list of user stories and features for Vox Quieta.
 
-**Last Updated:** 2026-07-05
+**Last Updated:** 2026-07-06
 
 **Verification Note (2026-04-20):** PR status reconciliation pass completed against GitHub.
 Confirmed merged PRs: #68, #171, #182, #191, #193, #194, #195, #196, #197, #208, #225, #226,
@@ -182,9 +182,9 @@ positives on Bible queries. This unblocks it.
 > `docs/TURBOVEC_EVALUATION.md` (turbovec evaluated and rejected — relevance, not infra,
 > is the lever).
 
-### 🎯 BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
+### 🚧 BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
 
-**Status:** 🎯 Todo — follow-up from the 2026-07-05 `_IncludedRouter` 500 incident
+**Status:** 🚧 In progress — scripted cross-origin smoke probe **delivered**; full browser smoke test open
 **Size:** M (one new synthetic probe + Telegram wiring; optional Azure availability test)
 **Created:** 2026-07-05
 
@@ -202,13 +202,68 @@ same reason native Android kept working.
 
 **Acceptance Criteria (summary — full story has detail):**
 
-- [ ] New CORS-preflight synthetic probe (`OPTIONS /api/v1/chat/stream` with `Origin` +
-      `Access-Control-Request-*` headers) asserts 2xx/204 and the `Access-Control-Allow-*` response headers
-- [ ] Wired into `prod-monitor.yml` on the 5-min schedule via the shared `notify-telegram` action
+- [x] New CORS-preflight synthetic probe (`OPTIONS /api/v1/chat/stream` with `Origin` +
+      `Access-Control-Request-*` headers) asserts 2xx/204 and the `Access-Control-Allow-*` response headers,
+      plus a cross-origin POST asserting a streamed answer (`scripts/monitor/synthetic_preflight.py`)
+- [x] Wired into `prod-monitor.yml` as the `cross-origin-smoke` job on the 5-min schedule via `notify-telegram`
+- [ ] Full production **browser** smoke test (Playwright vs voxquieta.org, submits a chat + asserts a
+      streamed reply); open Turnstile-in-automation decision
 - [ ] (Recommended) Azure availability test parity so the always-on path also alerts
 - [ ] Troubleshooting runbook note: "browser 500 but curl/app fine" ⇒ CORS-preflight / OTel path
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md`
+
+---
+
+### ✅ BITB-065: Backend Catch-All Error Alerting — HTTP 5xx, Unhandled & ASGI-Layer Exceptions
+
+**Status:** ✅ Done (delivered on the PR #824 branch)
+**Size:** S (three Terraform scheduled-query alerts)
+**Created:** 2026-07-05
+
+**As** the operator, **I want** an alert whenever the backend returns HTTP 5xx or throws an unhandled /
+ASGI-layer exception, **so that** a server-side outage pages me regardless of which subsystem broke.
+
+**Why P1:** Of 17 pre-existing alerts, **none** watched backend 5xx or the App Insights
+`requests`/`exceptions` tables — the generic 5xx KQL lived only in a passive workbook. The
+`_IncludedRouter` 500 fell through because it is not a DB metric, not a custom counter, and (being a
+crash *above* the app in the OTel middleware) produced no `| ERROR |` log line. Nuance: that crash
+records no `requests` row either (it dies before the span starts), so the reliable signal is the
+`uvicorn` "Exception in ASGI application" console line — hence a log-based rule alongside the table ones.
+
+**Acceptance Criteria:**
+
+- [x] `backend_5xx_rate` (App Insights `requests`, Sev 1), `backend_unhandled_exceptions` (App Insights
+      `exceptions`, Sev 2), `backend_asgi_exceptions` (console logs "Exception in ASGI application", Sev 1)
+- [x] All reuse the `ops_email` action group + `local.alerts_enabled` gating (email + Telegram)
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-065-backend-catchall-error-alerting.md`
+
+---
+
+### 🎯 BITB-066: Frontend Error Observability
+
+**Status:** 🎯 Todo
+**Size:** M (frontend reporter + backend metric/alert + middleware tweak)
+**Created:** 2026-07-05
+
+**As** the operator, **I want** the web frontend to report client-side errors (JS exceptions, unhandled
+rejections, API/network failures) and alert on spikes, **so that** browser-only failures are visible
+from the client — the way Android already reports via Firebase Crashlytics.
+
+**Why P1:** The web frontend has **no** general client-side error telemetry — the `ErrorBoundary` only
+`console.error`s, API failures are swallowed, and the only sink (`/api/v1/client-errors`) is used
+solely by Turnstile. A CORS-blocked preflight surfaces as a bare `TypeError` and is reported nowhere.
+
+**Acceptance Criteria (summary — full story has detail):**
+
+- [ ] Generalize the `reportTurnstileError` → `/api/v1/client-errors` pattern into a global
+      `window.onerror`/`unhandledrejection` + `api.ts` failure hook (sampled, PII-scrubbed)
+- [ ] `/api/v1/client-errors` emits a metric + a spike alert; `error.tsx`/`global-error.tsx` report too
+- [ ] `AccessAuditMiddleware` stops silently skipping `OPTIONS` 5xx
+- [ ] Open decision: reuse endpoint vs. adopt a RUM SDK (App Insights JS / Sentry)
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-066-frontend-error-observability.md`
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -241,9 +241,9 @@ records no `requests` row either (it dies before the span starts), so the reliab
 
 ---
 
-### 🎯 BITB-066: Frontend Error Observability
+### ✅ BITB-066: Frontend Error Observability
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done (delivered on the PR #824 branch, reuse-endpoint approach)
 **Size:** M (frontend reporter + backend metric/alert + middleware tweak)
 **Created:** 2026-07-05
 
@@ -251,17 +251,17 @@ records no `requests` row either (it dies before the span starts), so the reliab
 rejections, API/network failures) and alert on spikes, **so that** browser-only failures are visible
 from the client — the way Android already reports via Firebase Crashlytics.
 
-**Why P1:** The web frontend has **no** general client-side error telemetry — the `ErrorBoundary` only
-`console.error`s, API failures are swallowed, and the only sink (`/api/v1/client-errors`) is used
-solely by Turnstile. A CORS-blocked preflight surfaces as a bare `TypeError` and is reported nowhere.
+**Why P1:** The web frontend had **no** general client-side error telemetry — the `ErrorBoundary` only
+`console.error`d, API failures were swallowed, and the only sink (`/api/v1/client-errors`) was used
+solely by Turnstile. A CORS-blocked preflight surfaces as a bare `TypeError` and was reported nowhere.
 
-**Acceptance Criteria (summary — full story has detail):**
+**Acceptance Criteria (all delivered):**
 
-- [ ] Generalize the `reportTurnstileError` → `/api/v1/client-errors` pattern into a global
-      `window.onerror`/`unhandledrejection` + `api.ts` failure hook (sampled, PII-scrubbed)
-- [ ] `/api/v1/client-errors` emits a metric + a spike alert; `error.tsx`/`global-error.tsx` report too
-- [ ] `AccessAuditMiddleware` stops silently skipping `OPTIONS` 5xx
-- [ ] Open decision: reuse endpoint vs. adopt a RUM SDK (App Insights JS / Sentry)
+- [x] `clientErrorReporter.ts` (fire-and-forget, PII-scrubbed, capped/deduped) + global
+      `window.onerror`/`unhandledrejection` handlers + `api.ts` failure hook + `ErrorBoundary` + `global-error.tsx`
+- [x] `/api/v1/client-errors` hardened (model, cap, rate-limit, flag) + `client.errors_total` metric + spike alert
+- [x] `AccessAuditMiddleware` emits `api.preflight_errors_total` on `OPTIONS` 5xx
+- [x] Mechanism decision resolved: reuse the existing endpoint (RUM SDK deferred)
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-066-frontend-error-observability.md`
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -206,10 +206,10 @@ same reason native Android kept working.
       `Access-Control-Request-*` headers) asserts 2xx/204 and the `Access-Control-Allow-*` response headers,
       plus a cross-origin POST asserting a streamed answer (`scripts/monitor/synthetic_preflight.py`)
 - [x] Wired into `prod-monitor.yml` as the `cross-origin-smoke` job on the 5-min schedule via `notify-telegram`
+- [x] Azure `backend_preflight` availability web test (OPTIONS + CORS headers) + alert → always-on channel
+- [x] Troubleshooting runbook note: "browser 500 but curl/app fine" ⇒ CORS-preflight / OTel path
 - [ ] Full production **browser** smoke test (Playwright vs voxquieta.org, submits a chat + asserts a
-      streamed reply); open Turnstile-in-automation decision
-- [ ] (Recommended) Azure availability test parity so the always-on path also alerts
-- [ ] Troubleshooting runbook note: "browser 500 but curl/app fine" ⇒ CORS-preflight / OTel path
+      streamed reply); open Turnstile-in-automation decision — the only remaining item
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md`
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -182,9 +182,9 @@ positives on Bible queries. This unblocks it.
 > `docs/TURBOVEC_EVALUATION.md` (turbovec evaluated and rejected — relevance, not infra,
 > is the lever).
 
-### 🚧 BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
+### ✅ BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
 
-**Status:** 🚧 In progress — scripted cross-origin smoke probe **delivered**; full browser smoke test open
+**Status:** ✅ Done — scripted cross-origin probe, Azure preflight web test, runbook, and full browser smoke test all delivered
 **Size:** M (one new synthetic probe + Telegram wiring; optional Azure availability test)
 **Created:** 2026-07-05
 
@@ -208,8 +208,8 @@ same reason native Android kept working.
 - [x] Wired into `prod-monitor.yml` as the `cross-origin-smoke` job on the 5-min schedule via `notify-telegram`
 - [x] Azure `backend_preflight` availability web test (OPTIONS + CORS headers) + alert → always-on channel
 - [x] Troubleshooting runbook note: "browser 500 but curl/app fine" ⇒ CORS-preflight / OTel path
-- [ ] Full production **browser** smoke test (Playwright vs voxquieta.org, submits a chat + asserts a
-      streamed reply); open Turnstile-in-automation decision — the only remaining item
+- [x] Full production **browser** smoke test (`prod-chat-smoke.spec.ts` + hourly `prod-browser-smoke.yml`),
+      Turnstile passed via a separate injected-at-test-time `smoke_probe_secret` (never in the bundle)
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md`
 

--- a/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
+++ b/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
@@ -1,6 +1,7 @@
 # BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
 
-**Status:** 🎯 Todo (follow-up carved out of the 2026-07-05 `_IncludedRouter` 500 incident)
+**Status:** 🚧 In progress — scripted cross-origin smoke probe **delivered**; full production
+**browser** smoke test (real Chromium journey) remains open.
 **Priority:** P1 (High) — a total browser-facing chat outage shipped to production and **no monitor,
 alert, or Telegram notification fired**; only a user report surfaced it.
 **Size:** M (1-2 days — one new synthetic probe + wiring; optional Azure availability test)
@@ -52,22 +53,33 @@ fix; this story covers the *production* smoke + alert half.)
 
 ## Acceptance Criteria
 
-- [ ] **Browser-preflight synthetic probe.** New probe (e.g. `scripts/monitor/synthetic_preflight.py`)
-      sends a real cross-origin CORS preflight to a representative included-router route — at minimum
-      `OPTIONS /api/v1/chat/stream` with `Origin: https://voxquieta.org`,
+- [x] **Browser-preflight synthetic probe.** `scripts/monitor/synthetic_preflight.py` sends a real
+      cross-origin CORS preflight to `OPTIONS /api/v1/chat/stream` with `Origin: https://voxquieta.org`,
       `Access-Control-Request-Method: POST`, `Access-Control-Request-Headers: content-type,x-turnstile-token`
-      (mirror the failing request from the incident) — and **asserts 2xx/204 AND the presence of the
-      expected `Access-Control-Allow-Origin` / `Access-Control-Allow-Methods` headers**. It fails on
-      the 500 this incident produced.
-- [ ] **Wired into `prod-monitor.yml`** as its own job on the existing `*/5 * * * *` schedule, using
-      the shared `./.github/actions/notify-telegram` action so a failure pages the same Telegram chat
-      as the other probes. Reuse the existing state-branch / de-dup mechanism the other jobs use.
+      and **asserts 2xx/204 AND the `Access-Control-Allow-Origin` / `Access-Control-Allow-Methods`
+      headers**, then a cross-origin POST (Origin + probe secret) asserting a streamed answer. It fails
+      on the 500 this incident produced (verified against the broken vs fixed OTel pins).
+- [x] **Wired into `prod-monitor.yml`** as the `cross-origin-smoke` job on the `*/5 * * * *` schedule,
+      using the shared `./.github/actions/notify-telegram` action.
+- [ ] **Full production browser smoke test (open).** Complete the incomplete Playwright spec so it
+      actually **submits a chat and asserts a streamed assistant reply** (today `turnstile-ready.spec.ts`
+      stops at asserting the user's own text), then run it on a schedule against
+      `PLAYWRIGHT_BASE_URL=https://voxquieta.org` via the pre-installed Chromium. This is the only test
+      that exercises the *full* real journey: rendered frontend → real CORS preflight → instrumented
+      API → streamed answer. **Open decision — Turnstile in automation:** (a) a smoke-scoped bypass
+      header (frontend attaches the monitor-probe-secret when a smoke secret is present, so only
+      Turnstile *verification* is bypassed) vs. (b) a staging deploy with Cloudflare Turnstile **test
+      keys** (always-pass). Resolve when scheduled.
 - [ ] **(Recommended) Azure availability test parity.** Add a second `azurerm_application_insights_web_test`
       (or upgrade the existing one) that issues the CORS preflight, so the always-on Azure-native path
       also alerts — not just the 5-min GitHub cron. *If cost/complexity is a concern, the GitHub probe
       alone satisfies the story; note the decision.*
 - [ ] **Runbook note** in `docs/TROUBLESHOOTING.md`: "browser 500 but native app / curl fine" ⇒ suspect
       the CORS-preflight / OTel-instrumentation path and a FastAPI-vs-instrumentation version skew.
+
+**Delivered in PR #824 branch:** the scripted `cross-origin-smoke` probe (`scripts/monitor/synthetic_preflight.py`
++ `prod-monitor.yml` job). Remaining: the full browser smoke test, the Azure web-test parity, and the
+runbook note.
 
 ## Notes / Reuse
 

--- a/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
+++ b/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
@@ -25,13 +25,13 @@ The `_IncludedRouter` 500 broke **only the browser CORS preflight** (`OPTIONS` w
 `Access-Control-Request-Method`). The actual `GET`/`POST` requests returned 200. Reproduced locally
 under the exact production pins:
 
-| Request                                              | Broken pin (0.61b0) | Fixed pin (0.64b0) |
-| ---------------------------------------------------- | ------------------- | ------------------ |
-| `OPTIONS /api/v1/chat/stream` (browser preflight)    | **500**             | 200                |
-| `POST /api/v1/chat/stream` (native app / curl)       | 200                 | 200                |
-| `GET /health/ready`                                  | 200                 | 200                |
+| Request                                           | Broken pin (0.61b0) | Fixed pin (0.64b0) |
+| ------------------------------------------------- | ------------------- | ------------------ |
+| `OPTIONS /api/v1/chat/stream` (browser preflight) | **500**             | 200                |
+| `POST /api/v1/chat/stream` (native app / curl)    | 200                 | 200                |
+| `GET /health/ready`                               | 200                 | 200                |
 
-Every existing safety net sends requests the *non-browser* way, so all of them stayed green:
+Every existing safety net sends requests the _non-browser_ way, so all of them stayed green:
 
 1. **Azure availability test** pings `GET /health/ready` (`deployment/main.tf:267-286`) → 200 → green.
 2. **`synthetic-chat` probe** (`scripts/monitor/synthetic_chat.py`, run by
@@ -40,7 +40,7 @@ Every existing safety net sends requests the *non-browser* way, so all of them s
    browser-only behavior.
 3. **`verse-search` probe** — same, a direct `GET`/`POST`.
 
-Net: the browser is the *only* client that broke, and **no probe ever behaves like a browser**, so
+Net: the browser is the _only_ client that broke, and **no probe ever behaves like a browser**, so
 `prod-monitor.yml` never failed, the `notify-telegram` action never fired, and Azure Monitor never
 alerted. The `android works good` observation during triage was the tell — native Android sends no
 preflight, so it was unaffected, exactly like every monitor.
@@ -49,7 +49,7 @@ A second, deeper gap: the crashing layer (`FastAPIInstrumentor.instrument_app`) 
 production**, gated on `APPLICATIONINSIGHTS_CONNECTION_STRING` (`api/main.py:266-273`). No unit or
 integration test sets that var, so the instrumented request path — the exact thing that failed —
 had zero automated coverage before this incident. (Closing the unit/CI half is tracked in the code
-fix; this story covers the *production* smoke + alert half.)
+fix; this story covers the _production_ smoke + alert half.)
 
 ## Acceptance Criteria
 
@@ -66,7 +66,7 @@ fix; this story covers the *production* smoke + alert half.)
       new `data-testid="assistant-message"`) — the full real journey: rendered frontend → real CORS
       preflight → instrumented API → streamed answer. Runs hourly via `.github/workflows/prod-browser-smoke.yml`,
       wired to `notify-telegram`. **Turnstile decision resolved — smoke-scoped bypass header:** a
-      *separate*, rotatable `smoke_probe_secret` (distinct from `monitor_probe_secret`) is injected into
+      _separate_, rotatable `smoke_probe_secret` (distinct from `monitor_probe_secret`) is injected into
       the CI browser at test time via `addInitScript` (never shipped in the bundle — verified); the
       deployed bundle only reads `window.__VOXQUIETA_SMOKE_SECRET__` (inert for real users) via
       `frontend/src/lib/smoke.ts`, and `getHeaders()` attaches `X-Monitor-Probe-Secret` +
@@ -84,9 +84,40 @@ availability web test + alert, the troubleshooting runbook note, and the full pr
 smoke test (`frontend/e2e/prod-chat-smoke.spec.ts` + `.github/workflows/prod-browser-smoke.yml`, with
 the `smoke_probe_secret` bypass wired through the backend + deploy).
 
-**Operational note:** set the `SMOKE_PROBE_SECRET` repo secret (and `TF_VAR_smoke_probe_secret` flows
-to the backend via `azure-deploy.yml`) to arm the browser smoke test; until then the scheduled job's
-test skips.
+## Setup — arming the browser smoke test (one-time)
+
+The browser smoke test is inert until `SMOKE_PROBE_SECRET` exists as a repo secret. Until then,
+`prod-chat-smoke.spec.ts` skips itself (`test.skip(!SMOKE_SECRET, ...)`) — the scheduled job still
+runs and reports "passed" (0 tests skipped, not a failure), it just doesn't exercise anything yet.
+
+1. **Generate a value** (any high-entropy random string works; this is a bearer-style shared secret,
+   not a signing key, so a plain random hex string is fine):
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. **Set it as a GitHub repo secret** (Settings → Secrets and variables → Actions → New repository
+   secret, or via the CLI):
+
+   ```bash
+   openssl rand -hex 32 | gh secret set SMOKE_PROBE_SECRET
+   ```
+
+3. **Redeploy** (or re-run `azure-deploy.yml`) so `TF_VAR_smoke_probe_secret` (already wired in
+   `azure-deploy.yml` from this same repo secret) reaches the backend container as
+   `SMOKE_PROBE_SECRET` and `settings.smoke_probe_secret` picks it up
+   (`api/config.py` / `api/utils/monitor_probe.py`). No Azure Key Vault step is needed — unlike the
+   Telegram bot token, this flows straight through a Container App secret (`deployment/main.tf`),
+   the same way `MONITOR_PROBE_SECRET` already does.
+4. **Verify:** trigger `.github/workflows/prod-browser-smoke.yml` manually (Actions → Prod Browser
+   Smoke → Run workflow). The job should now actually run the Chromium test (not skip) and report a
+   streamed assistant reply.
+
+Deliberately kept **separate** from `MONITOR_PROBE_SECRET` (used by the server-to-server probes in
+`prod-monitor.yml`) — this secret transits an ephemeral CI browser (injected via Playwright
+`addInitScript`, never present in the deployed bundle — verified), so it should be independently
+rotatable if it ever needs to be revoked without touching the other probes.
 
 ## Notes / Reuse
 
@@ -99,7 +130,7 @@ test skips.
   alert wiring in `deployment/monitoring.tf`. The Telegram bridge (`ops_email` action group +
   `logic_app_workflow.telegram_alert`, BITB-056) already reposts Azure alerts to Telegram.
 - Related: **BITB-055 / BITB-056 / BITB-057** — this is the same "make it loud" observability thread; the
-  new signal here is *browser-shaped* traffic, which none of those covered.
+  new signal here is _browser-shaped_ traffic, which none of those covered.
 
 ## Out of Scope
 

--- a/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
+++ b/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
@@ -70,16 +70,17 @@ fix; this story covers the *production* smoke + alert half.)
       header (frontend attaches the monitor-probe-secret when a smoke secret is present, so only
       Turnstile *verification* is bypassed) vs. (b) a staging deploy with Cloudflare Turnstile **test
       keys** (always-pass). Resolve when scheduled.
-- [ ] **(Recommended) Azure availability test parity.** Add a second `azurerm_application_insights_web_test`
-      (or upgrade the existing one) that issues the CORS preflight, so the always-on Azure-native path
-      also alerts — not just the 5-min GitHub cron. *If cost/complexity is a concern, the GitHub probe
-      alone satisfies the story; note the decision.*
-- [ ] **Runbook note** in `docs/TROUBLESHOOTING.md`: "browser 500 but native app / curl fine" ⇒ suspect
+- [x] **Azure availability test parity.** `backend_preflight` standard web test (`deployment/main.tf`)
+      issues the `OPTIONS` preflight with the CORS request headers and expects 200, wired to the
+      `backend_preflight_availability` metric alert (`deployment/monitoring.tf`) → `ops_email` →
+      Telegram. Second, always-on channel independent of the GitHub cron.
+- [x] **Runbook note** in `docs/TROUBLESHOOTING.md`: "browser 500 but native app / curl fine" ⇒ suspect
       the CORS-preflight / OTel-instrumentation path and a FastAPI-vs-instrumentation version skew.
 
 **Delivered in PR #824 branch:** the scripted `cross-origin-smoke` probe (`scripts/monitor/synthetic_preflight.py`
-+ `prod-monitor.yml` job). Remaining: the full browser smoke test, the Azure web-test parity, and the
-runbook note.
++ `prod-monitor.yml` job), the `backend_preflight` Azure availability web test + alert, and the
+troubleshooting runbook note. **Remaining:** only the full production **browser** smoke test (Playwright
+vs voxquieta.org) with its open Turnstile-in-automation decision.
 
 ## Notes / Reuse
 

--- a/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
+++ b/docs/BACKLOG_STORIES/BITB-064-browser-preflight-smoke-and-alerting.md
@@ -1,7 +1,7 @@
 # BITB-064: Catch Browser-Only Outages — CORS-Preflight Smoke Test + Instrumented-Request Alerting
 
-**Status:** 🚧 In progress — scripted cross-origin smoke probe **delivered**; full production
-**browser** smoke test (real Chromium journey) remains open.
+**Status:** ✅ Done — scripted cross-origin probe, Azure preflight web test, runbook, AND the full
+production **browser** smoke test all delivered on the PR #824 branch.
 **Priority:** P1 (High) — a total browser-facing chat outage shipped to production and **no monitor,
 alert, or Telegram notification fired**; only a user report surfaced it.
 **Size:** M (1-2 days — one new synthetic probe + wiring; optional Azure availability test)
@@ -61,15 +61,16 @@ fix; this story covers the *production* smoke + alert half.)
       on the 500 this incident produced (verified against the broken vs fixed OTel pins).
 - [x] **Wired into `prod-monitor.yml`** as the `cross-origin-smoke` job on the `*/5 * * * *` schedule,
       using the shared `./.github/actions/notify-telegram` action.
-- [ ] **Full production browser smoke test (open).** Complete the incomplete Playwright spec so it
-      actually **submits a chat and asserts a streamed assistant reply** (today `turnstile-ready.spec.ts`
-      stops at asserting the user's own text), then run it on a schedule against
-      `PLAYWRIGHT_BASE_URL=https://voxquieta.org` via the pre-installed Chromium. This is the only test
-      that exercises the *full* real journey: rendered frontend → real CORS preflight → instrumented
-      API → streamed answer. **Open decision — Turnstile in automation:** (a) a smoke-scoped bypass
-      header (frontend attaches the monitor-probe-secret when a smoke secret is present, so only
-      Turnstile *verification* is bypassed) vs. (b) a staging deploy with Cloudflare Turnstile **test
-      keys** (always-pass). Resolve when scheduled.
+- [x] **Full production browser smoke test.** `frontend/e2e/prod-chat-smoke.spec.ts` loads the deployed
+      site in real Chromium, submits a chat, and asserts a **streamed assistant reply** renders (via a
+      new `data-testid="assistant-message"`) — the full real journey: rendered frontend → real CORS
+      preflight → instrumented API → streamed answer. Runs hourly via `.github/workflows/prod-browser-smoke.yml`,
+      wired to `notify-telegram`. **Turnstile decision resolved — smoke-scoped bypass header:** a
+      *separate*, rotatable `smoke_probe_secret` (distinct from `monitor_probe_secret`) is injected into
+      the CI browser at test time via `addInitScript` (never shipped in the bundle — verified); the
+      deployed bundle only reads `window.__VOXQUIETA_SMOKE_SECRET__` (inert for real users) via
+      `frontend/src/lib/smoke.ts`, and `getHeaders()` attaches `X-Monitor-Probe-Secret` +
+      `ChatIsland` relaxes the send gate only when it's present.
 - [x] **Azure availability test parity.** `backend_preflight` standard web test (`deployment/main.tf`)
       issues the `OPTIONS` preflight with the CORS request headers and expects 200, wired to the
       `backend_preflight_availability` metric alert (`deployment/monitoring.tf`) → `ops_email` →
@@ -77,10 +78,15 @@ fix; this story covers the *production* smoke + alert half.)
 - [x] **Runbook note** in `docs/TROUBLESHOOTING.md`: "browser 500 but native app / curl fine" ⇒ suspect
       the CORS-preflight / OTel-instrumentation path and a FastAPI-vs-instrumentation version skew.
 
-**Delivered in PR #824 branch:** the scripted `cross-origin-smoke` probe (`scripts/monitor/synthetic_preflight.py`
-+ `prod-monitor.yml` job), the `backend_preflight` Azure availability web test + alert, and the
-troubleshooting runbook note. **Remaining:** only the full production **browser** smoke test (Playwright
-vs voxquieta.org) with its open Turnstile-in-automation decision.
+**Delivered in PR #824 branch (all AC complete):** the scripted `cross-origin-smoke` probe
+(`scripts/monitor/synthetic_preflight.py` + `prod-monitor.yml` job), the `backend_preflight` Azure
+availability web test + alert, the troubleshooting runbook note, and the full production **browser**
+smoke test (`frontend/e2e/prod-chat-smoke.spec.ts` + `.github/workflows/prod-browser-smoke.yml`, with
+the `smoke_probe_secret` bypass wired through the backend + deploy).
+
+**Operational note:** set the `SMOKE_PROBE_SECRET` repo secret (and `TF_VAR_smoke_probe_secret` flows
+to the backend via `azure-deploy.yml`) to arm the browser smoke test; until then the scheduled job's
+test skips.
 
 ## Notes / Reuse
 

--- a/docs/BACKLOG_STORIES/BITB-065-backend-catchall-error-alerting.md
+++ b/docs/BACKLOG_STORIES/BITB-065-backend-catchall-error-alerting.md
@@ -1,0 +1,73 @@
+# BITB-065: Backend Catch-All Error Alerting — HTTP 5xx, Unhandled & ASGI-Layer Exceptions
+
+**Status:** ✅ Done (delivered on the PR #824 branch)
+**Priority:** P1 (High) — a total outage produced no alert because no rule watched the most basic
+failure signal: a backend 5xx.
+**Size:** S (three Terraform scheduled-query alerts)
+**Created:** 2026-07-05
+**Incident ref:** the 2026-07-05 `_IncludedRouter` 500 (HTTP 500 on every CORS preflight) — see BITB-064.
+
+## User Story
+
+As the operator, I want an alert to fire whenever the backend returns HTTP 5xx or throws an unhandled
+/ ASGI-layer exception, so that a server-side outage pages me on Telegram regardless of which specific
+subsystem broke — instead of only the hand-picked failure signatures the existing rules watch.
+
+## Problem / Motivation
+
+An audit of the 17 pre-existing Azure Monitor alerts found **none keyed on backend HTTP 5xx or the
+App Insights `requests` / `exceptions` tables.** They watch DB resource metrics, custom counters
+(`scripture.*`, `embedding.fallback_total`, …), and specific app `| ERROR |` log strings. The generic
+5xx KQL existed only in the **passive** performance workbook
+(`deployment/azure-monitor/workbook-performance-dashboard.json`), which visualizes but never fires.
+
+So when the `_IncludedRouter` crash returned HTTP 500 on every CORS preflight, it fell through every
+net: it is not a DB metric, not a custom counter, and — because the crash is in the OpenTelemetry ASGI
+middleware **above** the app — it never reached a `bible_app` logger, so it produced no
+`| ERROR |`-formatted line and the `backend_errors` filter never matched.
+
+**Load-bearing nuance:** the crash happens inside `default_span_details()` **before** the request span
+is started (`opentelemetry/instrumentation/asgi/__init__.py`: line 755 runs before the span-start at
+line 760), so App Insights records **no `requests` row** for the failing request. A 5xx-on-`requests`
+alert therefore cannot see *this* class — but the crash **does** emit a `uvicorn.error`
+"Exception in ASGI application" console line. That log line is the reliable in-telemetry signal, which
+is why a log-based rule is required alongside the `requests`/`exceptions` rules.
+
+## Acceptance Criteria (all delivered)
+
+- [x] **`backend_5xx_rate`** — App-Insights-scoped scheduled query over `requests`
+      (`success == false or toint(resultCode) >= 500`), fires on 3+ in 10 min, Sev 1. Broad catch-all
+      for app-layer 5xx. KQL mirrors the workbook "Failed Requests" tile.
+- [x] **`backend_unhandled_exceptions`** — App-Insights-scoped over `exceptions`, fires on 3+ in
+      10 min, Sev 2. Catches regressions that raise past route handlers.
+- [x] **`backend_asgi_exceptions`** — Log-Analytics-scoped over `ContainerAppConsoleLogs_CL`, matches
+      `"Exception in ASGI application"` or a bare `Traceback (most recent call last)`, Sev 1. The
+      in-telemetry catch for the middleware-layer class that the other two (and the `| ERROR |` filter)
+      structurally miss.
+- [x] All three reuse the `ops_email` action group and `local.alerts_enabled` gating, so they deliver
+      to email + Telegram exactly like the existing alerts. (`deployment/monitoring.tf`.)
+
+## Notes / Reuse
+
+- KQL lifted from the proven workbook queries (`workbook-performance-dashboard.json:58,360,374`) — same
+  tables/columns, so no new query invention.
+- Rule structure mirrors `scripture_pipeline_errors` / `scripture_grounding_errors` in
+  `deployment/monitoring.tf` (App-Insights- and Log-Analytics-scoped variants respectively).
+- Thresholds (`>= 3` for the table-based rules) are conservative to avoid single-blip fatigue and are
+  tunable once a production baseline is observed; the ASGI-log rule fires on the first occurrence.
+
+## Out of Scope
+
+- The browser-preflight probe and full browser smoke test (BITB-064).
+- Frontend client-side error telemetry (BITB-066).
+- Fixing the OTel→App Insights exporter drops that can under-count metric-based alerts (BITB-057 Phase 4).
+
+## Verification
+
+- `terraform -chdir=deployment fmt -check` (passes) + `validate` + `plan` (no apply) renders the three
+  new rules wired to `ops_email` with no diff to existing resources. *(Local `validate` is blocked by
+  the registry being unreachable behind the agent proxy; CI's Terraform job runs the full check.)*
+- Dry-run each KQL in the Log Analytics / App Insights query editor over the last 24h to confirm it
+  parses and returns sensibly.
+- Operationally, confirm `TF_VAR_ALERT_EMAIL` / `TELEGRAM_CHAT_ID` / `enable_application_insights` are
+  set in the deploy env so the new alerts actually deliver.

--- a/docs/BACKLOG_STORIES/BITB-066-frontend-error-observability.md
+++ b/docs/BACKLOG_STORIES/BITB-066-frontend-error-observability.md
@@ -1,6 +1,6 @@
 # BITB-066: Frontend Error Observability
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done (delivered on the PR #824 branch, reuse-endpoint approach)
 **Priority:** P1 (High) — the web frontend has **no** general client-side error telemetry, so
 user-facing failures (including the 2026-07-05 outage) are invisible to the operator.
 **Size:** M (frontend reporter + backend metric/alert + middleware tweak)
@@ -32,25 +32,30 @@ An audit found the web frontend has **essentially zero** client-side error obser
 
 Contrast: Android has Firebase Crashlytics fully wired. The web asymmetry is the gap.
 
-## Acceptance Criteria
+## Acceptance Criteria (all delivered)
 
-- [ ] **Generalize the existing reporter.** Extend the `reportTurnstileError` → `/api/v1/client-errors`
-      pattern into a small global client-error reporter: a `window.onerror` +
-      `window.addEventListener("unhandledrejection", …)` handler and an `api.ts` failure hook, each
-      POSTing a structured `{type, detail}` to `/api/v1/client-errors`. Must be **sampled / rate-limited**
-      and fire-and-forget (never block the UI, never loop on its own failure), and must scrub PII from
-      `detail`.
-- [ ] **Make the endpoint alertable.** Have `/api/v1/client-errors` emit a custom metric (e.g.
-      `client.errors_total` with a `type` attribute) in addition to the current `logger.warning`, and
-      add a scheduled-query alert on a spike (mirror the `scripture_pipeline_errors` rule in
-      `deployment/monitoring.tf`). A storm of `Failed to fetch` from real browsers then pages us even
-      when backend telemetry is blind (as it was for the preflight crash).
-- [ ] **Stop dropping preflight failures server-side.** Make `AccessAuditMiddleware` count (or at least
-      not silently skip) `OPTIONS` 5xx, so a preflight failure is observable server-side too.
-- [ ] **Wire the App Router error routes.** Add `error.tsx` / `global-error.tsx` that report to the
-      same sink (not just render), so render-time crashes are captured.
+- [x] **Generalized reporter.** `frontend/src/lib/clientErrorReporter.ts` — global `window.onerror` +
+      `unhandledrejection` handlers (registered in `providers.tsx`), an `api.ts` failure hook (at the
+      generic non-2xx fallbacks + the network-`TypeError` catch in `sendMessage`/`streamMessage`), all
+      POSTing `{type, detail}` to `/api/v1/client-errors`. **Fire-and-forget** (never throws),
+      **PII-scrubbed** (`scrubPII`), and **capped/deduped** (≤10/session). Unit-tested (10 tests).
+- [x] **Alertable endpoint.** `/api/v1/client-errors` now validates a Pydantic model, caps `detail`,
+      is rate-limited, gated on `client_error_reporting_enabled`, and emits `client.errors_total`
+      (bounded `type` label). New `frontend_client_errors` spike alert (>20/10m, Sev 2) in
+      `deployment/monitoring.tf`.
+- [x] **Preflight failures observed server-side.** `AccessAuditMiddleware` now captures the `OPTIONS`
+      response and emits `api.preflight_errors_total` + a warning on a 5xx (still passes the response
+      through untouched).
+- [x] **App Router error route.** Added `frontend/src/app/global-error.tsx` (reports + renders) and
+      report from `ErrorBoundary.componentDidCatch`.
 
-## Open Decision — mechanism
+## Decision (resolved) — mechanism
+
+**Reuse the existing `/api/v1/client-errors` endpoint** (no new dependency, no third-party data
+sharing). A RUM SDK (App Insights JS / Sentry) remains a future option if richer client telemetry
+(source-mapped stack traces, sessions) is later needed.
+
+## Original open-decision note (superseded)
 
 Reuse the existing `/api/v1/client-errors` endpoint (no new dependency, no third-party data sharing,
 privacy-friendly) **vs.** adopt a full RUM SDK (Application Insights JS or Sentry) for richer client

--- a/docs/BACKLOG_STORIES/BITB-066-frontend-error-observability.md
+++ b/docs/BACKLOG_STORIES/BITB-066-frontend-error-observability.md
@@ -1,0 +1,82 @@
+# BITB-066: Frontend Error Observability
+
+**Status:** 🎯 Todo
+**Priority:** P1 (High) — the web frontend has **no** general client-side error telemetry, so
+user-facing failures (including the 2026-07-05 outage) are invisible to the operator.
+**Size:** M (frontend reporter + backend metric/alert + middleware tweak)
+**Created:** 2026-07-05
+**Incident ref:** the 2026-07-05 `_IncludedRouter` 500 (browser-only CORS-preflight failure) — see BITB-064.
+
+## User Story
+
+As the operator, I want the web frontend to report client-side errors (JS exceptions, unhandled
+promise rejections, and API/network failures) to a telemetry sink, and I want a spike in those to
+alert me, so that a browser-only outage is visible from the client side — not just the server — the
+way the Android app already reports via Firebase Crashlytics.
+
+## Problem / Motivation
+
+An audit found the web frontend has **essentially zero** client-side error observability:
+
+- No RUM/telemetry dependency at all (no App Insights JS, no Sentry) in `frontend/package.json`.
+- The React `ErrorBoundary` (`frontend/src/components/ErrorBoundary.tsx`) only `console.error`s.
+- API failures in `frontend/src/lib/api.ts` map to typed errors + `console.error` + an in-chat error
+  bubble, but are **reported nowhere**. A CORS-blocked preflight surfaces to JS as a bare `TypeError`
+  ("Failed to fetch") and is swallowed apart from console + UI.
+- No `error.tsx` / `global-error.tsx` in the App Router; `not-found.tsx` renders only.
+- Exactly **one** telemetry path exists — `reportTurnstileError()` POSTs to `/api/v1/client-errors`
+  (`frontend/src/lib/turnstile.tsx:68-74`; backend endpoint `api/main.py:359-374`) — and only for
+  Turnstile challenge failures, once per session.
+- The backend's `AccessAuditMiddleware` **explicitly skips `OPTIONS`**
+  (`api/middleware/access_audit.py:143-145`), so a preflight 500 isn't even counted server-side.
+
+Contrast: Android has Firebase Crashlytics fully wired. The web asymmetry is the gap.
+
+## Acceptance Criteria
+
+- [ ] **Generalize the existing reporter.** Extend the `reportTurnstileError` → `/api/v1/client-errors`
+      pattern into a small global client-error reporter: a `window.onerror` +
+      `window.addEventListener("unhandledrejection", …)` handler and an `api.ts` failure hook, each
+      POSTing a structured `{type, detail}` to `/api/v1/client-errors`. Must be **sampled / rate-limited**
+      and fire-and-forget (never block the UI, never loop on its own failure), and must scrub PII from
+      `detail`.
+- [ ] **Make the endpoint alertable.** Have `/api/v1/client-errors` emit a custom metric (e.g.
+      `client.errors_total` with a `type` attribute) in addition to the current `logger.warning`, and
+      add a scheduled-query alert on a spike (mirror the `scripture_pipeline_errors` rule in
+      `deployment/monitoring.tf`). A storm of `Failed to fetch` from real browsers then pages us even
+      when backend telemetry is blind (as it was for the preflight crash).
+- [ ] **Stop dropping preflight failures server-side.** Make `AccessAuditMiddleware` count (or at least
+      not silently skip) `OPTIONS` 5xx, so a preflight failure is observable server-side too.
+- [ ] **Wire the App Router error routes.** Add `error.tsx` / `global-error.tsx` that report to the
+      same sink (not just render), so render-time crashes are captured.
+
+## Open Decision — mechanism
+
+Reuse the existing `/api/v1/client-errors` endpoint (no new dependency, no third-party data sharing,
+privacy-friendly) **vs.** adopt a full RUM SDK (Application Insights JS or Sentry) for richer client
+telemetry (stack traces, sessions, source maps). Deferred — pick when this is scheduled. The
+acceptance criteria above assume the reuse approach as the low-risk default; adopting a RUM SDK would
+replace the first two criteria.
+
+## Notes / Reuse
+
+- Reporter pattern + endpoint already exist: `frontend/src/lib/turnstile.tsx:68-74`, `api/main.py:359-374`.
+- Metric + alert scaffolding to mirror: the custom-metric counters in `api/utils/metrics.py` and the
+  `azurerm_monitor_scheduled_query_rules_alert_v2` blocks in `deployment/monitoring.tf`.
+- Android reference (already solved there): Firebase Crashlytics in
+  `android/app/src/main/kotlin/org/voxquieta/app/VoxQuietaApp.kt` and `.../analytics/`.
+- Related: BITB-064 (browser smoke test) and BITB-065 (backend catch-all alerts) — this is the
+  client-side third of the same "make failures loud" effort.
+
+## Out of Scope
+
+- The backend alert net (BITB-065) and the browser smoke test / Turnstile-in-automation (BITB-064).
+- Full session-replay / product analytics.
+
+## Verification
+
+- Force a client error (throw in a component; block the API) and confirm a `/api/v1/client-errors`
+  POST is sent, the metric increments, and the spike alert fires in a test window.
+- Confirm sampling/rate-limiting caps the POST volume and that the reporter never recurses on its own
+  network failure.
+- `terraform fmt/validate` for the new alert; frontend unit test for the reporter's sampling + PII scrub.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -502,6 +502,45 @@ docker-compose exec postgres psql -U bible -d bibledb -c "SELECT 1;"
 
 ---
 
+## Production Incidents
+
+### Problem: Browser shows 500 / "Failed to fetch", but the native app and `curl` work fine
+
+**Symptoms:** The website chat fails for browser users (Firefox/Chrome show a CORS or network
+error, or the frontend renders a generic "something went wrong" bubble), yet the **Android app keeps
+working** and a direct `curl -X POST .../api/v1/chat/stream` returns 200. Health checks and the
+`synthetic-chat` monitor stay green.
+
+**Diagnosis:** This is the signature of a **CORS-preflight-only failure**. Browsers send a cross-origin
+`OPTIONS` preflight before the real `POST`; native apps and `curl` do not. If only the preflight
+breaks, every non-browser client (including all synthetic probes that don't send a preflight) stays
+green while every browser is down. Confirm with the exact preflight:
+
+```bash
+curl -i -X OPTIONS https://api.voxquieta.org/api/v1/chat/stream \
+  -H 'Origin: https://voxquieta.org' \
+  -H 'Access-Control-Request-Method: POST' \
+  -H 'Access-Control-Request-Headers: content-type,x-turnstile-token'
+# Healthy: HTTP 200/204 with Access-Control-Allow-Origin echoing the Origin.
+# Broken:  HTTP 500 (or missing Access-Control-Allow-* headers).
+```
+
+**Common root cause:** a **FastAPI-vs-OpenTelemetry version skew**. FastAPI ≥ 0.137 / starlette ≥ 1.3
+store an `_IncludedRouter` object in `app.routes`; an older `opentelemetry-instrumentation-fastapi`
+(pinned transitively by `azure-monitor-opentelemetry`) does `route.path` on it and raises
+`'_IncludedRouter' object has no attribute 'path'` on **every preflight** — but only when App Insights
+instrumentation is active (production), so it never reproduces in local/CI without
+`APPLICATIONINSIGHTS_CONNECTION_STRING` set. Fix: bump `azure-monitor-opentelemetry` to a version whose
+instrumentation handles `_IncludedRouter` (see PR #824 / BITB-064). More generally: this class lives in
+the OTel/CORS middleware **above** the app, so it emits a `uvicorn` "Exception in ASGI application"
+log line rather than the app's `| ERROR |` format, and records no App Insights `requests` row.
+
+**Which alerts catch it:** the `cross-origin-smoke` job in `prod-monitor.yml`, the Azure
+`*-preflight-failed` availability alert, and the `*-backend-asgi-exceptions` log alert (all BITB-064 /
+BITB-065). If none fired, verify `TF_VAR_ALERT_EMAIL` / `TELEGRAM_CHAT_ID` are set in the deploy env.
+
+---
+
 ## Getting Help
 
 If issues persist:

--- a/frontend/e2e/prod-chat-smoke.spec.ts
+++ b/frontend/e2e/prod-chat-smoke.spec.ts
@@ -24,13 +24,17 @@ import { test, expect } from "@playwright/test";
 const SMOKE_SECRET = process.env.SMOKE_PROBE_SECRET;
 
 test.describe("production chat smoke", () => {
-  test.skip(!SMOKE_SECRET, "SMOKE_PROBE_SECRET not set — skipping prod smoke test");
+  test.skip(
+    !SMOKE_SECRET,
+    "SMOKE_PROBE_SECRET not set — skipping prod smoke test",
+  );
 
   test("submitting a message streams an assistant reply", async ({ page }) => {
     // Inject the smoke secret before any app code runs.
     await page.addInitScript((secret) => {
-      (window as unknown as { __VOXQUIETA_SMOKE_SECRET__?: string }).__VOXQUIETA_SMOKE_SECRET__ =
-        secret;
+      (
+        window as unknown as { __VOXQUIETA_SMOKE_SECRET__?: string }
+      ).__VOXQUIETA_SMOKE_SECRET__ = secret;
     }, SMOKE_SECRET);
 
     await page.goto("/en");

--- a/frontend/e2e/prod-chat-smoke.spec.ts
+++ b/frontend/e2e/prod-chat-smoke.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Production browser smoke test (BITB-064).
+ *
+ * The full real user journey nothing else covers: a real Chromium browser loads
+ * the deployed frontend, submits a chat message, and asserts a streamed
+ * assistant reply renders — which exercises the rendered frontend → real
+ * cross-origin CORS preflight → instrumented backend → SSE streaming, together.
+ *
+ * Run against production with:
+ *   PLAYWRIGHT_BASE_URL=https://voxquieta.org \
+ *   SMOKE_PROBE_SECRET=<secret> npm run test:e2e -- prod-chat-smoke.spec.ts
+ *
+ * Turnstile: a headless CI browser can't solve the invisible challenge, so the
+ * test injects the smoke secret (window.__VOXQUIETA_SMOKE_SECRET__) via
+ * addInitScript before navigation. api.ts then attaches it as
+ * X-Monitor-Probe-Secret (backend bypasses Turnstile + rate limits) and the UI
+ * relaxes the send gate. The secret exists only in this browser session — never
+ * in the shipped bundle. Skipped unless SMOKE_PROBE_SECRET is set, so local
+ * `npm run test:e2e` never hits production.
+ */
+
+const SMOKE_SECRET = process.env.SMOKE_PROBE_SECRET;
+
+test.describe("production chat smoke", () => {
+  test.skip(!SMOKE_SECRET, "SMOKE_PROBE_SECRET not set — skipping prod smoke test");
+
+  test("submitting a message streams an assistant reply", async ({ page }) => {
+    // Inject the smoke secret before any app code runs.
+    await page.addInitScript((secret) => {
+      (window as unknown as { __VOXQUIETA_SMOKE_SECRET__?: string }).__VOXQUIETA_SMOKE_SECRET__ =
+        secret;
+    }, SMOKE_SECRET);
+
+    await page.goto("/en");
+
+    const input = page.getByPlaceholder(/Share what's on your heart/i);
+    await expect(input).toBeVisible({ timeout: 30_000 });
+    await input.fill("What does John 3:16 say?");
+
+    const submit = page.locator('form button[type="submit"]');
+    await expect(submit).toBeEnabled({ timeout: 30_000 });
+    await submit.click();
+
+    // The streamed assistant reply must render with non-empty text. Generous
+    // timeout to tolerate backend cold start.
+    const assistant = page.getByTestId("assistant-message").last();
+    await expect(assistant).toBeVisible({ timeout: 60_000 });
+    await expect
+      .poll(async () => (await assistant.innerText()).trim().length, {
+        timeout: 60_000,
+        message: "assistant reply never accrued streamed text",
+      })
+      .toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -59,6 +59,7 @@ import {
 import { updateMultiWordNames } from "@/lib/versePatterns";
 import { mergeVerses } from "@/lib/mergeVerses";
 import { useTurnstile } from "@/lib/turnstile";
+import { isSmokeMode } from "@/lib/smoke";
 import { useRouter, usePathname } from "@/i18n/navigation";
 
 // Extended message type with message_id for feedback tracking
@@ -92,8 +93,12 @@ export default function ChatIsland({
   // Block submissions until /config has resolved: until then we don't yet
   // know whether Turnstile is enabled, and a fast click could fire a POST
   // without an X-Turnstile-Token header and get bounced as 403.
+  // BITB-064: under the browser smoke test the backend bypasses Turnstile via
+  // the injected smoke secret, so don't leave the send button disabled waiting
+  // for a token a headless bot can't earn.
   const turnstileBlocked =
-    !turnstileConfigLoaded || (turnstileEnabled && !turnstileReady);
+    !isSmokeMode() &&
+    (!turnstileConfigLoaded || (turnstileEnabled && !turnstileReady));
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");

--- a/frontend/src/app/[locale]/providers.tsx
+++ b/frontend/src/app/[locale]/providers.tsx
@@ -49,14 +49,16 @@ function TurnstileTokenSync({ children }: { children: React.ReactNode }) {
   // observable. Registered once for the app lifetime.
   useEffect(() => {
     const onError = (e: ErrorEvent) => {
-      const detail = e.error?.stack || e.message || String(e.error ?? "unknown");
+      const detail =
+        e.error?.stack || e.message || String(e.error ?? "unknown");
       reportClientError("window_onerror", detail);
     };
     const onRejection = (e: PromiseRejectionEvent) => {
       const reason = e.reason;
       const detail =
-        (reason instanceof Error ? reason.stack || reason.message : String(reason)) ||
-        "unknown";
+        (reason instanceof Error
+          ? reason.stack || reason.message
+          : String(reason)) || "unknown";
       reportClientError("unhandledrejection", detail);
     };
     window.addEventListener("error", onError);

--- a/frontend/src/app/[locale]/providers.tsx
+++ b/frontend/src/app/[locale]/providers.tsx
@@ -8,6 +8,7 @@ import {
   setTurnstileAwaiter,
 } from "@/lib/api";
 import { useTurnstile } from "@/lib/turnstile";
+import { reportClientError } from "@/lib/clientErrorReporter";
 import { SplashScreen } from "@/components/SplashScreen";
 
 function hasSplashCookie(): boolean {
@@ -42,6 +43,29 @@ function TurnstileTokenSync({ children }: { children: React.ReactNode }) {
     setTurnstileAwaiter(awaitToken);
     return () => setTurnstileAwaiter(null);
   }, [awaitToken]);
+
+  // Global client-error reporting (BITB-066): surface uncaught JS errors and
+  // unhandled promise rejections to the backend so a browser-side outage is
+  // observable. Registered once for the app lifetime.
+  useEffect(() => {
+    const onError = (e: ErrorEvent) => {
+      const detail = e.error?.stack || e.message || String(e.error ?? "unknown");
+      reportClientError("window_onerror", detail);
+    };
+    const onRejection = (e: PromiseRejectionEvent) => {
+      const reason = e.reason;
+      const detail =
+        (reason instanceof Error ? reason.stack || reason.message : String(reason)) ||
+        "unknown";
+      reportClientError("unhandledrejection", detail);
+    };
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+    };
+  }, []);
 
   return <>{children}</>;
 }

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * Root global error boundary (BITB-066).
+ *
+ * Next.js renders this when an error is thrown in the root layout — the one
+ * place the in-tree <ErrorBoundary> component cannot catch. It must render its
+ * own <html>/<body>. Besides showing a minimal fallback, it reports the error
+ * so a root-layout crash is observable client-side.
+ */
+
+import { useEffect } from "react";
+import { reportClientError } from "@/lib/clientErrorReporter";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    reportClientError("react_render", error.stack || error.message);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "system-ui, sans-serif",
+          padding: "1rem",
+          textAlign: "center",
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: "1.5rem", marginBottom: "0.5rem" }}>
+            Something went wrong
+          </h1>
+          <p style={{ color: "#555", marginBottom: "1.5rem" }}>
+            Please try again in a moment.
+          </p>
+          <button
+            onClick={() => reset()}
+            style={{
+              padding: "0.75rem 1.5rem",
+              borderRadius: "0.5rem",
+              border: "none",
+              background: "#4f46e5",
+              color: "white",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -203,6 +203,7 @@ export default function ChatMessage({
 
   return (
     <div
+      data-testid={isUser ? "user-message" : "assistant-message"}
       className={`flex gap-2 sm:gap-4 message-enter ${isUser ? "justify-end" : "justify-start"}`}
     >
       {!isUser && (

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@
 
 import React, { Component, ReactNode } from "react";
 import { useTranslations } from "next-intl";
+import { reportClientError } from "@/lib/clientErrorReporter";
 
 interface Props {
   children: ReactNode;
@@ -24,6 +25,7 @@ class ErrorBoundaryClass extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error("ErrorBoundary caught an error:", error, errorInfo);
+    reportClientError("react_render", error.stack || error.message);
   }
 
   render() {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,8 @@
  * API client for Bible Chat backend
  */
 
+import { reportClientError } from "./clientErrorReporter";
+
 // In production builds, NEXT_PUBLIC_API_URL must be set at build time.
 // The fallback is only for local development.
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
@@ -494,6 +496,9 @@ export async function sendMessage(
       if (response.status === 503 || response.status === 502) {
         throw new ColdStartError("Backend is starting up");
       }
+      // Unexpected non-2xx (not one of the handled/expected statuses above):
+      // report so a systemic backend failure is observable client-side.
+      reportClientError("api_failure", `sendMessage HTTP ${response.status}`);
       throw new Error(`API error: ${response.status}`);
     }
 
@@ -507,6 +512,10 @@ export async function sendMessage(
       error instanceof TypeError ||
       (error instanceof DOMException && error.name === "AbortError")
     ) {
+      // A network TypeError ("Failed to fetch") is also how a CORS-blocked
+      // preflight surfaces to JS — the exact browser-only signature we now
+      // want visibility into.
+      reportClientError("api_failure", `sendMessage network: ${String(error)}`);
       throw new ColdStartError("Backend is warming up, please wait...");
     }
     throw error;
@@ -658,6 +667,7 @@ export async function* streamMessage(
         throw new MessageTooLongError();
       }
     }
+    reportClientError("api_failure", `streamMessage HTTP ${response.status}`);
     throw new Error(`API error: ${response.status}`);
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,7 @@
  */
 
 import { reportClientError } from "./clientErrorReporter";
+import { getSmokeSecret } from "./smoke";
 
 // In production builds, NEXT_PUBLIC_API_URL must be set at build time.
 // The fallback is only for local development.
@@ -199,6 +200,14 @@ function getHeaders(): HeadersInit {
   };
   if (turnstileToken) {
     headers["X-Turnstile-Token"] = turnstileToken;
+  }
+  // BITB-064: the production browser smoke test injects a smoke secret at
+  // runtime (never shipped in the bundle); when present, attach it so the
+  // backend bypasses Turnstile + rate limits deterministically. Inert (null)
+  // for real users.
+  const smokeSecret = getSmokeSecret();
+  if (smokeSecret) {
+    headers["X-Monitor-Probe-Secret"] = smokeSecret;
   }
   return headers;
 }

--- a/frontend/src/lib/clientErrorReporter.test.ts
+++ b/frontend/src/lib/clientErrorReporter.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  scrubPII,
+  shouldReport,
+  reportClientError,
+  __resetReporterStateForTest,
+  MAX_REPORTS_PER_SESSION,
+  MAX_DETAIL_CHARS,
+} from "./clientErrorReporter";
+
+beforeEach(() => {
+  __resetReporterStateForTest();
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true } as Response));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("scrubPII", () => {
+  it("redacts email addresses", () => {
+    expect(scrubPII("failed for jane.doe@example.com now")).toBe(
+      "failed for [email] now",
+    );
+  });
+
+  it("redacts JWT-like and long token strings", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w";
+    expect(scrubPII(`token ${jwt} leaked`)).toContain("[jwt]");
+    expect(scrubPII("key=ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")).toContain("[token]");
+  });
+
+  it("redacts long digit runs", () => {
+    expect(scrubPII("phone 5551234567 here")).toBe("phone [num] here");
+  });
+
+  it("caps length at MAX_DETAIL_CHARS", () => {
+    // Many short words (not one long token-like run, which would be redacted
+    // to a placeholder before truncation).
+    const long = "word ".repeat(MAX_DETAIL_CHARS);
+    expect(scrubPII(long).length).toBe(MAX_DETAIL_CHARS);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(scrubPII("")).toBe("");
+  });
+});
+
+describe("shouldReport (cap + dedupe)", () => {
+  it("dedupes identical reports", () => {
+    expect(shouldReport("api_failure", "boom")).toBe(true);
+    expect(shouldReport("api_failure", "boom")).toBe(false);
+  });
+
+  it("enforces the per-session cap", () => {
+    for (let i = 0; i < MAX_REPORTS_PER_SESSION; i++) {
+      expect(shouldReport("api_failure", `unique-${i}`)).toBe(true);
+    }
+    expect(shouldReport("api_failure", "one-too-many")).toBe(false);
+  });
+});
+
+describe("reportClientError", () => {
+  it("POSTs a scrubbed {type, detail} body to /api/v1/client-errors", () => {
+    reportClientError("window_onerror", "boom for user@example.com");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(String(url)).toContain("/api/v1/client-errors");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.type).toBe("window_onerror");
+    expect(body.detail).toBe("boom for [email]");
+  });
+
+  it("dedupes so a repeating error only POSTs once", () => {
+    reportClientError("api_failure", "same");
+    reportClientError("api_failure", "same");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("never throws even if fetch rejects", () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error("network down")));
+    expect(() => reportClientError("react_render", "x")).not.toThrow();
+  });
+});

--- a/frontend/src/lib/clientErrorReporter.test.ts
+++ b/frontend/src/lib/clientErrorReporter.test.ts
@@ -26,9 +26,10 @@ describe("scrubPII", () => {
 
   it("redacts JWT-like and long token strings", () => {
     const jwt =
-      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w";
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w"; // pragma: allowlist secret
     expect(scrubPII(`token ${jwt} leaked`)).toContain("[jwt]");
-    expect(scrubPII("key=ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")).toContain("[token]");
+    const longToken = "key=ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"; // pragma: allowlist secret
+    expect(scrubPII(longToken)).toContain("[token]");
   });
 
   it("redacts long digit runs", () => {
@@ -65,7 +66,8 @@ describe("reportClientError", () => {
   it("POSTs a scrubbed {type, detail} body to /api/v1/client-errors", () => {
     reportClientError("window_onerror", "boom for user@example.com");
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0];
     expect(String(url)).toContain("/api/v1/client-errors");
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body.type).toBe("window_onerror");

--- a/frontend/src/lib/clientErrorReporter.ts
+++ b/frontend/src/lib/clientErrorReporter.ts
@@ -1,0 +1,91 @@
+/**
+ * Client-side error reporter (BITB-066).
+ *
+ * Sends JS errors, unhandled promise rejections, React render errors, and API
+ * failures to the backend POST /api/v1/client-errors sink, which records the
+ * client.errors_total metric so a spike (e.g. a browser-only outage) alerts.
+ *
+ * Design constraints:
+ *  - Fire-and-forget: it must NEVER throw, or it would re-enter the
+ *    unhandledrejection handler and loop.
+ *  - PII-scrubbing + length-capped detail (mirrors the backend cap).
+ *  - Per-session cap + dedupe so a repeating error can't flood the endpoint.
+ *  - SSR-safe: every window access is guarded.
+ *
+ * Mirrors the existing reportTurnstileError pattern in lib/turnstile.tsx.
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+/** Bounded set of report types — matches the backend metric `type` whitelist. */
+export type ClientErrorType =
+  | "window_onerror"
+  | "unhandledrejection"
+  | "api_failure"
+  | "react_render";
+
+/** Max reports per page load — a repeating error can't flood the endpoint. */
+export const MAX_REPORTS_PER_SESSION = 10;
+/** Detail length cap (mirrors settings.client_error_max_detail_chars). */
+export const MAX_DETAIL_CHARS = 500;
+
+let reportCount = 0;
+const seenKeys = new Set<string>();
+
+/** Test-only: reset the per-session cap/dedupe state. */
+export function __resetReporterStateForTest(): void {
+  reportCount = 0;
+  seenKeys.clear();
+}
+
+/**
+ * Remove obvious PII / secrets from a free-text error detail and cap its length.
+ * Pure function — unit-testable without a DOM or fetch.
+ */
+export function scrubPII(detail: string): string {
+  if (!detail) return "";
+  const scrubbed = detail
+    // emails
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[email]")
+    // JWTs / bearer / API-key-like long tokens
+    .replace(/\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, "[jwt]")
+    .replace(/\b[A-Za-z0-9_-]{24,}\b/g, "[token]")
+    // long digit runs (phone numbers, ids)
+    .replace(/\b\d{7,}\b/g, "[num]");
+  return scrubbed.length > MAX_DETAIL_CHARS
+    ? scrubbed.slice(0, MAX_DETAIL_CHARS)
+    : scrubbed;
+}
+
+/**
+ * Whether this (type, detail) should be reported: enforces the per-session cap
+ * and dedupes identical reports. Pure aside from module-level counters.
+ */
+export function shouldReport(type: ClientErrorType, detail: string): boolean {
+  if (reportCount >= MAX_REPORTS_PER_SESSION) return false;
+  const key = `${type}:${detail}`;
+  if (seenKeys.has(key)) return false;
+  seenKeys.add(key);
+  reportCount += 1;
+  return true;
+}
+
+/**
+ * Report a client-side error. Fire-and-forget; never throws.
+ */
+export function reportClientError(type: ClientErrorType, rawDetail: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const detail = scrubPII(rawDetail);
+    if (!shouldReport(type, detail)) return;
+    // fire-and-forget; swallow all errors so we never re-enter our own handler
+    void fetch(`${API_URL}/api/v1/client-errors`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type, detail }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // never throw from the reporter
+  }
+}

--- a/frontend/src/lib/clientErrorReporter.ts
+++ b/frontend/src/lib/clientErrorReporter.ts
@@ -48,7 +48,10 @@ export function scrubPII(detail: string): string {
     // emails
     .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, "[email]")
     // JWTs / bearer / API-key-like long tokens
-    .replace(/\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g, "[jwt]")
+    .replace(
+      /\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+      "[jwt]",
+    )
     .replace(/\b[A-Za-z0-9_-]{24,}\b/g, "[token]")
     // long digit runs (phone numbers, ids)
     .replace(/\b\d{7,}\b/g, "[num]");
@@ -73,7 +76,10 @@ export function shouldReport(type: ClientErrorType, detail: string): boolean {
 /**
  * Report a client-side error. Fire-and-forget; never throws.
  */
-export function reportClientError(type: ClientErrorType, rawDetail: string): void {
+export function reportClientError(
+  type: ClientErrorType,
+  rawDetail: string,
+): void {
   if (typeof window === "undefined") return;
   try {
     const detail = scrubPII(rawDetail);

--- a/frontend/src/lib/smoke.ts
+++ b/frontend/src/lib/smoke.ts
@@ -1,0 +1,35 @@
+/**
+ * Smoke-test bypass reader (BITB-064).
+ *
+ * The production browser smoke test needs to get past Cloudflare Turnstile
+ * deterministically (a headless CI browser can't reliably solve an invisible
+ * challenge). Rather than bake a bypass secret into the shipped bundle — which
+ * would hand every real user a Turnstile + rate-limit bypass — the deployed
+ * bundle only READS a value that the Playwright test injects at runtime via
+ * `addInitScript` (so it exists solely in the ephemeral CI browser session):
+ *
+ *     window.__VOXQUIETA_SMOKE_SECRET__ = "<secret>";
+ *
+ * When present, api.ts attaches it as the X-Monitor-Probe-Secret header and the
+ * chat UI relaxes the send gate. For real users the global is `undefined`, so
+ * this is entirely inert. The value is NEVER a NEXT_PUBLIC_* env var and is
+ * never shipped in the bundle.
+ */
+
+declare global {
+  interface Window {
+    __VOXQUIETA_SMOKE_SECRET__?: unknown;
+  }
+}
+
+/** The injected smoke secret, or null (real users, SSR). */
+export function getSmokeSecret(): string | null {
+  if (typeof window === "undefined") return null;
+  const value = window.__VOXQUIETA_SMOKE_SECRET__;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/** Whether the current browser session is a smoke test. */
+export function isSmokeMode(): boolean {
+  return getSmokeSecret() !== null;
+}

--- a/scripts/monitor/synthetic_preflight.py
+++ b/scripts/monitor/synthetic_preflight.py
@@ -1,0 +1,296 @@
+"""
+Cross-origin (browser-shaped) smoke probe for the chat endpoint.
+
+Every other synthetic probe sends the API the *non-browser* way — a direct
+httpx/curl request with no Origin and no CORS preflight — so a browser-only
+outage stays invisible. That is exactly what happened in the 2026-07-05
+`_IncludedRouter` incident: `OPTIONS /api/v1/chat/stream` (the browser's CORS
+preflight) returned HTTP 500 under the instrumented production backend, while
+direct GET/POST returned 200, so nothing alerted. See BITB-064.
+
+This probe reproduces the actual browser request sequence against the
+**instrumented production** backend, in two steps:
+
+1. CORS preflight — `OPTIONS /api/v1/chat/stream` with the same Origin +
+   Access-Control-Request-* headers a browser sends. Asserts a 2xx/204 and that
+   the response echoes `Access-Control-Allow-Origin` and advertises
+   `Access-Control-Allow-Methods`. This is the direct, telemetry-independent
+   catch for the incident class.
+
+2. Cross-origin POST — `POST /api/v1/chat/stream` with the `Origin` header set
+   (so the response CORS headers are exercised on the real request) plus the
+   `X-Monitor-Probe-Secret` bypass (to pass Turnstile + rate limits
+   deterministically). Asserts a streamed `content` + `completion` SSE chunk
+   arrives and that `Access-Control-Allow-Origin` is present on the response.
+
+Note: this bypasses Turnstile *verification* by design so the probe is
+deterministic. The full browser journey (real widget, real streaming rendered
+in Chromium) is the open part of BITB-064.
+
+Exit codes:
+    0 — probe passed (preflight OK + streamed answer with CORS headers)
+    1 — probe failed (preflight non-2xx / missing CORS headers, HTTP error,
+        missing SSE chunks, in-band error, or timeout)
+
+The failure detail is also written to the path passed via --detail-out so the
+caller (CI workflow) can include it in the alert message.
+
+Required environment variables:
+    BACKEND_URL              — backend ACA URL, e.g. https://bible-app-backend.<...>.azurecontainerapps.io
+    MONITOR_PROBE_SECRET     — shared secret matching settings.monitor_probe_secret
+                               (sent as X-Monitor-Probe-Secret to bypass Turnstile + rate limits)
+
+Optional:
+    PROBE_ORIGIN             — Origin header to send (default: https://voxquieta.org)
+    PROBE_MESSAGE            — prompt to send on the POST (default: "What does John 3:16 say?")
+    PROBE_TIMEOUT_SECONDS    — overall timeout for the streamed POST (default: 30)
+    PROBE_FIRST_CHUNK_SECONDS — fail if no content chunk arrives within this (default: 20)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+
+import httpx
+
+CHAT_STREAM_PATH = "/api/v1/chat/stream"
+# The exact headers a browser preflights the streaming chat request with — the
+# `x-turnstile-token` custom header is what forces the preflight in the first place.
+PREFLIGHT_REQUEST_HEADERS = "content-type,x-turnstile-token"
+
+
+def fail(detail: str, detail_out: str | None) -> int:
+    print(f"PROBE FAIL: {detail}", file=sys.stderr)
+    if detail_out:
+        try:
+            with open(detail_out, "w", encoding="utf-8") as f:
+                f.write(detail)
+        except OSError as e:
+            print(f"could not write detail to {detail_out}: {e}", file=sys.stderr)
+    return 1
+
+
+def parse_sse_line(line: str) -> dict | str | None:
+    """Parse one SSE 'data:' line. Returns the JSON object, the literal '[DONE]',
+    or None for non-data lines (comments, blank lines, event:, id:, retry:)."""
+    if not line.startswith("data:"):
+        return None
+    payload = line[5:].lstrip()
+    if payload == "[DONE]":
+        return "[DONE]"
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+
+
+def check_preflight(
+    client: httpx.Client, url: str, origin: str, detail_out: str | None
+) -> int | None:
+    """Send the browser CORS preflight. Returns an exit code on failure, or None
+    if the preflight passed."""
+    req_headers = {
+        "Origin": origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": PREFLIGHT_REQUEST_HEADERS,
+    }
+    try:
+        resp = client.request("OPTIONS", url, headers=req_headers)
+    except httpx.HTTPError as e:
+        return fail(f"preflight OPTIONS {url} raised: {e}", detail_out)
+
+    # A crashing/instrumentation-broken backend returns 500 here (the incident);
+    # a healthy CORS layer returns 200/204.
+    if resp.status_code >= 400:
+        body = resp.text[:500]
+        hint = (
+            " A 5xx here is the browser-only failure signature of the "
+            "_IncludedRouter/OTel incident (BITB-064)."
+            if resp.status_code >= 500
+            else ""
+        )
+        return fail(
+            f"preflight OPTIONS {url} returned HTTP {resp.status_code} "
+            f"(expected 2xx).{hint} body={body!r}",
+            detail_out,
+        )
+
+    acao = resp.headers.get("access-control-allow-origin")
+    acam = resp.headers.get("access-control-allow-methods")
+    if acao not in (origin, "*"):
+        return fail(
+            f"preflight succeeded (HTTP {resp.status_code}) but "
+            f"Access-Control-Allow-Origin={acao!r} does not allow Origin {origin!r} "
+            f"— the browser would block the request as a CORS error",
+            detail_out,
+        )
+    if not acam:
+        return fail(
+            f"preflight succeeded (HTTP {resp.status_code}, ACAO={acao!r}) but "
+            f"Access-Control-Allow-Methods is missing — CORS response is malformed",
+            detail_out,
+        )
+    print(
+        f"PREFLIGHT OK: HTTP {resp.status_code} "
+        f"ACAO={acao!r} ACAM={acam!r} for Origin {origin!r}"
+    )
+    return None
+
+
+def check_cross_origin_stream(
+    client: httpx.Client,
+    url: str,
+    origin: str,
+    probe_secret: str,
+    message: str,
+    overall_timeout: float,
+    first_chunk_timeout: float,
+    detail_out: str | None,
+) -> int:
+    """Send the real cross-origin POST and validate the streamed SSE response.
+    Returns a process exit code (0 pass, 1 fail)."""
+    session_id = f"monitor-preflight-{uuid.uuid4().hex[:12]}"
+    body = {
+        "message": message,
+        "conversation_history": [],
+        "include_search": True,
+        "session_id": session_id,
+    }
+    headers = {
+        "Content-Type": "application/json",
+        # Real browser sends Origin on the actual request too; setting it here
+        # exercises the response CORS headers on the POST, not just the preflight.
+        "Origin": origin,
+        # Bypass Turnstile + rate limits so the probe is deterministic.
+        "X-Monitor-Probe-Secret": probe_secret,
+    }
+
+    started = time.monotonic()
+    saw_content = False
+    saw_completion = False
+    first_chunk_at: float | None = None
+    last_chunk: dict | None = None
+
+    try:
+        with client.stream("POST", url, json=body, headers=headers) as response:
+            if response.status_code != 200:
+                text = response.read().decode("utf-8", errors="replace")[:500]
+                return fail(
+                    f"cross-origin POST {url} returned HTTP {response.status_code}: {text}",
+                    detail_out,
+                )
+            acao = response.headers.get("access-control-allow-origin")
+            if acao not in (origin, "*"):
+                return fail(
+                    f"cross-origin POST succeeded but Access-Control-Allow-Origin={acao!r} "
+                    f"does not allow Origin {origin!r} — a browser would block reading the "
+                    f"streamed response",
+                    detail_out,
+                )
+
+            for raw_line in response.iter_lines():
+                if time.monotonic() - started > overall_timeout:
+                    return fail(
+                        f"overall timeout {overall_timeout}s exceeded "
+                        f"(saw_content={saw_content} last={last_chunk!r})",
+                        detail_out,
+                    )
+                if not saw_content and time.monotonic() - started > first_chunk_timeout:
+                    return fail(
+                        f"no content chunk within {first_chunk_timeout}s (last={last_chunk!r})",
+                        detail_out,
+                    )
+
+                parsed = parse_sse_line(raw_line)
+                if parsed is None:
+                    continue
+                if parsed == "[DONE]":
+                    break
+                last_chunk = parsed
+                chunk_type = parsed.get("type")
+                if chunk_type == "error":
+                    err = parsed.get("error", "<no error field>")
+                    code = parsed.get("error_code")
+                    return fail(
+                        f"in-band SSE error: {err}" + (f" (code={code})" if code else ""),
+                        detail_out,
+                    )
+                if chunk_type == "content":
+                    if not saw_content:
+                        first_chunk_at = time.monotonic() - started
+                    saw_content = True
+                elif chunk_type == "completion":
+                    saw_completion = True
+    except httpx.ReadTimeout:
+        return fail(
+            f"server unresponsive: no data received within {first_chunk_timeout}s "
+            f"(saw_content={saw_content})",
+            detail_out,
+        )
+    except httpx.TimeoutException as e:
+        return fail(f"httpx timeout: {e}", detail_out)
+    except httpx.HTTPError as e:
+        return fail(f"httpx error: {e}", detail_out)
+
+    if not saw_content:
+        return fail("stream ended without any content chunk", detail_out)
+    if not saw_completion:
+        return fail(
+            f"stream ended without completion chunk (last={last_chunk!r})",
+            detail_out,
+        )
+
+    elapsed = time.monotonic() - started
+    first = f"{first_chunk_at:.2f}s" if first_chunk_at is not None else "n/a"
+    print(f"CROSS-ORIGIN STREAM OK: first_chunk={first} total={elapsed:.2f}s session={session_id}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Cross-origin CORS-preflight smoke probe.")
+    parser.add_argument(
+        "--detail-out",
+        default=None,
+        help="Path to write failure detail (for CI alert payload).",
+    )
+    args = parser.parse_args()
+
+    backend_url = os.environ.get("BACKEND_URL", "").rstrip("/")
+    probe_secret = os.environ.get("MONITOR_PROBE_SECRET", "")
+    if not backend_url:
+        return fail("BACKEND_URL env var is required", args.detail_out)
+    if not probe_secret:
+        return fail("MONITOR_PROBE_SECRET env var is required", args.detail_out)
+
+    origin = os.environ.get("PROBE_ORIGIN", "https://voxquieta.org").rstrip("/")
+    message = os.environ.get("PROBE_MESSAGE", "What does John 3:16 say?")
+    overall_timeout = float(os.environ.get("PROBE_TIMEOUT_SECONDS", "30"))
+    first_chunk_timeout = float(os.environ.get("PROBE_FIRST_CHUNK_SECONDS", "20"))
+
+    url = f"{backend_url}{CHAT_STREAM_PATH}"
+
+    with httpx.Client(
+        timeout=httpx.Timeout(connect=10.0, read=first_chunk_timeout, write=10.0, pool=5.0)
+    ) as client:
+        preflight_result = check_preflight(client, url, origin, args.detail_out)
+        if preflight_result is not None:
+            return preflight_result
+        return check_cross_origin_stream(
+            client,
+            url,
+            origin,
+            probe_secret,
+            message,
+            overall_timeout,
+            first_chunk_timeout,
+            args.detail_out,
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Monitoring & alerting hardening, follow-up to the `_IncludedRouter` 500 fix (PR #824, already merged). That incident was a total browser-facing outage that produced **no alert and no Telegram notification** — because every probe hit the API the non-browser way and no rule watched a plain backend 5xx. This closes those gaps across three stories.

> Rebased onto latest `main` (the #824 fix is already merged as `033ed6b`); these are the 4 unmerged follow-up commits, not a re-open of #824.

## BITB-065 — Backend catch-all error alerting
- New Azure Monitor scheduled-query alerts in `deployment/monitoring.tf`: `backend_5xx_rate` (App Insights `requests`), `backend_unhandled_exceptions` (`exceptions`), and `backend_asgi_exceptions` (the uvicorn "Exception in ASGI application" console line — the one in-telemetry signal the `_IncludedRouter` crash actually emitted, since it records no `requests` row). KQL lifted from the existing perf workbook; all reuse the `ops_email` action group → email + Telegram.

## BITB-064 — Real cross-origin smoke test + browser smoke test
- **Scripted cross-origin probe** (`scripts/monitor/synthetic_preflight.py` + `cross-origin-smoke` job in `prod-monitor.yml`): sends the real CORS preflight (`OPTIONS` + `Origin`) then a cross-origin POST, asserting 2xx + `Access-Control-Allow-*` + a streamed answer. Verified: fails on the broken OTel pin, passes on the fixed one.
- **Always-on Azure preflight web test** (`backend_preflight` + `backend_preflight_availability` alert) — a second channel independent of the GitHub cron.
- **Production browser smoke test** (`frontend/e2e/prod-chat-smoke.spec.ts` + hourly `prod-browser-smoke.yml`): real Chromium loads voxquieta.org, submits a chat, asserts a **streamed assistant reply**. Turnstile is passed via a **separate, rotatable `smoke_probe_secret`** injected at test time (`addInitScript`) — **never shipped in the bundle** (verified: the bundle contains only the `window.__VOXQUIETA_SMOKE_SECRET__` reader, inert for real users).
- Troubleshooting runbook note for "browser 500 but native app/curl fine".

## BITB-066 — Frontend error observability
- `frontend/src/lib/clientErrorReporter.ts` — fire-and-forget POST to `/api/v1/client-errors`, PII-scrubbed, length-capped, per-session capped + deduped, never throws (10 unit tests). Wired into global `window.onerror`/`unhandledrejection`, `ErrorBoundary`, a new `global-error.tsx`, and the `api.ts` chat-path failure sites (incl. the network `TypeError` a CORS-blocked preflight produces).
- Backend `/api/v1/client-errors` hardened (Pydantic model + cap, rate-limited, flag-gated) and now emits `client.errors_total`; `AccessAuditMiddleware` emits `api.preflight_errors_total` on `OPTIONS` 5xx; new `frontend_client_errors` spike alert.

## Test plan
- [x] Frontend: `tsc` clean, eslint clean, **697/697 unit tests pass**, `next build` succeeds, Playwright spec compiles — all against latest `main`.
- [x] Backend: compiles, `ruff` + `black` clean; `test_client_errors.py` added.
- [x] Terraform: `fmt` clean on all touched files (`validate` runs in the PR's tf-validate job).
- [x] Cross-origin probe verified end-to-end against a running server on both the broken and fixed OTel pins.

## Operational note
Set the `SMOKE_PROBE_SECRET` repo secret (it flows to the backend via `TF_VAR_smoke_probe_secret`) to arm the browser smoke test. Until then that scheduled job's test simply skips — everything else is active on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPLbZLWXnRZeHUCCx2gwzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPLbZLWXnRZeHUCCx2gwzR)_