### PR TITLE
fix(android): prevent FOREIGN KEY crash when saving a message for a deleted conversation

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/local/MessageDao.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/local/MessageDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -14,4 +15,21 @@ interface MessageDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(message: MessageEntity)
+
+    @Query("SELECT EXISTS(SELECT 1 FROM conversations WHERE id = :conversationId)")
+    suspend fun conversationExists(conversationId: String): Boolean
+
+    /**
+     * Inserts [message] only if its parent conversation still exists. Wrapped in a
+     * transaction so a concurrent conversation delete cannot slip between the existence
+     * check and the insert, which would otherwise raise a FOREIGN KEY constraint failure
+     * (SQLITE_CONSTRAINT_FOREIGNKEY). A missing parent means the conversation was deleted
+     * mid-stream, so the write is safely skipped instead of crashing.
+     */
+    @Transaction
+    suspend fun upsertIfConversationExists(message: MessageEntity) {
+        if (conversationExists(message.conversationId)) {
+            upsert(message)
+        }
+    }
 }

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/repositories/ChatRepositoryImpl.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/repositories/ChatRepositoryImpl.kt
@@ -49,7 +49,9 @@ class ChatRepositoryImpl @Inject constructor(
         }
 
     override suspend fun saveMessage(conversationId: String, message: Message) {
-        db.messageDao().upsert(message.toEntity(conversationId))
+        // upsertIfConversationExists skips the write (rather than crashing with a FOREIGN
+        // KEY constraint failure) when the parent conversation was deleted mid-stream.
+        db.messageDao().upsertIfConversationExists(message.toEntity(conversationId))
     }
 
     override suspend fun createConversation(id: String, title: String): Conversation {

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -858,8 +858,11 @@ class ChatViewModel @Inject constructor(
 
     /** Deletes the active conversation from DB and resets in-memory state. */
     fun clearConversation() {
+        // Stop any in-flight stream first: its onCompletion would otherwise try to persist
+        // the assistant message against the conversation we are about to delete.
+        cancelStream()
         val conversationId = _uiState.value.currentConversationId
-        _uiState.update { it.copy(messages = emptyList(), error = null, currentConversationId = null, allVerses = emptyList()) }
+        _uiState.update { it.copy(messages = emptyList(), error = null, isLoading = false, currentConversationId = null, allVerses = emptyList()) }
         if (conversationId != null) {
             viewModelScope.launch {
                 lastConversationPreferences.setLastConversationId(null)
@@ -870,7 +873,10 @@ class ChatViewModel @Inject constructor(
 
     /** Deletes ALL conversations from DB and resets in-memory state. */
     fun clearAllConversations() {
-        _uiState.update { it.copy(messages = emptyList(), error = null, currentConversationId = null, allVerses = emptyList()) }
+        // Stop any in-flight stream first: its onCompletion would otherwise try to persist
+        // the assistant message against a conversation we are about to delete.
+        cancelStream()
+        _uiState.update { it.copy(messages = emptyList(), error = null, isLoading = false, currentConversationId = null, allVerses = emptyList()) }
         viewModelScope.launch {
             lastConversationPreferences.setLastConversationId(null)
             repository.clearAllConversations()

--- a/android/app/src/test/kotlin/org/voxquieta/app/data/local/MessageDaoTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/data/local/MessageDaoTest.kt
@@ -1,0 +1,89 @@
+package org.voxquieta.app.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-backed because [MessageDao] needs a real (in-memory) Room database with
+ * foreign-key enforcement — the behaviour under test is the FOREIGN KEY guard added to
+ * prevent the SQLITE_CONSTRAINT_FOREIGNKEY crash when a conversation is deleted mid-stream.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class MessageDaoTest {
+
+    private lateinit var db: VoxQuietaDatabase
+    private lateinit var messageDao: MessageDao
+    private lateinit var conversationDao: ConversationDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            VoxQuietaDatabase::class.java,
+        ).build()
+        messageDao = db.messageDao()
+        conversationDao = db.conversationDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun conversation(id: String) =
+        ConversationEntity(id = id, title = "t", createdAt = 0L, updatedAt = 0L)
+
+    private fun message(id: String, conversationId: String) = MessageEntity(
+        id = id,
+        conversationId = conversationId,
+        role = "assistant",
+        content = "hi",
+        versesJson = "[]",
+        createdAt = 0L,
+    )
+
+    @Test
+    fun `upsertIfConversationExists inserts when the parent conversation exists`() = runTest {
+        conversationDao.upsert(conversation("c1"))
+
+        messageDao.upsertIfConversationExists(message("m1", "c1"))
+
+        val stored = messageDao.observeByConversation("c1").first()
+        assertEquals(1, stored.size)
+        assertEquals("m1", stored.first().id)
+    }
+
+    @Test
+    fun `upsertIfConversationExists is a no-op when the parent conversation is missing`() = runTest {
+        // No conversation row inserted — this simulates the conversation being deleted mid-stream.
+        messageDao.upsertIfConversationExists(message("m1", "missing"))
+
+        val stored = messageDao.observeByConversation("missing").first()
+        assertTrue("Expected no message to be persisted for a missing parent", stored.isEmpty())
+    }
+
+    @Test
+    fun `plain upsert throws a foreign key constraint failure when the parent is missing`() = runTest {
+        // Documents the underlying crash the guard protects against: a bare insert against a
+        // non-existent conversation violates the foreign key.
+        try {
+            messageDao.upsert(message("m1", "missing"))
+            org.junit.Assert.fail("Expected a foreign key constraint failure")
+        } catch (e: android.database.sqlite.SQLiteConstraintException) {
+            assertTrue(e.message?.contains("FOREIGN KEY", ignoreCase = true) == true)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Google Play reported a fatal crash:

```
android.database.sqlite.SQLiteConstraintException
FOREIGN KEY constraint failed (code 787 SQLITE_CONSTRAINT_FOREIGNKEY)
  ...
androidx.room.EntityInsertionAdapter.insert
org.voxquieta.app.data.local.MessageDao_Impl$2.call (MessageDao_Impl.java:64)
```

This is a **delete-during-stream race**, not a schema/migration problem.

`MessageEntity.conversationId` is a foreign key to `conversations.id` (`onDelete = CASCADE`), and Room enforces foreign keys by default. `ChatViewModel.sendMessage` persists the **assistant** message in the stream's `onCompletion` block, inside `withContext(NonCancellable)`, reusing a `conversationId` captured at the start of the send.

If the user deletes that conversation while it is still streaming — via `clearConversation()`, `clearAllConversations()`, or delete/clear-all from the conversations list, none of which cancelled the stream — the parent row is gone (CASCADE) by the time the assistant insert runs. The insert then violates the foreign key and crashes; the `NonCancellable` block has no try/catch, so it propagates.

The initial *user* message insert was always safe because `ensureConversation` creates and awaits the parent conversation row first. `upsert` being `@Insert(onConflict = REPLACE)` did not help — `REPLACE` only resolves primary-key (message id) conflicts, never the foreign key.

## Fix

- **`MessageDao.upsertIfConversationExists`** — a `@Transaction` method that checks the parent conversation exists before inserting. Wrapping the check-then-insert in a transaction closes the window against a concurrent delete. A missing parent means the conversation was deleted mid-stream, so the write is safely skipped instead of crashing (and without resurrecting a deleted conversation).
- **`ChatRepositoryImpl.saveMessage`** now routes through the guarded insert, covering both the user- and assistant-message write paths.
- **Hardening** — `clearConversation()` and `clearAllConversations()` now call `cancelStream()` (and reset `isLoading`), so deleting the active conversation stops the in-flight stream rather than letting it keep streaming and attempt to persist against a row that is being removed. The DAO guard remains the actual crash fix (completion runs under `NonCancellable`); this just avoids wasted work.
- **`MessageDaoTest`** (Robolectric + in-memory Room) covers the guard inserting when the parent exists, no-op'ing when it does not, and documents the raw FK failure of a bare insert.

## Testing

Could not run the Gradle suite in the authoring environment (egress policy blocks `dl.google.com:443`, so the Android Gradle Plugin cannot be resolved). The new `MessageDaoTest` will exercise the fix in CI, where Google's Maven repo is reachable. The changes are otherwise small and localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHJMLfQRod8YEzUsR6fy4q)_