### PR TITLE
fix(security): shared Postgres rate limiter across replicas (BITB-061)

### DIFF
--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -98,6 +98,13 @@ jobs:
           DATABASE_URL: postgresql://bible:bible123@localhost:5432/bibledb # pragma: allowlist secret
           LLM_PROVIDER: ollama
           OLLAMA_HOST: http://localhost:11434
+          # BITB-061: this job's Postgres service has no migrations applied, so
+          # the shared rate-limit tables don't exist. Route-level tests that
+          # exercise require_rate_limit() would otherwise hit real DB errors
+          # until the circuit breaker trips and fails closed for the rest of
+          # the session. test_rate_limiter*.py exercise the postgres backend
+          # explicitly (backend="postgres") regardless of this default.
+          RATE_LIMIT_BACKEND: memory
         run: |
           cd api
           pytest -v --tb=short

--- a/api/config.py
+++ b/api/config.py
@@ -172,6 +172,11 @@ class Settings(BaseSettings):
     # Security Settings
     max_message_length: int = 300  # Max characters per chat message
     rate_limit_enabled: bool = True
+    # BITB-061: "postgres" shares counters across replicas and survives
+    # restarts/deploys (the whole point of this setting); "memory" is the
+    # legacy in-process behavior, kept reachable for tests and local dev
+    # without a database.
+    rate_limit_backend: Literal["postgres", "memory"] = "postgres"
     rate_limit_requests_per_minute: int = 20  # Per IP address
     rate_limit_requests_per_session_minute: int = 10  # Per session per minute
     rate_limit_session_max_requests: int = 10  # Lifetime max per session (encourages breaks)

--- a/api/tests/test_rate_limiter.py
+++ b/api/tests/test_rate_limiter.py
@@ -1,0 +1,236 @@
+"""
+Tests for the Postgres-backed shared rate limiter (BITB-061).
+
+`test_utils_coverage.py` / `test_security.py` already cover the sliding-window
+algorithm itself via `RateLimiter(backend="memory")`. This file covers what's
+new in this phase:
+
+- `PostgresStore` issues the right SQL/params for each decision branch
+  (mocked `AsyncSession` — no DB required).
+- `RateLimiter` falls back to the in-memory store on an isolated Postgres
+  error, and fails closed once the circuit breaker trips on persistent
+  failures — never silently fails open.
+- True concurrent-request safety (the reason this migration exists): a burst
+  of concurrent `check_rate_limit` calls against the same session must not
+  double-count or lose an increment.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+import utils.rate_limiter as rate_limiter_module
+from utils.rate_limiter import PostgresStore, RateLimiter
+
+
+class FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one(self):
+        return self._value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class FakeSession:
+    """Minimal async-context-manager stand-in for `AsyncSession`.
+
+    Routes each `execute()` call to a canned result by inspecting the SQL
+    text/params, so tests don't need to hardcode call order/count.
+    """
+
+    def __init__(
+        self, ip_count: int = 0, session_count: int = 0, lifetime_total: int | None = None
+    ):
+        self.ip_count = ip_count
+        self.session_count = session_count
+        self.lifetime_total = lifetime_total
+        self.executed: list[tuple[str, dict]] = []
+        self.committed = False
+
+    async def execute(self, stmt, params=None):
+        sql = str(stmt)
+        params = params or {}
+        self.executed.append((sql, params))
+
+        if "pg_advisory_xact_lock" in sql:
+            return FakeResult(None)
+        if "total_requests FROM rate_limit_sessions" in sql:
+            return FakeResult(self.lifetime_total)
+        if "count(*) FROM rate_limit_hits" in sql:
+            key = params.get("key", "")
+            return FakeResult(self.ip_count if key.startswith("ip:") else self.session_count)
+        return FakeResult(None)  # INSERT / ON CONFLICT UPSERT
+
+    async def commit(self):
+        self.committed = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FailingSession:
+    """Every `execute()` raises, simulating a Postgres outage."""
+
+    async def execute(self, stmt, params=None):
+        raise RuntimeError("connection refused")
+
+    async def commit(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _patch_session_factory(session):
+    return patch("scripture.database.async_session_factory", lambda: session)
+
+
+class TestPostgresStoreSql:
+    """PostgresStore issues the expected SQL for each decision branch."""
+
+    @pytest.mark.asyncio
+    async def test_allows_and_records_when_under_all_limits(self):
+        session = FakeSession(ip_count=0, session_count=0, lifetime_total=0)
+        store = PostgresStore(
+            requests_per_minute=20,
+            session_requests_per_minute=10,
+            session_max_requests=100,
+            window_seconds=60,
+        )
+        with _patch_session_factory(session):
+            allowed, reason = await store.check_and_record("1.2.3.4", "sess-1")
+
+        assert allowed is True
+        assert reason is None
+        assert session.committed is True
+        inserted_keys = {
+            p["key"] for sql, p in session.executed if sql.startswith("INSERT INTO rate_limit_hits")
+        }
+        assert inserted_keys == {"ip:1.2.3.4", "session:sess-1"}
+        upsert = [p for sql, p in session.executed if "ON CONFLICT (session_id)" in sql]
+        assert upsert == [{"sid": "sess-1"}]
+
+    @pytest.mark.asyncio
+    async def test_blocks_on_ip_limit_without_recording(self):
+        session = FakeSession(ip_count=20)
+        store = PostgresStore(
+            requests_per_minute=20,
+            session_requests_per_minute=10,
+            session_max_requests=100,
+            window_seconds=60,
+        )
+        with _patch_session_factory(session):
+            allowed, reason = await store.check_and_record("1.2.3.4", None)
+
+        assert allowed is False
+        assert reason == "IP rate limit exceeded"
+        assert session.committed is False
+        assert not any(sql.startswith("INSERT") for sql, _ in session.executed)
+
+    @pytest.mark.asyncio
+    async def test_blocks_on_session_lifetime_limit_before_per_minute_check(self):
+        session = FakeSession(ip_count=0, session_count=0, lifetime_total=100)
+        store = PostgresStore(
+            requests_per_minute=20,
+            session_requests_per_minute=10,
+            session_max_requests=100,
+            window_seconds=60,
+        )
+        with _patch_session_factory(session):
+            allowed, reason = await store.check_and_record("1.2.3.4", "sess-1")
+
+        assert allowed is False
+        assert reason == "Session lifetime limit exceeded"
+        # Lifetime check short-circuits before the session per-minute query.
+        assert not any(
+            "count(*) FROM rate_limit_hits" in sql and p.get("key") == "session:sess-1"
+            for sql, p in session.executed
+        )
+
+    @pytest.mark.asyncio
+    async def test_blocks_on_session_per_minute_limit(self):
+        session = FakeSession(ip_count=0, session_count=10, lifetime_total=5)
+        store = PostgresStore(
+            requests_per_minute=20,
+            session_requests_per_minute=10,
+            session_max_requests=100,
+            window_seconds=60,
+        )
+        with _patch_session_factory(session):
+            allowed, reason = await store.check_and_record("1.2.3.4", "sess-1")
+
+        assert allowed is False
+        assert reason == "Session rate limit exceeded"
+
+
+class TestRateLimiterFailover:
+    """RateLimiter must never silently fail open on a Postgres error."""
+
+    @pytest.mark.asyncio
+    async def test_isolated_db_error_falls_back_to_in_memory(self):
+        limiter = RateLimiter(requests_per_minute=5, backend="postgres")
+        with (
+            patch.object(rate_limiter_module, "rate_limiter_fallback_counter") as fallback_counter,
+            _patch_session_factory(FailingSession()),
+        ):
+            allowed, reason = await limiter.check_rate_limit("1.2.3.4")
+
+        assert allowed is True
+        assert reason is None
+        fallback_counter.add.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persistent_db_errors_trip_breaker_and_fail_closed(self):
+        limiter = RateLimiter(requests_per_minute=5, backend="postgres")
+        with (
+            patch.object(
+                rate_limiter_module, "rate_limiter_fail_closed_counter"
+            ) as fail_closed_counter,
+            _patch_session_factory(FailingSession()),
+        ):
+            results = [await limiter.check_rate_limit("1.2.3.4") for _ in range(6)]
+
+        # First 4 failures fall back (breaker still closed); the 5th failure
+        # trips the breaker (failure_threshold=5) and fails closed from then on.
+        assert [allowed for allowed, _ in results[:4]] == [True, True, True, True]
+        assert results[4] == (False, "Rate limiter temporarily unavailable")
+        assert results[5] == (False, "Rate limiter temporarily unavailable")
+        assert fail_closed_counter.add.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_memory_backend_never_touches_postgres(self):
+        """backend="memory" must not import/patch scripture.database at all."""
+        limiter = RateLimiter(requests_per_minute=5, backend="memory")
+        allowed, reason = await limiter.check_rate_limit("1.2.3.4")
+        assert allowed is True
+        assert reason is None
+
+
+class TestConcurrency:
+    """Concurrent requests must not double-count or lose an increment."""
+
+    @pytest.mark.asyncio
+    async def test_in_memory_lifetime_cap_holds_under_concurrent_requests(self):
+        limiter = RateLimiter(
+            requests_per_minute=1000,
+            session_requests_per_minute=1000,
+            session_max_requests=10,
+            backend="memory",
+        )
+
+        results = await asyncio.gather(
+            *[limiter.check_rate_limit("1.2.3.4", "burst-session") for _ in range(50)]
+        )
+
+        allowed_count = sum(1 for allowed, _ in results if allowed)
+        assert allowed_count == 10

--- a/api/tests/test_rate_limiter_integration.py
+++ b/api/tests/test_rate_limiter_integration.py
@@ -45,6 +45,19 @@ async def rate_limit_tables():
     Skips when Postgres is unreachable. Yields nothing usable by callers other
     than a live `scripture.database.async_session_factory` (imported fresh by
     `PostgresStore` inside `check_and_record`)."""
