### PR TITLE
feat(language): runtime readiness guard so a default Bible is never served before it's loaded

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ Vox Quieta API
 Main FastAPI application entry point.
 """
 
+import asyncio
 import os
 import traceback as _traceback
 from contextlib import asynccontextmanager
@@ -95,6 +96,39 @@ async def _check_translation_coverage_at_startup() -> None:
         logger.warning("Translation coverage check failed at startup: %s", e)
 
 
+async def _warm_ready_translations() -> None:
+    """Populate the translation readiness cache from live DB coverage (best-effort).
+
+    Lets default resolution skip a language default that has no verses/embeddings
+    yet and fall back to the next ready translation. Any failure (e.g. DB not
+    ready) is swallowed — resolution then uses the static default, no worse than
+    before.
+    """
+    try:
+        from scripture.coverage import refresh_ready_translations
+        from scripture.database import async_session_factory
+
+        async with async_session_factory() as session:
+            await refresh_ready_translations(session)
+    except Exception as e:
+        logger.warning("Translation readiness warm-up failed: %s", e)
+
+
+async def _readiness_refresh_loop() -> None:
+    """Refresh the readiness cache periodically so a newly-seeded translation
+    becomes usable without a redeploy."""
+    from utils.translation_readiness import READY_TTL_SECONDS
+
+    while True:
+        try:
+            await asyncio.sleep(READY_TTL_SECONDS)
+            await _warm_ready_translations()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # never let the loop die on a transient error
+            logger.warning("Translation readiness refresh loop error: %s", e)
+
+
 async def _purge_blocked_samples_at_startup() -> None:
     """Best-effort TTL sweep for blocked-message samples on app start."""
     try:
@@ -170,12 +204,24 @@ async def lifespan(app: FastAPI):
         logger.error("Database initialization failed", extra={"error": str(e)})
 
     await _check_translation_coverage_at_startup()
+    await _warm_ready_translations()
     await _purge_blocked_samples_at_startup()
+
+    # Keep the readiness cache fresh so a translation seeded after boot becomes
+    # usable without a redeploy.
+    readiness_task = asyncio.create_task(_readiness_refresh_loop())
 
     yield
 
     # Shutdown
     logger.info("Shutting down application")
+
+    readiness_task.cancel()
+    try:
+        await readiness_task
+    except asyncio.CancelledError:
+        pass
+
     await close_db()
 
     # Close provider HTTP clients

--- a/api/scripture/coverage.py
+++ b/api/scripture/coverage.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from utils import translation_readiness
 from utils.language import LANGUAGE_TO_TRANSLATION, SUPPORTED_LANGUAGES
 
 from .repository import ScriptureRepository
@@ -73,3 +74,17 @@ async def check_translation_coverage(
     coverage = await repo.get_translation_coverage()
     unusable = find_unusable_languages(coverage)
     return coverage, unusable
+
+
+async def refresh_ready_translations(session: AsyncSession) -> None:
+    """Refresh the cached "ready translations" set from live DB coverage.
+
+    Feeds ``utils.translation_readiness`` so default resolution
+    (``utils.language.get_translation_for_language``) can skip a language default
+    whose verses/embeddings are not loaded yet and fall back to the next ready
+    translation. Best-effort: callers should swallow exceptions so a
+    cold/unreachable DB never blocks startup or a request.
+    """
+    repo = ScriptureRepository(session)
+    coverage = await repo.get_translation_coverage()
+    translation_readiness.set_ready_translations(translation_readiness.compute_ready(coverage))

--- a/api/tests/test_translation_readiness.py
+++ b/api/tests/test_translation_readiness.py
@@ -1,0 +1,141 @@
+"""Tests for the runtime translation-readiness guard.
+
+Covers the readiness predicate (`compute_ready`), the cache accessors, and the
+readiness-aware default resolution in `utils.language` — specifically that an
+unready language default is skipped in favour of the next ready translation,
+while a healthy or unknown default is never changed.
+"""
+
+import pytest
+
+from utils import translation_readiness
+from utils.language import get_translation_for_language, resolve_translation
+from utils.translation_readiness import (
+    READY_MIN_EMBED_RATIO,
+    READY_MIN_VERSES,
+    compute_ready,
+    get_ready_translations,
+    is_stale,
+    set_ready_translations,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_readiness():
+    """Isolate the module-level cache: start and end each test 'unknown'."""
+    translation_readiness.reset()
+    yield
+    translation_readiness.reset()
+
+
+# ---------------------------------------------------------------------------
+# compute_ready predicate
+# ---------------------------------------------------------------------------
+
+
+def _row(code, total, embedded):
+    return {"translation": code, "total_verses": total, "verses_with_embeddings": embedded}
+
+
+def test_full_bible_fully_embedded_is_ready():
+    ready = compute_ready([_row("kjv", 31102, 31102)])
+    assert ready == {"kjv"}
+
+
+def test_below_min_verses_not_ready():
+    # e.g. a CI-mode load of only 1 Corinthians
+    assert compute_ready([_row("kjv", 500, 500)]) == set()
+
+
+def test_no_embeddings_not_ready():
+    assert compute_ready([_row("luther1912", 31102, 0)]) == set()
+
+
+def test_below_95pct_embedded_not_ready():
+    below = int(READY_MIN_VERSES * 0.90)
+    assert compute_ready([_row("x", READY_MIN_VERSES, below)]) == set()
+
+
+def test_95pct_boundary_is_ready():
+    at_ratio = int(READY_MIN_VERSES * READY_MIN_EMBED_RATIO)
+    assert compute_ready([_row("x", READY_MIN_VERSES, at_ratio)]) == {"x"}
+    assert compute_ready([_row("x", READY_MIN_VERSES, at_ratio - 1)]) == set()
+
+
+def test_never_loaded_translation_absent():
+    # A translation with no verses simply doesn't appear in coverage.
+    assert "elberfelder1905" not in compute_ready([_row("kjv", 31102, 31102)])
+
+
+def test_multiple_translations():
+    ready = compute_ready(
+        [
+            _row("kjv", 31102, 31102),
+            _row("luther1912", 31102, 31102),
+            _row("hindi", 0, 0),
+            _row("schlachter", 31102, 100),  # loaded but barely embedded
+        ]
+    )
+    assert ready == {"kjv", "luther1912"}
+
+
+# ---------------------------------------------------------------------------
+# cache accessors
+# ---------------------------------------------------------------------------
+
+
+def test_cache_unknown_by_default():
+    assert get_ready_translations() is None
+    assert is_stale() is True
+
+
+def test_set_and_get_snapshot_is_immutable():
+    set_ready_translations({"kjv", "web"})
+    snap = get_ready_translations()
+    assert snap == frozenset({"kjv", "web"})
+    assert isinstance(snap, frozenset)
+    assert is_stale() is False
+
+
+# ---------------------------------------------------------------------------
+# readiness-aware default resolution (the guard)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_cache_uses_static_default():
+    # No cache populated -> current behaviour: German default = luther1912.
+    assert get_translation_for_language("de") == "luther1912"
+
+
+def test_empty_ready_set_uses_static_default():
+    set_ready_translations(set())
+    assert get_translation_for_language("de") == "luther1912"
+
+
+def test_unready_default_falls_back_to_next_ready():
+    # Luther not ready, Schlachter ready -> German resolves to Schlachter.
+    set_ready_translations({"schlachter"})
+    assert get_translation_for_language("de") == "schlachter"
+
+
+def test_ready_default_is_returned_unchanged():
+    # Both ready -> the configured first (luther1912) is kept.
+    set_ready_translations({"luther1912", "schlachter"})
+    assert get_translation_for_language("de") == "luther1912"
+
+
+def test_no_language_translation_ready_uses_static_default():
+    # Cache populated but none of German's translations are ready.
+    set_ready_translations({"kjv"})
+    assert get_translation_for_language("de") == "luther1912"
+
+
+def test_resolve_translation_respects_explicit_preference_even_if_unready():
+    # An explicit, valid user choice is honoured regardless of readiness.
+    set_ready_translations({"schlachter"})
+    assert resolve_translation("luther1912", "de") == "luther1912"
+
+
+def test_resolve_translation_uses_guard_for_language_default():
+    set_ready_translations({"schlachter"})
+    assert resolve_translation(None, "de") == "schlachter"

--- a/api/utils/language.py
+++ b/api/utils/language.py
@@ -8,6 +8,8 @@ multiple backends (lingua-py, langdetect, etc.) through a common interface.
 from abc import ABC, abstractmethod
 from typing import Literal
 
+from utils.translation_readiness import get_ready_translations
+
 # Supported languages for this application
 SUPPORTED_LANGUAGES = ["en", "it", "de", "es", "fr", "pt", "ar", "ru", "zh", "hi", "ko"]
 DEFAULT_LANGUAGE = "en"
@@ -386,7 +388,15 @@ def detect_language_confident(text: str) -> str | None:
 
 def get_translation_for_language(language_code: str) -> str:
     """
