### PR TITLE
fix(weekly-report): track sessions on the streaming chat endpoint

### DIFF
--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -105,7 +105,11 @@ async def chat(
     ],
 )
 async def chat_stream(
-    request: ChatRequest, db: DbSession, llm: LLMProviderDep, embedding: EmbeddingProviderDep
+    request: ChatRequest,
+    http_request: Request,
+    db: DbSession,
+    llm: LLMProviderDep,
+    embedding: EmbeddingProviderDep,
 ):
     """
     Stream a chat response for real-time display.
@@ -118,6 +122,11 @@ async def chat_stream(
     if request.session_id:
         chat_sessions_counter.add(1, {"session_token": request.session_id})
 
+    # Header-derived session attributes (mirrors the non-streaming `chat` handler).
+    user_agent = http_request.headers.get("user-agent")
+    accept_lang = http_request.headers.get("accept-language", "")
+    language = accept_lang.split(",")[0].split("-")[0] if accept_lang else None
+
     service = ChatService(db, llm, embedding)
 
     async def generate():
@@ -126,6 +135,10 @@ async def chat_stream(
                 # chunk is now a dict with 'type' field
                 # SSE format: data: {json}\n\n
                 yield f"data: {json.dumps(chunk)}\n\n"
+            # Track session only after the stream completes successfully, matching
+            # the non-streaming path. Fire-and-forget (never raises); committed by the
+            # get_db_session dependency cleanup once the response body is drained.
+            await track_session(db, request.session_id, user_agent=user_agent, language=language)
             yield "data: [DONE]\n\n"
         except AllModelsExhaustedError as e:
             logger.warning("Streaming: all LLM models exhausted (%s): %s", e.reason, e)

--- a/api/tests/test_provider_error_contract.py
+++ b/api/tests/test_provider_error_contract.py
@@ -116,6 +116,7 @@ class TestRouteMapsTypedError:
         mock_db = AsyncMock()
         mock_llm = AsyncMock()
         mock_embedding = AsyncMock()
+        mock_http = self._mock_http_request()
         request = ChatRequest(message="Hello")
 
         async def mock_gen(req):
@@ -131,7 +132,7 @@ class TestRouteMapsTypedError:
             mock_service.chat_stream = mock_gen
             mock_service_cls.return_value = mock_service
 
-            response = await chat_stream(request, mock_db, mock_llm, mock_embedding)
+            response = await chat_stream(request, mock_http, mock_db, mock_llm, mock_embedding)
 
             chunks = [chunk async for chunk in response.body_iterator]
 

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -847,18 +847,16 @@ class TestChatRoutes:
 class TestChatStreamRoute:
     """Tests for chat_stream route function."""
 
-    @pytest.mark.asyncio
-    async def test_chat_stream_returns_streaming_response(self):
-        from chat.service import ChatRequest
-        from routes.chat import chat_stream
+    @staticmethod
+    def _mock_http_request():
+        """Create a mock HTTP request with headers for chat_stream route tests."""
+        mock_req = MagicMock()
+        mock_req.headers = {"user-agent": "test-agent", "accept-language": "en-US"}
+        return mock_req
 
-        mock_db = AsyncMock()
-        mock_llm = AsyncMock()
-        mock_embedding = AsyncMock()
-
-        request = ChatRequest(message="Hello")
-
-        async def mock_gen(req):
+    @staticmethod
+    def _mock_gen(req):
+        async def gen(_req):
             yield {
                 "type": "metadata",
                 "message_id": "test-id",
@@ -869,15 +867,65 @@ class TestChatStreamRoute:
             yield {"type": "content", "content": "Hello "}
             yield {"type": "content", "content": "world!"}
 
-        with patch("routes.chat.ChatService") as mock_service_cls:
+        return gen(req)
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_returns_streaming_response(self):
+        from chat.service import ChatRequest
+        from routes.chat import chat_stream
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+        mock_http = self._mock_http_request()
+
+        request = ChatRequest(message="Hello")
+
+        with (
+            patch("routes.chat.ChatService") as mock_service_cls,
+            patch("routes.chat.track_session", new_callable=AsyncMock),
+        ):
             mock_service = MagicMock()
-            mock_service.chat_stream = mock_gen
+            mock_service.chat_stream = self._mock_gen
             mock_service_cls.return_value = mock_service
 
-            response = await chat_stream(request, mock_db, mock_llm, mock_embedding)
+            response = await chat_stream(request, mock_http, mock_db, mock_llm, mock_embedding)
 
         # Should be a StreamingResponse
         assert response.media_type == "text/event-stream"
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_tracks_session_after_stream(self):
+        """Draining the streamed body should upsert the session exactly once."""
+        from chat.service import ChatRequest
+        from routes.chat import chat_stream
+
+        mock_db = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_embedding = AsyncMock()
+        mock_http = self._mock_http_request()
+
+        request = ChatRequest(message="Hello", session_id="sess-123")
+
+        with (
+            patch("routes.chat.ChatService") as mock_service_cls,
+            patch("routes.chat.track_session", new_callable=AsyncMock) as mock_track,
+        ):
+            mock_service = MagicMock()
+            mock_service.chat_stream = self._mock_gen
+            mock_service_cls.return_value = mock_service
+
+            response = await chat_stream(request, mock_http, mock_db, mock_llm, mock_embedding)
+
+            # Tracking happens inside the generator, so it only fires once the body
+            # is consumed — not merely by constructing the StreamingResponse.
+            mock_track.assert_not_awaited()
+            chunks = [chunk async for chunk in response.body_iterator]
+
+        assert any("[DONE]" in chunk for chunk in chunks)
+        mock_track.assert_awaited_once_with(
+            mock_db, "sess-123", user_agent="test-agent", language="en"
+        )
 
 
 # ==================== Scripture Route Tests ====================

--- a/docs/BACKLOG_STORIES/BITB-069-android-user-agent-mobile-split.md
+++ b/docs/BACKLOG_STORIES/BITB-069-android-user-agent-mobile-split.md
@@ -1,0 +1,90 @@
+# BITB-069: Android — Send a User-Agent so the weekly report's Web/Mobile split is correct
+
+**Status:** 📋 To Do
+
+## User Story
+
+As the maintainer reading the weekly activity digest, I want Android traffic to be
+counted as **mobile** in the Web/Mobile split (and to record a meaningful user-agent),
+so the Engagement section reflects reality instead of attributing every Android session
+to "web".
+
+## Problem
+
+The backend classifies a session as mobile vs. web purely from the HTTP `User-Agent`
+header:
+
+- `api/utils/session_tracker.py:56` — `_detect_mobile()` returns true only when the UA
+  contains one of `mobile`, `android`, `iphone`, `ipad`.
+- The value is stored on the `sessions` row and surfaced by the weekly digest's
+  `Web / Mobile` line (`api/reports/weekly_report.py`).
+
+The Android OkHttp client sets no User-Agent header
+(`android/app/src/main/kotlin/org/voxquieta/app/data/remote/api/ApiClient.kt:32-40`),
+so requests carry OkHttp's default `okhttp/<version>`. That matches none of the mobile
+keywords, so once session tracking is active on `/chat/stream`, **every Android session
+is counted as web** and `sessions.user_agent` stores `okhttp/…`.
+
+(The `"Android/${Build.VERSION.RELEASE}"` string in `ChatViewModel.kt:1056` is sent as a
+contact-form *body* field, not as the transport User-Agent header — it does not affect
+session tracking.)
+
+## Proposed Changes
+
+Add a small interceptor in `ApiClient.create(...)` that sets a stable, descriptive
+User-Agent on every request, e.g.:
+
+```kotlin
+.addInterceptor { chain ->
+    val req = chain.request().newBuilder()
+        .header("User-Agent", "VoxQuieta-Android/$appVersion (Android ${Build.VERSION.RELEASE})")
+        .build()
+    chain.proceed(req)
+}
+```
+
+- Contains "Android", so `_detect_mobile()` classifies it as mobile.
+- Include the app version (thread it in from `BuildConfig`) for future debugging.
+- Applies to all endpoints, so contact/feedback rows also get a real UA.
+
+No backend change required — `_detect_mobile()` already keys on "android".
+
+## Acceptance Criteria
+
+- [ ] Every request from the Android app carries a `User-Agent` header containing
+      "Android".
+- [ ] After a chat send, the corresponding `sessions` row has `is_mobile = true` and a
+      non-`okhttp` `user_agent`.
+- [ ] A dry-run weekly report attributes Android sessions to the Mobile column.
+- [ ] Unit/instrumentation test asserts the interceptor sets the header.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `android/app/src/main/kotlin/org/voxquieta/app/data/remote/api/ApiClient.kt` | Add a User-Agent interceptor (thread app version in from `BuildConfig`) |
+| Android test (e.g. an ApiClient/interceptor test) | Assert the `User-Agent` header is present and contains "Android" |
+
+## Out of Scope
+
+- The backend streaming session-tracking fix (this backlog item's prerequisite; tracked
+  separately).
+- Reworking Android's `session_id` reset-on-new-conversation behavior (see Notes).
+- Richer device analytics (model, OS API level breakdown).
+
+## Priority
+
+P2 — the Web/Mobile split is wrong for all mobile users until this lands. Small, isolated.
+
+## Size
+
+S — one interceptor + a test.
+
+## Dependencies / Related Work
+
+- Depends on the backend fix that makes `/chat/stream` call `track_session`.
+- Related: `docs/USAGE_TRACKING.md`, `docs/WEEKLY_REPORT.md`.
+
+## Assignee
+
+android-expert


### PR DESCRIPTION
The weekly digest Engagement section was permanently zero because
`track_session` was only called from the non-streaming `POST /chat`
endpoint, while both the web app and Android use `POST /chat/stream`.
No `sessions` row was ever written by real traffic, so active/new
sessions, messages, web/mobile split and top languages all read 0.

Call `track_session` from `chat_stream` after the stream completes
successfully, mirroring the non-streaming path. It is fire-and-forget
and the write is committed by the existing get_db_session cleanup once
the response body is drained.

Also add BITB-069: Android sends OkHttp's default User-Agent, which the
backend mobile detection does not recognize, so Android sessions would be
miscounted as web in the Web/Mobile split once tracking is live.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NT5cD3QKMPijzwRd6Afr7Z