+    # scripture.database's engine/pool is a module-level singleton that can
+    # outlive the event loop it was created on -- pytest-asyncio gives each
+    # test function its own loop, and asyncpg connections are bound to the
+    # loop that opened them. Disposing here forces PostgresStore (which reuses
+    # that same engine) to open fresh connections on *this* test's loop,
+    # instead of occasionally handing back a stale connection from a prior
+    # test's now-closed loop (observed as a spurious "Event loop is closed"
+    # -> fallback -> one extra allowed request when run as part of the full
+    # suite).
+    from scripture import database as scripture_database
+
+    await scripture_database.engine.dispose()
+
     url, connect_args = get_async_database_url()
 
     engine = create_async_engine(url, poolclass=NullPool, connect_args=connect_args)

--- a/api/tests/test_rate_limiter_integration.py
+++ b/api/tests/test_rate_limiter_integration.py
@@ -1,0 +1,117 @@
+"""
+Integration test for the Postgres-backed rate limiter (BITB-061), run against
+a real database instead of mocking the session.
+
+Why this file exists
+---------------------
+`test_rate_limiter.py`'s concurrency proof runs `asyncio.gather` over a single
+in-process `InMemoryStore`, which was never the problem — a single process
+serializes fine even without a lock (no `await` inside its critical section).
+The actual bug this migration fixes only shows up **across separate
+connections/replicas**: two independent sessions racing the same session's
+lifetime counter must not double-count or lose an increment. That needs a
+real Postgres and real concurrent connections, which mocks can't reproduce.
+
+Applies migration 009's DDL (idempotent) against whatever `DATABASE_URL`
+points at, then hammers the real `PostgresStore` with concurrent connections.
+Cleans up only the rows it created, keyed by a unique test-run prefix, so it
+never touches unrelated data in a shared test database.
+
+Skips automatically when no Postgres is reachable (e.g. local runs without a
+DB). CI's `backend-tests` job provides a service container with
+`DATABASE_URL` set, so this runs on every PR.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+from scripture.database import get_async_database_url
+from utils.rate_limiter import RateLimiter
+
+_MIGRATION_009 = (
+    Path(__file__).resolve().parents[2] / "scripts" / "migrations" / "009_add_rate_limit_tables.sql"
+)
+
+
+@pytest_asyncio.fixture
+async def rate_limit_tables():
+    """Ensures migration 009's tables exist against the real `DATABASE_URL`.
+    Skips when Postgres is unreachable. Yields nothing usable by callers other
+    than a live `scripture.database.async_session_factory` (imported fresh by
+    `PostgresStore` inside `check_and_record`)."""
+    url, connect_args = get_async_database_url()
+
+    engine = create_async_engine(url, poolclass=NullPool, connect_args=connect_args)
+    try:
+        # Strip comment lines before splitting on ";" -- this migration's
+        # prose comments contain semicolons of their own (e.g. "short-lived;
+        # see migration 010"), which would otherwise split a statement in
+        # the wrong place. asyncpg only executes one statement per call.
+        sql_lines = (
+            line
+            for line in _MIGRATION_009.read_text().splitlines()
+            if not line.strip().startswith("--")
+        )
+        async with engine.begin() as conn:
+            for statement in "\n".join(sql_lines).split(";"):
+                statement = statement.strip()
+                if statement:
+                    await conn.execute(text(statement))
+    except Exception as exc:  # connection refused, auth failure, etc.
+        await engine.dispose()
+        pytest.skip(f"Postgres not reachable: {exc}")
+
+    try:
+        yield
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_lifetime_cap_holds_across_concurrent_connections(rate_limit_tables):
+    """The whole point of BITB-061 phase 3: concurrent requests against the
+    same session, from independent Postgres connections (not shared
+    in-process state), must not double-count or lose an increment."""
+    session_id = "itest-BITB-061-concurrent-session"
+    ip = "203.0.113.1"  # TEST-NET-3, RFC 5737
+
+    try:
+        # Each RateLimiter/PostgresStore opens its own session via
+        # scripture.database.async_session_factory, so N limiter instances
+        # give N independent connections racing the same session_id.
+        limiters = [
+            RateLimiter(
+                requests_per_minute=1000,
+                session_requests_per_minute=1000,
+                session_max_requests=10,
+                backend="postgres",
+            )
+            for _ in range(50)
+        ]
+
+        results = await asyncio.gather(
+            *[limiter.check_rate_limit(ip, session_id) for limiter in limiters]
+        )
+
+        allowed_count = sum(1 for allowed, _ in results if allowed)
+        assert allowed_count == 10
+    finally:
+        # Clean up only what this test created.
+        url, connect_args = get_async_database_url()
+        engine = create_async_engine(url, poolclass=NullPool, connect_args=connect_args)
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("DELETE FROM rate_limit_sessions WHERE session_id = :sid"),
+                {"sid": session_id},
+            )
+            await conn.execute(
+                text("DELETE FROM rate_limit_hits WHERE limit_key IN (:ip_key, :sess_key)"),
+                {"ip_key": f"ip:{ip}", "sess_key": f"session:{session_id}"},
+            )
+        await engine.dispose()

--- a/api/tests/test_security.py
+++ b/api/tests/test_security.py
@@ -90,7 +90,7 @@ class TestRateLimiter:
     @pytest.mark.asyncio
     async def test_allows_requests_under_limit(self):
         """Requests under the limit should be allowed."""
-        limiter = RateLimiter(requests_per_minute=5)
+        limiter = RateLimiter(backend="memory", requests_per_minute=5)
         for _ in range(5):
             allowed, reason = await limiter.check_rate_limit("192.168.1.1")
             assert allowed is True
@@ -99,7 +99,7 @@ class TestRateLimiter:
     @pytest.mark.asyncio
     async def test_blocks_requests_over_ip_limit(self):
         """Requests over the IP limit should be blocked."""
-        limiter = RateLimiter(requests_per_minute=3)
+        limiter = RateLimiter(backend="memory", requests_per_minute=3)
 
         # First 3 should pass
         for _ in range(3):
@@ -114,7 +114,7 @@ class TestRateLimiter:
     @pytest.mark.asyncio
     async def test_different_ips_have_separate_limits(self):
         """Different IPs should have separate rate limits."""
-        limiter = RateLimiter(requests_per_minute=2)
+        limiter = RateLimiter(backend="memory", requests_per_minute=2)
 
         # Max out first IP
         await limiter.check_rate_limit("192.168.1.1")
@@ -130,6 +130,7 @@ class TestRateLimiter:
     async def test_session_rate_limit(self):
         """Per-session rate limit should be enforced."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=10,  # High IP limit
             session_requests_per_minute=2,  # Low session limit
         )