-    Get the translation code for a given language.
+    Get the default translation code for a given language.
+
+    Readiness-aware: if the runtime readiness cache is populated, return the
+    first configured translation for the language that is actually loaded +
+    embedded in the DB, so a not-yet-seeded default is never served (it would
+    silently return empty search results / 404 lookups). Falls back to the
+    static configured default when readiness is unknown (cache never populated,
+    e.g. in tests) or when no configured translation is ready — so a healthy
+    default is never changed and behaviour degrades no worse than before.
 
     Args:
         language_code: ISO 639-1 language code
@@ -394,6 +404,11 @@ def get_translation_for_language(language_code: str) -> str:
     Returns:
         Translation code (e.g., 'kjv', 'ita1927', 'schlachter')
     """
+    ready = get_ready_translations()
+    if ready:
+        for code in LANGUAGE_TRANSLATIONS.get(language_code, []):
+            if code in ready:
+                return code
     return LANGUAGE_TO_TRANSLATION.get(language_code, DEFAULT_TRANSLATION)
 
 

--- a/api/utils/translation_readiness.py
+++ b/api/utils/translation_readiness.py
@@ -1,0 +1,87 @@
+"""Runtime readiness cache for Bible translations.
+
+A translation is "ready" only when it has a full set of verses AND embeddings in
+the vector DB, so semantic search actually works for it. Default resolution
+(``utils.language``) consults this cache so a language's default is never a
+translation that has not finished loading/embedding yet: an unready default is
+skipped in favour of the next ready translation for that language, and the guard
+self-heals once seeding completes (the cache is refreshed periodically).
+
+This module is intentionally dependency-free (stdlib only). It must NOT import
+``utils.language`` or ``scripture`` — ``scripture.coverage`` imports
+``utils.language`` and ``utils.language`` imports this module, so importing
+either here would create a cycle. The async DB refresh lives in
+``scripture.coverage.refresh_ready_translations`` and writes into this cache.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+# "Ready" matches the loader's ✅ READY definition (scripts/load_bible.py
+# print_status_report): a full Bible of verses, nearly all of them embedded.
+READY_MIN_VERSES = 30_000
+READY_MIN_EMBED_RATIO = 0.95
+
+# How long a cached ready-set is considered fresh. The background refresh in
+# api/main.py re-populates on this cadence, so a newly-seeded translation
+# becomes usable without a redeploy.
+READY_TTL_SECONDS = 300.0
+
+_lock = threading.Lock()
+# None => unknown / never populated (callers must fall back to the static
+# default, NOT treat every translation as unready).
+_ready: frozenset[str] | None = None
+_fetched_at: float = 0.0
+
+
+def compute_ready(coverage: list[dict]) -> set[str]:
+    """Return the translation codes that are fully loaded + embedded.
+
+    Args:
+        coverage: rows as returned by
+            ``ScriptureRepository.get_translation_coverage()`` — dicts with
+            ``"translation"``, ``"total_verses"``, ``"verses_with_embeddings"``.
+    """
+    ready: set[str] = set()
+    for row in coverage:
+        total = row.get("total_verses") or 0
+        embedded = row.get("verses_with_embeddings") or 0
+        if total >= READY_MIN_VERSES and embedded >= READY_MIN_EMBED_RATIO * total:
+            ready.add(row["translation"])
+    return ready
+
+
+def set_ready_translations(codes: set[str]) -> None:
+    """Atomically publish a new ready-set snapshot (immutable, so readers never
+    observe a partially-updated set)."""
+    global _ready, _fetched_at
+    snapshot = frozenset(codes)
+    with _lock:
+        _ready = snapshot
+        _fetched_at = time.monotonic()
+
+
+def get_ready_translations() -> frozenset[str] | None:
+    """Return the cached ready-set, or ``None`` if it has never been populated.
+
+    ``None`` means "unknown" — callers should use their configured default
+    rather than assuming nothing is ready.
+    """
+    return _ready
+
+
+def is_stale() -> bool:
+    """True if the cache is unpopulated or older than ``READY_TTL_SECONDS``."""
+    if _ready is None:
+        return True
+    return (time.monotonic() - _fetched_at) >= READY_TTL_SECONDS
+
+
+def reset() -> None:
+    """Clear the cache. Test helper — resets module state to 'unknown'."""
+    global _ready, _fetched_at
+    with _lock:
+        _ready = None
+        _fetched_at = 0.0


