### PR TITLE
fix(android): 16 KB page-size support — AGP 8.7 + graphics-path pin + CI gate

### DIFF
--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -225,6 +225,57 @@ jobs:
             -PversionName="${{ steps.version.outputs.version_name }}" \
             -PbaseUrl="https://api.voxquieta.org/"
 
+      - name: Verify 16 KB native library alignment
+        # Fail BEFORE uploading (which burns a versionCode) if any 64-bit native
+        # library isn't 16 KB page-size compliant. Google Play rejects such AABs
+        # with "Your app does not support 16 KB memory page sizes". Every LOAD
+        # segment of each 64-bit .so must have ELF alignment >= 16384 (0x4000).
+        # 32-bit ABIs are exempt. On FAIL, the printed library name identifies the
+        # owning dependency to bump to a 16 KB-built release.
+        working-directory: android
+        run: |
+          set -euo pipefail
+          AAB="app/build/outputs/bundle/release/app-release.aab"
+          WORK="$(mktemp -d)"
+          unzip -q "$AAB" -d "$WORK"
+          fail=0
+          checked=0
+          while IFS= read -r so; do
+            abi="$(basename "$(dirname "$so")")"
+            case "$abi" in
+              arm64-v8a|x86_64|riscv64) : ;;                 # 64-bit: must be 16 KB aligned
+              *) echo "skip  $abi/$(basename "$so") (32-bit ABI, exempt)"; continue ;;
+            esac
+            checked=1
+            # Minimum ELF Align (last column) across all LOAD program headers.
+            # bash arithmetic parses the 0x-prefixed hex values readelf prints.
+            min=0
+            while read -r a; do
+              dec=$(( a ))
+              if [ "$min" -eq 0 ] || [ "$dec" -lt "$min" ]; then min=$dec; fi
+            done < <(readelf -lW "$so" | awk '$1=="LOAD"{print $NF}')
+            if [ "$min" -eq 0 ]; then
+              echo "WARN  $abi/$(basename "$so"): no LOAD segments found"
+              continue
+            fi
+            if [ "$min" -ge 16384 ]; then
+              echo "ok    $abi/$(basename "$so") (align=$min)"
+            else
+              echo "FAIL  $abi/$(basename "$so") (align=$min < 16384)"
+              fail=1
+            fi
+          done < <(find "$WORK/base/lib" -name '*.so' 2>/dev/null | sort)
+          rm -rf "$WORK"
+          if [ "$checked" -eq 0 ]; then
+            echo "No 64-bit native libraries in the bundle — 16 KB check trivially passes."
+            exit 0
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::A 64-bit native library is not 16 KB aligned (see FAIL lines). Bump the owning dependency to a 16 KB-built release before publishing."
+            exit 1
+          fi
+          echo "All 64-bit native libraries are 16 KB aligned."
+
       - name: Set up Ruby for Fastlane
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -271,7 +271,8 @@ jobs:
             exit 0
           fi
           if [ "$fail" -ne 0 ]; then
-            echo "::error::A 64-bit native library is not 16 KB aligned (see FAIL lines). Bump the owning dependency to a 16 KB-built release before publishing."
+            echo "::error::A 64-bit native library is not 16 KB aligned (see FAIL lines)." \
+                 "Bump the owning dependency to a 16 KB-built release before publishing."
             exit 1
           fi
           echo "All 64-bit native libraries are 16 KB aligned."

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -143,6 +143,16 @@ android {
         buildConfig = true
     }
 
+    packaging {
+        jniLibs {
+            // Store native (.so) libraries uncompressed so bundletool can page-align
+            // them on 16 KB boundaries in the AAB. This is the default for minSdk 26,
+            // but is set explicitly here because it is a precondition for Google Play's
+            // 16 KB memory-page-size compliance (paired with AGP 8.7+ zipalign).
+            useLegacyPackaging = false
+        }
+    }
+
     testOptions {
         // Disable system animations during instrumented tests.
         // CircularProgressIndicator uses InfiniteTransition which permanently keeps
@@ -202,6 +212,9 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material.icons.extended)
+    // Force the transitive graphics-path native lib to a 16 KB-aligned build so
+    // the AAB passes Google Play's 16 KB memory-page-size check (BITB / prod-release).
+    implementation(libs.androidx.graphics.path)
 
     // Navigation
     implementation(libs.androidx.navigation.compose)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,9 @@
 [versions]
-agp = "8.4.2"
+# AGP 8.7.x is the first line that makes bundletool 16 KB-align (zipalign -P 16)
+# uncompressed native libraries in the AAB — required for Google Play's 16 KB
+# memory-page-size compliance. 8.7.3 keeps Gradle 8.9 (no wrapper bump) and
+# supports compileSdk 35 natively.
+agp = "8.7.3"
 kotlin = "2.0.21"
 firebase-bom = "33.7.0"
 googleServices = "4.4.2"
@@ -8,6 +12,12 @@ ksp = "2.0.21-1.0.28"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 compose-bom = "2024.12.01"
+# Explicit override of the graphics-path native lib (transitive of Compose
+# ui-graphics). Older releases shipped libandroidx.graphics.path.so with 4 KB
+# ELF segment alignment; 1.1.0 is built with 16 KB alignment. Pinned directly
+# (rather than bumping the whole Compose BOM) to keep the tested Compose/UI
+# surface on compileSdk 35 while fixing the only Compose-side native library.
+graphicsPath = "1.1.0"
 activityCompose = "1.9.3"
 navigationCompose = "2.8.5"
 lifecycleRuntimeKtx = "2.8.7"
@@ -49,6 +59,9 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+# 16 KB-aligned native lib (see graphicsPath version note); forces the
+# transitive libandroidx.graphics.path.so up to a 16 KB-compliant build.
+androidx-graphics-path = { group = "androidx.graphics", name = "graphics-path", version.ref = "graphicsPath" }
 
 # Navigation
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }


### PR DESCRIPTION
Google Play rejects the production AAB with "does not support 16 KB memory
page sizes". The app has no first-party native code; the offending .so ships
via prebuilt deps. Two conditions must both hold:

- Packaging: bundletool must 16 KB-zipalign uncompressed native libs → needs
  AGP >= 8.5.1. Bump AGP 8.4.2 → 8.7.3 (keeps Gradle 8.9, supports compileSdk
  35 natively) and set jniLibs.useLegacyPackaging = false explicitly.
- ELF alignment: each 64-bit .so's LOAD segments must be >= 16 KB aligned.
  Pin androidx.graphics:graphics-path to 1.1.0 (16 KB-built) — the only
  Compose-side native lib — instead of bumping the whole Compose BOM, to keep
  the tested UI surface on compileSdk 35.

Also add a pre-upload CI gate to android-publish.yml that unzips the AAB and
fails if any 64-bit native library isn't 16 KB aligned, before a versionCode
is burned. This doubles as the diagnostic if another dependency's .so is the
culprit.

Firebase BOM left at 33.7.0 (already past Firebase's 16 KB-support line); the
CI gate will flag it if it ships a non-compliant .so.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019otDVZcgoBtZGz1B2NJmA2