### PR TITLE
fix(deploy): rebind custom domain + origin cert when the backend app is replaced

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1066,8 +1066,14 @@ terraform output domain_verification_id
 
 ## Rollback: Emergency Cert Rebind
 
-If a deployment breaks custom domain HTTPS (e.g. Error 526), use
-these commands to manually fix without waiting for a full CI/CD cycle:
+If a deployment breaks custom domain HTTPS (Cloudflare **525** SSL Handshake Failed or **526**
+Invalid SSL certificate), use these commands to manually fix without waiting for a full CI/CD cycle.
+
+**Most common cause:** a Terraform apply **replaced** a Container App (e.g. `backend_secret_trigger`
+fires when a probe/API secret is rotated). The recreated app loses its imperatively-bound custom
+domain + certificate. Since the 2026-07-07 incident the rebind provisioners also key on
+`terraform_data.backend_secret_trigger.id`, so the *same apply* re-binds automatically — this manual
+runbook remains for older states and any other path that drops the binding.
 
 ```bash
 # Variables — adjust for your environment
@@ -1075,6 +1081,11 @@ ENV_NAME="bible-app-env"
 RG="bible-app-rg"
 FRONTEND_APP="bible-app-frontend"
 BACKEND_APP="bible-app-backend"
+
+# 0. If the app was REPLACED, the hostname itself is gone too — re-add it first
+#    (idempotent; errors harmlessly if already attached)
+az containerapp hostname add --name $BACKEND_APP --resource-group $RG \
+  --hostname api.voxquieta.org || true
 
 # 1. Upload the certificate (if not already present)
 az containerapp env certificate upload \

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -840,6 +840,13 @@ resource "null_resource" "backend_custom_domain" {
     container_app  = azurerm_container_app.backend.name
     resource_group = azurerm_resource_group.main.name
     cert_hash      = var.cloudflare_origin_cert_hash
+    # When backend_secret_trigger forces a REPLACEMENT of the backend app
+    # (secret rotation), the recreated app loses its imperatively-bound custom
+    # domain + certificate — the app *name* above doesn't change, so nothing
+    # re-ran and prod served Cloudflare 525 (2026-07-07 incident). terraform_data
+    # gets a fresh id on each replacement, so keying on it re-runs this
+    # provisioner in the same apply.
+    secret_trigger = terraform_data.backend_secret_trigger.id
   }
 
   provisioner "local-exec" {
@@ -999,6 +1006,9 @@ resource "null_resource" "backend_ssl_cert_bind" {
     container_app  = azurerm_container_app.backend.name
     resource_group = azurerm_resource_group.main.name
     environment    = azurerm_container_app_environment.main.name
+    # Re-run the cert bind whenever the backend app is replaced by a secret
+    # rotation (see backend_custom_domain trigger comment — 525 incident).
+    secret_trigger = terraform_data.backend_secret_trigger.id
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Summary

Fixes the **Cloudflare 525 / browser CORS outage** that followed the #839 deploy (run `28862240884`).

**Root cause chain:**
1. Setting the new `SMOKE_PROBE_SECRET` changed the `backend_secret_trigger` hash → Terraform **replaced** `azurerm_container_app.backend` (by design, to rotate ACA secrets past `ignore_changes = [secret]`).
2. The custom domain + Cloudflare origin cert are bound **imperatively** (`az containerapp hostname add/bind` in `null_resource` provisioners) — a replaced app comes back without them.
3. The rebind `null_resource`s key their `triggers` on the app **name**, which survives replacement → the provisioners never re-ran → Cloudflare Full (Strict) failed the origin handshake → `api.voxquieta.org` served **525**, which browsers surface as CORS failures. The post-deploy SSL check correctly caught it.

This is the recurring cert-unbind failure mode the README's "Emergency Cert Rebind" runbook exists for — any secret rotation that replaces the app would have re-triggered it.

## Fix

- `deployment/main.tf`: add `terraform_data.backend_secret_trigger.id` to the `triggers` of `backend_custom_domain` and `backend_ssl_cert_bind`. `terraform_data` gets a fresh id on every replacement, so **the same apply that replaces the app now re-runs the hostname add + cert bind**. Bonus: because the trigger map changed, the **next deploy re-binds once**, healing the current broken state even without the manual runbook.
- `deployment/README.md` (Emergency Cert Rebind runbook): cover **525** alongside 526, document the replacement root cause, and add the missing `az containerapp hostname add` step — after a full app replacement the hostname itself is gone, not just the cert binding.

## Immediate recovery (independent of this PR)

```bash
az containerapp hostname add --name bible-app-backend -g bible-app-rg --hostname api.voxquieta.org || true
CERT_ID=$(az containerapp env certificate list --name bible-app-env -g bible-app-rg \
  --query "[?properties.subjectAlternativeNames[?contains(@, 'voxquieta.org')]] | [0].id" -o tsv)
az containerapp hostname bind --name bible-app-backend -g bible-app-rg \
  --hostname api.voxquieta.org --certificate "$CERT_ID" --environment bible-app-env
```

## Test plan
- [x] `terraform fmt -check` clean; brace/ref sanity verified (`validate`/`plan` run in the PR's tf-validate job — registry unreachable from the sandbox).
- [x] `markdownlint` clean on the README (its CI gate; prettier drift there pre-exists on `main` and is out of CI scope).
- [ ] Post-merge deploy: apply re-runs both bind provisioners (visible in the plan as `null_resource` replacements) and the post-deploy SSL check passes (`api.voxquieta.org` → 200).
- [ ] Regression check: rotate any probe secret on a later deploy → app replacement now carries the domain + cert binding with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPLbZLWXnRZeHUCCx2gwzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPLbZLWXnRZeHUCCx2gwzR)_