### PR DESCRIPTION
## Problem

A newly-added translation can be made a language's **default** (first in `LANGUAGE_TRANSLATIONS`) and go live before its verses/embeddings finish seeding — which is exactly what happened when Luther 1912 became the German default. German requests then resolved to an empty translation: semantic search returned nothing (chat silently free-generated / marked citations `unresolved`) and REST verse/chapter lookups 404/502'd. The only safeguard was a **comment** in `api/utils/language.py`.

Supersedes #854 (which manually reverted the German default to Schlachter as a stopgap). Luther 1912 is now loaded, so **the default is unchanged** (German stays Luther 1912) — this PR enforces the invariant at runtime instead of hard-coding around seeding state.

## What it does

Default resolution now consults a cached **"ready translations"** set (translations with a full Bible of verses **and** ≥95% embeddings — matching `scripts/load_bible.py`'s ✅ READY definition) and returns the first configured translation for the language that is actually ready, falling back to the next ready one. Guarantees:

- **A healthy default is never changed** — the guard only *demotes* a leading default that isn't ready.
- **Self-heals**: the cache refreshes every 5 min, so a translation seeded after boot becomes usable without a redeploy.
- **Fail-open**: when readiness is unknown (cache unpopulated / cold DB / tests) or nothing is ready, it uses the static default — no worse than today.
- **Explicit user translation preference is always honoured**, ready or not.

## Changes

| File | Change |
|---|---|
| `api/utils/translation_readiness.py` (new) | Dependency-free cache + `compute_ready()` predicate + TTL. No app imports (avoids a cycle with `language`/`scripture`). |
| `api/scripture/coverage.py` | `refresh_ready_translations(session)` populates the cache from the existing `ScriptureRepository.get_translation_coverage()`. |
| `api/utils/language.py` | `get_translation_for_language()` (and thus `resolve_translation`) is readiness-aware. |
| `api/main.py` | Warm the cache at startup + a background refresh loop (cancelled on shutdown). All best-effort. |
| `api/tests/test_translation_readiness.py` (new) | Predicate, cache, and guard-resolution tests (unknown / empty / ready / unready / explicit preference). |

## Verification

- `compute_ready` classifies full+embedded vs `<30k` verses / `0` embeddings / `<95%` embedded / never-loaded correctly (incl. the 95% boundary).
- Guard: unknown or empty cache → `de` = `luther1912` (unchanged); Luther unready + Schlachter ready → `de` = `schlachter`; both ready → `luther1912`; explicit `resolve_translation("luther1912","de")` → `luther1912`.
- Existing `test_language*.py` pass unchanged (they never populate the cache, so the guard is a no-op).
- `compile` + standalone/guard logic verified locally; full suite runs in CI.

## Out of scope (optional follow-ups)
- Filtering the picker (`GET /scripture/translations`) to loaded-only translations.
- Tightening `find_unusable_languages` to the same shared threshold for diagnostic consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDAD9GT8JN99uZjChRDaMo)_