@@ -145,6 +146,7 @@ class TestRateLimiter:
     async def test_session_lifetime_limit(self):
         """Session lifetime limit should be enforced."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=100,
             session_requests_per_minute=100,
             session_max_requests=5,  # Low lifetime limit
@@ -163,7 +165,7 @@ class TestRateLimiter:
     @pytest.mark.asyncio
     async def test_get_stats(self):
         """Stats should reflect tracked IPs and sessions."""
-        limiter = RateLimiter()
+        limiter = RateLimiter(backend="memory")
         await limiter.check_rate_limit("192.168.1.1")
         await limiter.check_rate_limit("192.168.1.2", "session-1")
 

--- a/api/tests/test_utils_coverage.py
+++ b/api/tests/test_utils_coverage.py
@@ -676,7 +676,7 @@ class TestRateLimiter:
 
     @pytest.mark.asyncio
     async def test_allows_first_request(self):
-        limiter = RateLimiter(requests_per_minute=5)
+        limiter = RateLimiter(backend="memory", requests_per_minute=5)
         allowed, reason = await limiter.check_rate_limit("1.2.3.4")
         assert allowed is True
         assert reason is None
@@ -684,7 +684,7 @@ class TestRateLimiter:
     @pytest.mark.asyncio
     async def test_ip_rate_limit_exceeded(self):
         """Should block after exceeding IP rate limit."""
-        limiter = RateLimiter(requests_per_minute=3)
+        limiter = RateLimiter(backend="memory", requests_per_minute=3)
 
         for _ in range(3):
             allowed, _ = await limiter.check_rate_limit("1.2.3.4")
@@ -697,7 +697,7 @@ class TestRateLimiter:
     @pytest.mark.asyncio
     async def test_different_ips_independent(self):
         """Different IPs should have independent limits."""
-        limiter = RateLimiter(requests_per_minute=2)
+        limiter = RateLimiter(backend="memory", requests_per_minute=2)
 
         # Fill up first IP
         await limiter.check_rate_limit("1.1.1.1")
@@ -711,6 +711,7 @@ class TestRateLimiter:
     async def test_session_rate_limit(self):
         """Should block after exceeding session rate limit."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=100,
             session_requests_per_minute=2,
         )
@@ -726,6 +727,7 @@ class TestRateLimiter:
     async def test_session_lifetime_limit(self):
         """Should block after exceeding session lifetime limit."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=1000,
             session_requests_per_minute=1000,
             session_max_requests=3,
@@ -744,6 +746,7 @@ class TestRateLimiter:
     async def test_window_expiry(self):
         """Requests should expire after the window."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=2,
             window_seconds=1,
         )
@@ -766,6 +769,7 @@ class TestRateLimiter:
     async def test_cleanup_runs_periodically(self):
         """Cleanup should remove expired entries."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=100,
             window_seconds=1,
             cleanup_interval_seconds=0,  # Cleanup on every request
@@ -775,24 +779,25 @@ class TestRateLimiter:
         await limiter.check_rate_limit("1.1.1.1")
         await limiter.check_rate_limit("2.2.2.2")
 
-        assert len(limiter._ip_limits) == 2
+        assert len(limiter._store._ip_limits) == 2
 
         # Force entries to expire
-        limiter._last_cleanup = 0
-        for entry in limiter._ip_limits.values():
+        limiter._store._last_cleanup = 0
+        for entry in limiter._store._ip_limits.values():
             entry.timestamps = [time.time() - 100]
 
         # Next request triggers cleanup
         await limiter.check_rate_limit("3.3.3.3")
 
         # Old entries should be cleaned
-        assert "1.1.1.1" not in limiter._ip_limits
-        assert "2.2.2.2" not in limiter._ip_limits
+        assert "1.1.1.1" not in limiter._store._ip_limits
+        assert "2.2.2.2" not in limiter._store._ip_limits
 
     @pytest.mark.asyncio
     async def test_cleanup_keeps_active_sessions(self):
         """Cleanup should keep sessions that hit lifetime limit."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=100,
             session_requests_per_minute=100,
             session_max_requests=2,
@@ -805,15 +810,15 @@ class TestRateLimiter:
         await limiter.check_rate_limit("1.2.3.4", session_id="maxed-session")
 
         # Force timestamps to expire but keep total_requests
-        limiter._last_cleanup = 0
-        entry = limiter._session_limits["maxed-session"]
+        limiter._store._last_cleanup = 0
+        entry = limiter._store._session_limits["maxed-session"]
         entry.timestamps = [time.time() - 100]
 
         # Trigger cleanup
         await limiter.check_rate_limit("5.5.5.5")
 
         # Maxed session should be kept (lifetime limit reached)
-        assert "maxed-session" in limiter._session_limits
+        assert "maxed-session" in limiter._store._session_limits
 
     @pytest.mark.asyncio
     async def test_cleanup_keeps_idle_sub_limit_session_within_ttl(self):
@@ -825,6 +830,7 @@ class TestRateLimiter:
         must now be retained with their count intact.
         """
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=100,
             session_requests_per_minute=100,
             session_max_requests=10,
@@ -838,20 +844,21 @@ class TestRateLimiter:
             await limiter.check_rate_limit("1.2.3.4", session_id="idle-session")
 
         # Idle past the 1s rate window but well within the 1h TTL.
-        limiter._last_cleanup = 0
-        limiter._session_limits["idle-session"].timestamps = [time.time() - 100]
+        limiter._store._last_cleanup = 0
+        limiter._store._session_limits["idle-session"].timestamps = [time.time() - 100]
 
         # Trigger cleanup via another request.
         await limiter.check_rate_limit("5.5.5.5")
 
         # Session retained with its lifetime count intact.
-        assert "idle-session" in limiter._session_limits
-        assert limiter._session_limits["idle-session"].total_requests == 4
+        assert "idle-session" in limiter._store._session_limits
+        assert limiter._store._session_limits["idle-session"].total_requests == 4
 
     @pytest.mark.asyncio
     async def test_cleanup_evicts_session_after_ttl(self):
         """Sessions idle beyond the TTL are evicted to bound memory growth."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=100,
             session_requests_per_minute=100,
             session_max_requests=10,
@@ -863,19 +870,20 @@ class TestRateLimiter:
         await limiter.check_rate_limit("1.2.3.4", session_id="old-session")
 
         # Force last activity older than the TTL.
-        limiter._last_cleanup = 0
-        entry = limiter._session_limits["old-session"]
+        limiter._store._last_cleanup = 0
+        entry = limiter._store._session_limits["old-session"]
         entry.last_seen = time.time() - 120
         entry.timestamps = [time.time() - 120]
 
         # Trigger cleanup via another request.
         await limiter.check_rate_limit("5.5.5.5")
 
-        assert "old-session" not in limiter._session_limits
+        assert "old-session" not in limiter._store._session_limits
 
     def test_get_stats(self):
         """get_stats should return current statistics."""
         limiter = RateLimiter(
+            backend="memory",
             requests_per_minute=20,
             session_requests_per_minute=10,
             session_max_requests=100,

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -311,3 +311,21 @@ content_safety_fallback_counter = meter.create_counter(
     ),
     unit="1",
 )  # attributes: stage (llama_guard|openai_moderation|azure), reason
+
+rate_limiter_db_error_counter = meter.create_counter(
+    name="rate_limiter.db_error_total",
+    description="Postgres-backed rate limiter errors (transient DB failure while checking/recording a hit) (BITB-061)",
+    unit="1",
+)  # attributes: reason (<exc_name>)
+
+rate_limiter_fallback_counter = meter.create_counter(
+    name="rate_limiter.fallback_total",
+    description="Rate-limit checks served by the in-memory fallback store because Postgres was unavailable (BITB-061)",
+    unit="1",
+)
+
+rate_limiter_fail_closed_counter = meter.create_counter(
+    name="rate_limiter.fail_closed_total",
+    description="Rate-limit checks rejected because the Postgres store's circuit breaker is open (persistent DB outage) (BITB-061)",
+    unit="1",
+)

--- a/api/utils/rate_limiter.py
+++ b/api/utils/rate_limiter.py
@@ -1,13 +1,33 @@
 """
-In-memory sliding window rate limiter.
+Shared rate limiter (BITB-061).
 
-Provides per-IP and per-session rate limiting with automatic cleanup.
+Enforces per-IP and per-session sliding-window rate limits plus a durable
+per-session lifetime cap. Backed by Postgres by default so limits hold across
+replicas and survive deploys/restarts (the in-memory limiter this replaces
+tracked counters per-process, so with N replicas the effective limit was N
+times the configured value, and every restart reset the lifetime cap it
+exists to enforce). Falls back to an in-process store — circuit-breaker
+mediated — when Postgres is transiently unavailable, and is selectable as the
+sole backend via `rate_limit_backend=memory` for tests/local dev without a
+database.
 """
 
-import asyncio
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
+from typing import Protocol
+
+from sqlalchemy import text
+
+from utils.circuit_breaker import CircuitBreaker
+from utils.logging_config import get_logger
+from utils.metrics import (
+    rate_limiter_db_error_counter,
+    rate_limiter_fail_closed_counter,
+    rate_limiter_fallback_counter,
+)
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -19,26 +39,33 @@ class RateLimitEntry:
     last_seen: float = 0.0  # Timestamp of the most recent request (for session TTL)
 
 
-class RateLimiter:
+class RateLimitStore(Protocol):
+    """A backend that decides + atomically records a rate-limit check."""
+
+    async def check_and_record(
+        self, ip_address: str, session_id: str | None
+    ) -> tuple[bool, str | None]: ...
+
+    def get_stats(self) -> dict: ...
+
+
+class InMemoryStore:
     """
-    Sliding window rate limiter with automatic cleanup.
+    In-process sliding-window store (the pre-BITB-061 behavior).
 
-    Tracks:
-    - Per-IP request rate (requests per minute)
-    - Per-session request rate (requests per minute)
-    - Per-session lifetime requests (total requests ever)
-
-    Thread-safe via asyncio lock.
+    Not shared across replicas and reset on restart — kept as the fallback
+    used when Postgres is unavailable, and as the backend selectable via
+    `rate_limit_backend=memory` for tests/local dev without a database.
     """
 
     def __init__(
         self,
-        requests_per_minute: int = 20,
-        session_requests_per_minute: int = 10,
-        session_max_requests: int = 100,
-        window_seconds: int = 60,
-        cleanup_interval_seconds: int = 300,
-        session_ttl_seconds: int = 3600,
+        requests_per_minute: int,
+        session_requests_per_minute: int,
+        session_max_requests: int,
+        window_seconds: int,
+        cleanup_interval_seconds: int,
+        session_ttl_seconds: int,
     ):
         self.requests_per_minute = requests_per_minute
         self.session_requests_per_minute = session_requests_per_minute
@@ -50,69 +77,50 @@ class RateLimiter:
         # survives normal idle gaps instead of resetting every minute.
         self.session_ttl_seconds = session_ttl_seconds
 
-        # Storage
         self._ip_limits: dict[str, RateLimitEntry] = defaultdict(RateLimitEntry)
         self._session_limits: dict[str, RateLimitEntry] = defaultdict(RateLimitEntry)
-        self._lock = asyncio.Lock()
         self._last_cleanup = time.time()
 
-    async def check_rate_limit(
+    async def check_and_record(
         self, ip_address: str, session_id: str | None = None
     ) -> tuple[bool, str | None]:
-        """
-        Check if a request should be allowed.
+        now = time.time()
+        cutoff = now - self.window_seconds
 
-        Args:
-            ip_address: Client IP address
-            session_id: Optional session identifier
+        if now - self._last_cleanup > self.cleanup_interval:
+            await self._cleanup(now, cutoff)
+            self._last_cleanup = now
 
-        Returns:
-            Tuple of (allowed, error_reason)
-        """
-        async with self._lock:
-            now = time.time()
-            cutoff = now - self.window_seconds
+        ip_entry = self._ip_limits[ip_address]
+        ip_entry.timestamps = [t for t in ip_entry.timestamps if t > cutoff]
 
-            # Periodic cleanup
-            if now - self._last_cleanup > self.cleanup_interval:
-                await self._cleanup(now, cutoff)
-                self._last_cleanup = now
+        if len(ip_entry.timestamps) >= self.requests_per_minute:
+            return False, "IP rate limit exceeded"
 
-            # Check IP rate limit
-            ip_entry = self._ip_limits[ip_address]
-            ip_entry.timestamps = [t for t in ip_entry.timestamps if t > cutoff]
+        if session_id:
+            session_entry = self._session_limits[session_id]
+            session_entry.timestamps = [t for t in session_entry.timestamps if t > cutoff]
 
-            if len(ip_entry.timestamps) >= self.requests_per_minute:
-                return False, "IP rate limit exceeded"
+            # Check lifetime session limit first so it always takes precedence
+            # over the per-minute check, ensuring the farewell UX is shown.
+            if session_entry.total_requests >= self.session_max_requests:
+                return False, "Session lifetime limit exceeded"
 
-            # Check session limits (if session provided)
-            if session_id:
-                session_entry = self._session_limits[session_id]
-                session_entry.timestamps = [t for t in session_entry.timestamps if t > cutoff]
+            if len(session_entry.timestamps) >= self.session_requests_per_minute:
+                return False, "Session rate limit exceeded"
 
-                # Check lifetime session limit first so it always takes precedence
-                # over the per-minute check, ensuring the farewell UX is shown.
-                if session_entry.total_requests >= self.session_max_requests:
-                    return False, "Session lifetime limit exceeded"
+        ip_entry.timestamps.append(now)
 
-                # Check per-minute session limit
-                if len(session_entry.timestamps) >= self.session_requests_per_minute:
-                    return False, "Session rate limit exceeded"
+        if session_id:
+            session_entry = self._session_limits[session_id]
+            session_entry.timestamps.append(now)
+            session_entry.total_requests += 1
+            session_entry.last_seen = now
 
-            # Allow request and record it
-            ip_entry.timestamps.append(now)
-
-            if session_id:
-                session_entry = self._session_limits[session_id]
-                session_entry.timestamps.append(now)
-                session_entry.total_requests += 1
-                session_entry.last_seen = now
-
-            return True, None
+        return True, None
 
     async def _cleanup(self, now: float, cutoff: float) -> None:
         """Remove expired entries to prevent memory growth."""
-        # Clean IP entries (purely rate-window based)
         expired_ips = [
             ip
             for ip, entry in self._ip_limits.items()
@@ -121,11 +129,8 @@ class RateLimiter:
         for ip in expired_ips:
             del self._ip_limits[ip]
 
-        # Clean session entries by inactivity TTL only. Previously sessions under
-        # the lifetime limit were deleted once idle past the 60s rate window,
-        # which silently reset the "lifetime" counter on brief idle gaps. Evicting
-        # by last_seen keeps the count alive for the session's real lifetime while
-        # still bounding memory.
+        # Clean session entries by inactivity TTL only, not the 60s rate
+        # window, so the lifetime counter survives normal idle gaps.
         session_cutoff = now - self.session_ttl_seconds
         expired_sessions = [
             sid for sid, entry in self._session_limits.items() if entry.last_seen <= session_cutoff
@@ -134,8 +139,8 @@ class RateLimiter:
             del self._session_limits[sid]
 
     def get_stats(self) -> dict:
-        """Get current rate limiter statistics."""
         return {
+            "backend": "memory",
             "tracked_ips": len(self._ip_limits),
             "tracked_sessions": len(self._session_limits),
             "config": {
@@ -145,6 +150,228 @@ class RateLimiter:
                 "window_seconds": self.window_seconds,
             },
         }
+
+
+class PostgresStore:
+    """
+    Shared, cross-replica store backed by Postgres (`rate_limit_hits` /
+    `rate_limit_sessions`, migration 009).
+
+    Uses transaction-scoped advisory locks (`pg_advisory_xact_lock`) keyed by
+    IP/session so concurrent requests for the *same* key serialize (matching
+    the single-lock semantics `InMemoryStore` had per-process, now enforced
+    across replicas too) while different keys never block each other. The
+    session lifetime counter is updated via an atomic
+    `INSERT ... ON CONFLICT DO UPDATE` so concurrent replicas can never
+    double-count or lose an increment. Window rows are purged by pg_cron
+    (migration 010), not by this class.
+    """
+
+    def __init__(
+        self,
+        requests_per_minute: int,
+        session_requests_per_minute: int,
+        session_max_requests: int,
+        window_seconds: int,
+    ):
+        self.requests_per_minute = requests_per_minute
+        self.session_requests_per_minute = session_requests_per_minute
+        self.session_max_requests = session_max_requests
+        self.window_seconds = window_seconds
+
+    async def check_and_record(
+        self, ip_address: str, session_id: str | None = None
+    ) -> tuple[bool, str | None]:
+        # Lazy import: avoids a module-load-time cycle between utils.security
+        # (imports utils.rate_limiter) and scripture.database.
+        from scripture.database import async_session_factory
+
+        ip_key = f"ip:{ip_address}"
+        sess_key = f"session:{session_id}" if session_id else None
+
+        async with async_session_factory() as session:
+            # Lock in a deterministic order so a request touching both an IP
+            # key and a session key can never deadlock against another
+            # request locking the same two keys in the opposite order.
+            for key in sorted(k for k in (ip_key, sess_key) if k):
+                await session.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext(:key))"), {"key": key}
+                )
+
+            ip_count = (
+                await session.execute(
+                    text(
+                        "SELECT count(*) FROM rate_limit_hits "
+                        "WHERE limit_key = :key "
+                        "AND created_at > now() - make_interval(secs => :secs)"
+                    ),
+                    {"key": ip_key, "secs": self.window_seconds},
+                )
+            ).scalar_one()
+
+            if ip_count >= self.requests_per_minute:
+                return False, "IP rate limit exceeded"
+
+            if sess_key:
+                lifetime_total = (
+                    await session.execute(
+                        text(
+                            "SELECT total_requests FROM rate_limit_sessions WHERE session_id = :sid"
+                        ),
+                        {"sid": session_id},
+                    )
+                ).scalar_one_or_none()
+
+                # Lifetime limit takes precedence over the per-minute check so
+                # the farewell UX is shown, matching InMemoryStore's ordering.
+                if (lifetime_total or 0) >= self.session_max_requests:
+                    return False, "Session lifetime limit exceeded"
+
+                session_count = (
+                    await session.execute(
+                        text(
+                            "SELECT count(*) FROM rate_limit_hits "
+                            "WHERE limit_key = :key "
+                            "AND created_at > now() - make_interval(secs => :secs)"
+                        ),
+                        {"key": sess_key, "secs": self.window_seconds},
+                    )
+                ).scalar_one()
+
+                if session_count >= self.session_requests_per_minute:
+                    return False, "Session rate limit exceeded"
+
+            await session.execute(
+                text("INSERT INTO rate_limit_hits (limit_key) VALUES (:key)"), {"key": ip_key}
+            )
+
+            if sess_key:
+                await session.execute(
+                    text("INSERT INTO rate_limit_hits (limit_key) VALUES (:key)"), {"key": sess_key}
+                )
+                await session.execute(
+                    text(
+                        "INSERT INTO rate_limit_sessions (session_id, total_requests, last_seen) "
+                        "VALUES (:sid, 1, now()) "
+                        "ON CONFLICT (session_id) DO UPDATE "
+                        "SET total_requests = rate_limit_sessions.total_requests + 1, "
+                        "last_seen = now()"
+                    ),
+                    {"sid": session_id},
+                )
+
+            await session.commit()
+            return True, None
+
+    def get_stats(self) -> dict:
+        return {
+            "backend": "postgres",
+            "config": {
+                "requests_per_minute": self.requests_per_minute,
+                "session_requests_per_minute": self.session_requests_per_minute,
+                "session_max_requests": self.session_max_requests,
+                "window_seconds": self.window_seconds,
+            },
+        }
+
+
+class RateLimiter:
+    """
+    Public entry point used by `api/utils/security.py` — signature and
+    behavior are unchanged from the pre-BITB-061 in-memory-only limiter.
+
+    Delegates to a Postgres-backed store by default. An isolated Postgres
+    error falls back to an in-process store for that check (degraded but
+    still enforcing *something*) and emits `rate_limiter.fallback_total`.
+    Persistent Postgres failures trip a circuit breaker and the check fails
+    CLOSED (`rate_limiter.fail_closed_total`) rather than silently allowing
+    every request through — the fail-open behavior this story exists to
+    close.
+    """
+
+    def __init__(
+        self,
+        requests_per_minute: int = 20,
+        session_requests_per_minute: int = 10,
+        session_max_requests: int = 100,
+        window_seconds: int = 60,
+        cleanup_interval_seconds: int = 300,
+        session_ttl_seconds: int = 3600,
+        backend: str = "postgres",
+    ):
+        self._fallback = InMemoryStore(
+            requests_per_minute=requests_per_minute,
+            session_requests_per_minute=session_requests_per_minute,
+            session_max_requests=session_max_requests,
+            window_seconds=window_seconds,
+            cleanup_interval_seconds=cleanup_interval_seconds,
+            session_ttl_seconds=session_ttl_seconds,
+        )
+        self._use_postgres = backend == "postgres"
+        self._store: RateLimitStore = (
+            PostgresStore(
+                requests_per_minute=requests_per_minute,
+                session_requests_per_minute=session_requests_per_minute,
+                session_max_requests=session_max_requests,
+                window_seconds=window_seconds,
+            )
+            if self._use_postgres
+            else self._fallback
+        )
+
+        # Trip after 5 consecutive Postgres errors; cooldown 30s — mirrors
+        # TurnstileVerifier's breaker (utils/turnstile.py). While closed, an
+        # isolated DB blip falls back to the in-memory store; once open,
+        # checks fail closed without hitting the network until cooldown.
+        self._breaker = CircuitBreaker(
+            name="rate_limiter",
+            failure_threshold=5,
+            cooldown_seconds=30.0,
+        )
+
+    async def check_rate_limit(
+        self, ip_address: str, session_id: str | None = None
+    ) -> tuple[bool, str | None]:
+        """
+        Check if a request should be allowed, recording it if so.
+
+        Args:
+            ip_address: Client IP address
+            session_id: Optional session identifier
+
+        Returns:
+            Tuple of (allowed, error_reason)
+        """
+        if not self._use_postgres:
+            return await self._store.check_and_record(ip_address, session_id)
+
+        if self._breaker.is_open():
+            rate_limiter_fail_closed_counter.add(1)
+            logger.error("Rate limiter Postgres store circuit open — failing closed")
+            return False, "Rate limiter temporarily unavailable"
+
+        try:
+            result = await self._store.check_and_record(ip_address, session_id)
+            self._breaker.record_success()
+            return result
+        except Exception as e:
+            self._breaker.record_failure()
+            rate_limiter_db_error_counter.add(1, {"reason": type(e).__name__.lower()})
+            logger.warning(
+                "Rate limiter Postgres store failed (%s) — falling back to in-memory store",
+                type(e).__name__,
+                exc_info=True,
+            )
+            if self._breaker.is_open():
+                rate_limiter_fail_closed_counter.add(1)
+                logger.error("Rate limiter Postgres store persistently failing — failing closed")
+                return False, "Rate limiter temporarily unavailable"
+            rate_limiter_fallback_counter.add(1)
+            return await self._fallback.check_and_record(ip_address, session_id)
+
+    def get_stats(self) -> dict:
+        """Get current rate limiter statistics."""
+        return self._store.get_stats()
 
 
 # Global instance (initialized on first use)
@@ -162,5 +389,12 @@ def get_rate_limiter() -> RateLimiter:
             session_requests_per_minute=settings.rate_limit_requests_per_session_minute,
             session_max_requests=settings.rate_limit_session_max_requests,
             session_ttl_seconds=settings.rate_limit_session_ttl_seconds,
+            backend=settings.rate_limit_backend,
         )
     return _rate_limiter
+
+
+def reset_rate_limiter() -> None:
+    """Test hook: clear the singleton so the next get_rate_limiter() call re-reads config."""
+    global _rate_limiter
+    _rate_limiter = None

--- a/api/utils/rate_limiter.py
+++ b/api/utils/rate_limiter.py
@@ -308,16 +308,16 @@ class RateLimiter:
             session_ttl_seconds=session_ttl_seconds,
         )
         self._use_postgres = backend == "postgres"
-        self._store: RateLimitStore = (
-            PostgresStore(
+        self._store: RateLimitStore
+        if self._use_postgres:
+            self._store = PostgresStore(
                 requests_per_minute=requests_per_minute,
                 session_requests_per_minute=session_requests_per_minute,
                 session_max_requests=session_max_requests,
                 window_seconds=window_seconds,
             )
-            if self._use_postgres
-            else self._fallback
-        )
+        else:
+            self._store = self._fallback
 
         # Trip after 5 consecutive Postgres errors; cooldown 30s — mirrors
         # TurnstileVerifier's breaker (utils/turnstile.py). While closed, an

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -362,9 +362,9 @@ misreported as a generic 500.
 
 ---
 
-### 🚧 BITB-061: Make the Abuse-Control Stack Fail Closed (Turnstile, Rate Limits, Content Safety)
+### ✅ BITB-061: Make the Abuse-Control Stack Fail Closed (Turnstile, Rate Limits, Content Safety)
 
-**Status:** 🚧 In Progress — Turnstile and content-safety phases complete; rate-limiter phase remains
+**Status:** ✅ Done — Turnstile, rate-limiter, and content-safety phases all complete
 **Size:** M (three coordinated changes: Turnstile policy, shared rate-limit store, safety defaults/metrics)
 **Created:** 2026-07-03
 **Audit ref:** `docs/audits/2026-07-adversarial-audit.md` — E2, S3, O2
@@ -385,7 +385,7 @@ error — unacceptable for a pastoral-care product serving people in crisis.
 
 - [x] Turnstile: rejections fail closed (403); repeated transient siteverify errors trip a circuit
       breaker to fail-closed; isolated blips still fail open but emit a metric (`turnstile.fail_open_total`)
-- [ ] Rate limiting: counters live in a shared store surviving restarts and consistent across replicas;
+- [x] Rate limiting: counters live in a shared store surviving restarts and consistent across replicas;
       session lifetime cap survives deploys; dedicated unit tests added
 - [x] Content safety: keyword stage always runs regardless of ML-stage availability; empty/malformed
       Llama Guard response treated as an error, not "safe"; every fallback branch emits

--- a/docs/BACKLOG_STORIES/BITB-061-fail-closed-abuse-controls.md
+++ b/docs/BACKLOG_STORIES/BITB-061-fail-closed-abuse-controls.md
@@ -1,6 +1,6 @@
 # BITB-061: Make the Abuse-Control Stack Fail Closed (Turnstile, Rate Limits, Content Safety)
 
-**Status:** 🚧 In Progress — Turnstile and content-safety phases complete; rate-limiter phase remains
+**Status:** ✅ Done — Turnstile, rate-limiter, and content-safety phases all complete
 **Priority:** P1 (High) — 2026-07 adversarial audit E2 + S3 + O2 (all HIGH); every layer of bot/abuse/safety protection currently fails open, silently
 **Size:** M (three coordinated changes: Turnstile policy, shared rate-limit store, safety defaults/metrics)
 **Created:** 2026-07-03
@@ -49,11 +49,49 @@ the cooldown elapses.
 
 ### Rate limiting
 
-- [ ] Counters live in a shared store surviving restarts and consistent across replicas — Postgres
+- [x] Counters live in a shared store surviving restarts and consistent across replicas — Postgres
       UPSERT sliding window (pg_cron cleanup already available) or managed Redis; decision recorded
       in the story on implementation.
-- [ ] Session lifetime cap survives deploys; limits hold at N replicas.
-- [ ] `utils/rate_limiter.py` gains dedicated unit tests (window expiry, session cap, concurrency).
+- [x] Session lifetime cap survives deploys; limits hold at N replicas.
+- [x] `utils/rate_limiter.py` gains dedicated unit tests (window expiry, session cap, concurrency).
+
+**Implemented 2026-07-13:** chose **Postgres over Redis** — the stack has zero Redis
+infrastructure today (grep-verified across `api/`, `deployment/`, `frontend/`), Postgres is
+already the one datastore every replica shares, and migration 005's pg_cron cleanup job is a
+working precedent. Adding managed Redis for three small counter tables would be a new
+dependency, new Terraform, new secret, and a new failure mode for no real benefit.
+
+Two new tables (migration `009_add_rate_limit_tables.sql`): `rate_limit_hits` (sliding-window
+event log — one row per allowed request, keyed `ip:<addr>` / `session:<id>`) and
+`rate_limit_sessions` (durable per-session lifetime counter, the piece that must survive
+deploys). `rate_limit_hits` rows are purged by pg_cron (migration `010_schedule_rate_limit_purge.sql`,
+same pattern as migration 005); `rate_limit_sessions` rows expire on idle past
+`rate_limit_session_ttl_seconds`.
+
+`api/utils/rate_limiter.py` now has a `RateLimitStore` protocol with two implementations:
+`InMemoryStore` (the pre-existing per-process algorithm, now also the fallback) and
+`PostgresStore` (transaction-scoped `pg_advisory_xact_lock` per IP/session key, so concurrent
+requests for the *same* key serialize across replicas; the lifetime counter increments via
+`INSERT ... ON CONFLICT (session_id) DO UPDATE`, which is atomic under concurrent writers — no
+double-counting or lost increments). `RateLimiter.check_rate_limit()` keeps its exact signature
+and reason strings, so `api/utils/security.py`'s call site is unchanged.
+
+**Fail-mode policy** (the important design decision, since this story is about *not* failing
+open): reuses `utils/circuit_breaker.py`, same as the Turnstile phase.
+An isolated Postgres error (breaker still closed) falls back to the in-memory store for that
+check — degraded but still enforcing a limit — and emits `rate_limiter.fallback_total`.
+Persistent failures (5 consecutive) trip the breaker and the check **fails closed**
+(`rate_limiter.fail_closed_total`) rather than allowing every request through. Pure fail-open was
+rejected (defeats the story); pure fail-closed on every DB blip was rejected too (turns an
+isolated Postgres hiccup into a full chat outage). New `rate_limit_backend` config
+(`postgres`/`memory`) keeps the old in-process-only behavior reachable for tests/local dev
+without a database.
+
+Tests: `api/tests/test_rate_limiter.py` (mocked `AsyncSession` — SQL/params per decision branch,
+fallback-on-error, fail-closed-after-breaker-trips, in-process concurrency) and
+`api/tests/test_rate_limiter_integration.py` (self-skipping when Postgres is unreachable; the
+real proof — 50 concurrent connections against a live Postgres racing the same session, exactly
+`session_max_requests` allowed).
 
 ### Content safety
 

--- a/scripts/migrations/009_add_rate_limit_tables.sql
+++ b/scripts/migrations/009_add_rate_limit_tables.sql
@@ -1,0 +1,41 @@
+-- Migration 009: Shared rate-limit counters (BITB-061 phase 3)
+-- Date: 2026-07-13
+-- Purpose: api/utils/rate_limiter.py was an in-memory, per-process limiter.
+--   Production runs up to 2 replicas, so IP/session-per-minute limits were
+--   effectively 2x the configured value, and every deploy/restart reset all
+--   counters -- including the 10-message session lifetime cap that is meant
+--   to survive the whole session. Moving the counters into Postgres (already
+--   the one datastore every replica shares) closes both gaps.
+--
+-- Two tables because the semantics genuinely differ:
+--   - rate_limit_hits: sliding-window event log (one row per allowed
+--     request), used for the per-minute IP and per-session limits. Rows are
+--     short-lived; see migration 010 for the pg_cron purge.
+--   - rate_limit_sessions: durable per-session lifetime counter. Must survive
+--     window cleanup and deploys -- that durability is the whole point of
+--     this migration.
+--
+-- Safe to run multiple times (idempotent).
+
+CREATE TABLE IF NOT EXISTS rate_limit_hits (
+    id         BIGSERIAL PRIMARY KEY,
+    -- 'ip:<addr>' or 'session:<id>' -- both share this table.
+    limit_key  TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports both the windowed COUNT (key, recent-first) and the cron purge
+-- (age-only scan).
+CREATE INDEX IF NOT EXISTS idx_rate_limit_hits_key_time
+    ON rate_limit_hits (limit_key, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_hits_created_at
+    ON rate_limit_hits (created_at);
+
+CREATE TABLE IF NOT EXISTS rate_limit_sessions (
+    session_id     TEXT PRIMARY KEY,
+    total_requests INTEGER NOT NULL DEFAULT 0,
+    last_seen      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_sessions_last_seen
+    ON rate_limit_sessions (last_seen);

--- a/scripts/migrations/010_schedule_rate_limit_purge.sql
+++ b/scripts/migrations/010_schedule_rate_limit_purge.sql
@@ -1,0 +1,61 @@
+-- Migration 010: Schedule pg_cron purge for shared rate-limit tables (BITB-061)
+-- Date: 2026-07-13
+-- Purpose: rate_limit_hits/rate_limit_sessions (migration 009) grow forever
+--          without a cleanup job. Follows the same pg_cron pattern as
+--          migration 005 (blocked-sample purge).
+--
+-- Prerequisites (operator-level, one-time -- same as migration 005):
+--   1. Add `pg_cron` to the `azure.extensions` server parameter
+--      (see deployment/main.tf). Restart the Postgres flexible server.
+--   2. Set the `cron.database_name` server parameter to the app database
+--      (e.g. `bibledb`) so cron jobs run against the right DB. Restart.
+--   3. Run this migration as a superuser (cron schema is owned by
+--      `azure_pg_admin` on Azure flexible server).
+--
+-- Behaviour:
+--   - rate_limit_hits rows only need to live one sliding window (60s by
+--     default: rate_limit_requests_per_minute / rate_limit_requests_per_
+--     session_minute); purge generously and keep 1 hour so a slow purge run
+--     never races a live window check.
+--   - rate_limit_sessions rows expire on idle past
+--     `rate_limit_session_ttl_seconds` (default 3600s = 1 hour). The purge
+--     horizon below is hardcoded to match that default because pg_cron
+--     cannot read application config -- if that setting is ever changed,
+--     this file must be updated to match (keep the purge horizon >= the app
+--     TTL so cron never deletes a counter the app still considers live).
+--
+-- Idempotency:
+--   - `CREATE EXTENSION IF NOT EXISTS` is safe to re-run.
+--   - `cron.unschedule` is wrapped in a DO block so re-running this
+--     migration just replaces the schedule without errors.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DO $$
+BEGIN
+    PERFORM cron.unschedule('purge-rate-limit-hits')
+    FROM cron.job
+    WHERE jobname = 'purge-rate-limit-hits';
+
+    PERFORM cron.unschedule('purge-rate-limit-sessions')
+    FROM cron.job
+    WHERE jobname = 'purge-rate-limit-sessions';
+END
+$$;
+
+SELECT cron.schedule(
+    'purge-rate-limit-hits',
+    '*/10 * * * *',
+    $cmd$DELETE FROM rate_limit_hits WHERE created_at < now() - interval '1 hour'$cmd$
+);
+
+SELECT cron.schedule(
+    'purge-rate-limit-sessions',
+    '15 * * * *',
+    $cmd$DELETE FROM rate_limit_sessions WHERE last_seen < now() - interval '1 hour'$cmd$
+);
+
+-- Verify
+SELECT jobid, jobname, schedule, command
+FROM cron.job
+WHERE jobname IN ('purge-rate-limit-hits', 'purge-rate-limit-sessions');


### PR DESCRIPTION
## Summary

Part 3 (final) of BITB-061 ("Make the Abuse-Control Stack Fail Closed"). The Turnstile phase already merged (#821); the content-safety phase is open on #840. This closes the last remaining piece: `api/utils/rate_limiter.py` was in-memory and per-process, so with prod's 2 replicas the effective IP/session limits were ~2x the configured value, and every deploy/restart reset all counters — including the 10-message session lifetime cap the story exists to make durable.

## Changes

- **Two new Postgres tables** (`scripts/migrations/009_add_rate_limit_tables.sql`): `rate_limit_hits` (sliding-window event log, one row per allowed request, keyed `ip:<addr>` / `session:<id>`) and `rate_limit_sessions` (durable per-session lifetime counter — the piece that must survive deploys).
- **pg_cron purge job** (`scripts/migrations/010_schedule_rate_limit_purge.sql`), same pattern as migration 005's blocked-sample purge.
- **`api/utils/rate_limiter.py` refactor**: new `RateLimitStore` protocol with `InMemoryStore` (the pre-existing algorithm, unchanged, now also the fallback) and `PostgresStore` (transaction-scoped `pg_advisory_xact_lock` per IP/session key so concurrent requests for the same key serialize across replicas; the lifetime counter increments via `INSERT ... ON CONFLICT (session_id) DO UPDATE`, atomic under concurrent writers). `RateLimiter.check_rate_limit()` keeps its exact signature and reason strings, so `api/utils/security.py`'s call site is **unchanged**.
- **Fail-mode policy** (reuses `utils/circuit_breaker.py`, same pattern as the Turnstile phase): an isolated Postgres error falls back to the in-memory store (`rate_limiter.fallback_total`) — degraded but still enforcing a limit. Persistent failures (5 consecutive) trip the breaker and the check **fails closed** (`rate_limiter.fail_closed_total`) rather than silently allowing every request through. New `rate_limit_backend` config (`postgres`/`memory`) keeps the old in-process-only behavior reachable for tests/local dev without a database.

### Design decision recorded in the story

Chose **Postgres over Redis** — zero Redis infrastructure exists anywhere in this stack (grep-verified across `api/`, `deployment/`, `frontend/`), Postgres is already the one datastore every replica shares, and migration 005 is a working pg_cron precedent. Adding managed Redis for three small counter tables would be a new dependency, new Terraform, new secret, and a new failure mode for no real benefit.

## Test plan

- [x] 8 new tests in `api/tests/test_rate_limiter.py` (mocked `AsyncSession`): SQL/params issued per decision branch, isolated-error fallback, persistent-error fail-closed, in-process concurrency.
- [x] `api/tests/test_rate_limiter_integration.py`: self-skipping when Postgres is unreachable (mirrors `test_weekly_report_integration.py`'s pattern); against a real local Postgres 16, 50 concurrent connections racing the same `session_id` land exactly `session_max_requests` allowed — the actual cross-replica correctness proof mocks can't give.
- [x] Migration 009 applied and re-applied (idempotent) against a real local Postgres. Migration 010 (pg_cron) manually brace/statement-checked — no `pg_cron` extension available in this sandbox; mirrors how #840 handled Terraform-only changes with no `terraform` binary.
- [x] Existing `test_security.py` / `test_utils_coverage.py` `RateLimiter` tests updated to construct `backend="memory"` explicitly (they test the sliding-window algorithm itself, not the new Postgres path) and redirect private-attribute access through `._store`.
- [x] `ruff check` / `black --check` / `mypy` clean on all touched files.
- [x] Full backend suite: **3441 passed, 94 skipped**. 126 failures are pre-existing and unrelated (missing `lingua-language-detector` package in this sandbox environment — confirmed by re-running one failure in isolation, same `ModuleNotFoundError` with no code change).
- [x] `docs/BACKLOG.md` and `docs/BACKLOG_STORIES/BITB-061-fail-closed-abuse-controls.md` updated: rate-limiting acceptance criteria checked off, design decision + implementation notes recorded (matching the style #821/#840 used for the other two phases of this story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwgK88XPggfimXnGquJuNa

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwgK88XPggfimXnGquJuNa)_