### PR TITLE
feat(android): "What's New" bottom sheet on first launch after update (BITB-058)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/MainActivity.kt
@@ -20,7 +20,9 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -33,6 +35,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import org.voxquieta.app.analytics.AnalyticsHelper
 import org.voxquieta.app.presentation.components.TurnstileWebView
+import org.voxquieta.app.presentation.components.WhatsNewBottomSheet
+import org.voxquieta.app.presentation.components.shouldShowWhatsNew
 import org.voxquieta.app.presentation.screens.ChangelogScreen
 import org.voxquieta.app.presentation.screens.ChatScreen
 import org.voxquieta.app.presentation.screens.ConversationsScreen
@@ -51,6 +55,14 @@ private fun Context.hasSplashBeenSeen(): Boolean =
 private fun Context.markSplashSeen() =
     getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
         .edit().putBoolean("splash_seen", true).apply()
+
+private fun Context.lastSeenVersionCode(): Int =
+    getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+        .getInt("last_seen_version_code", -1)
+
+private fun Context.markVersionSeen(code: Int) =
+    getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+        .edit().putInt("last_seen_version_code", code).apply()
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -71,6 +83,10 @@ class MainActivity : ComponentActivity() {
     // Play In-App Update (BITB-057): flexible flow, checked on cold start and on resume.
     @Inject
     lateinit var inAppUpdateManager: InAppUpdateManager
+
+    // Computed once on cold start (BITB-058); read inside setContent{} to seed the
+    // "What's New" sheet's Compose state.
+    private var showWhatsNewOnLaunch = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Capture the splash screen handle before super.onCreate() as required by the API.
@@ -96,6 +112,13 @@ class MainActivity : ComponentActivity() {
         // the Activity on SDK < 33), rotation, or other config changes.
         if (savedInstanceState == null) {
             analyticsHelper.logEvent(AnalyticsHelper.EVENT_APP_OPEN)
+
+            // "What's New" bottom sheet (BITB-058): shown once per update, never on
+            // fresh install. The version is marked seen here (not on dismiss/see-all)
+            // so a process death before the user acts still counts as "seen".
+            val storedVersion = lastSeenVersionCode()
+            showWhatsNewOnLaunch = shouldShowWhatsNew(storedVersion, BuildConfig.VERSION_CODE)
+            if (storedVersion != BuildConfig.VERSION_CODE) markVersionSeen(BuildConfig.VERSION_CODE)
         }
 
         // Play Store isn't available in debug builds, so the check is a silent no-op there.
@@ -119,6 +142,7 @@ class MainActivity : ComponentActivity() {
             VoxQuietaTheme(darkTheme = darkTheme) {
                 val navController = rememberNavController()
                 val context = LocalContext.current
+                var showWhatsNew by remember { mutableStateOf(showWhatsNewOnLaunch) }
 
                 // Track screen views every time the user navigates to a new destination.
                 DisposableEffect(navController) {
@@ -232,6 +256,18 @@ class MainActivity : ComponentActivity() {
                     // of which screen the user navigates to first) finds a fresh
                     // token already cached. The widget itself is 1.dp / invisible.
                     TurnstileWebView(turnstileManager = turnstileManager)
+
+                    // "What's New" bottom sheet (BITB-058). Version is already marked
+                    // seen in onCreate, so both actions just dismiss the overlay.
+                    if (showWhatsNew) {
+                        WhatsNewBottomSheet(
+                            onDismiss = { showWhatsNew = false },
+                            onSeeAll = {
+                                showWhatsNew = false
+                                navController.navigate("changelog")
+                            },
+                        )
+                    }
 
                     // Activity-scoped snackbar for the in-app update flow (BITB-057).
                     // There's no single reusable SnackbarHost in this Compose tree

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/WhatsNewBottomSheet.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/WhatsNewBottomSheet.kt
@@ -1,0 +1,105 @@
+package org.voxquieta.app.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.jeziellago.compose.markdowntext.MarkdownText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import org.voxquieta.app.R
+import org.voxquieta.app.presentation.screens.ChangelogEntry
+
+internal fun shouldShowWhatsNew(storedVersionCode: Int, currentVersionCode: Int): Boolean =
+    storedVersionCode != -1 && storedVersionCode < currentVersionCode
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WhatsNewBottomSheet(onDismiss: () -> Unit, onSeeAll: () -> Unit) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    var entry by remember { mutableStateOf<ChangelogEntry?>(null) }
+    var loaded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        entry = withContext(Dispatchers.IO) {
+            runCatching {
+                val raw = context.assets.open("changelog.json")
+                    .bufferedReader().use { it.readText() }
+                Json { ignoreUnknownKeys = true }.decodeFromString<List<ChangelogEntry>>(raw)
+            }.getOrDefault(emptyList()).firstOrNull()
+        }
+        loaded = true
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.whats_new_title),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+
+            val currentEntry = entry
+            if (currentEntry != null) {
+                Text(
+                    text = currentEntry.version,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                MarkdownText(
+                    markdown = currentEntry.body,
+                    style = MaterialTheme.typography.bodyMedium,
+                    linkColor = MaterialTheme.colorScheme.primary,
+                    onLinkClicked = { url -> uriHandler.openUri(url) },
+                )
+            } else if (loaded) {
+                Text(
+                    text = stringResource(R.string.changelog_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                TextButton(onClick = onDismiss) {
+                    Text(text = stringResource(R.string.whats_new_dismiss))
+                }
+                Spacer(Modifier.weight(1f))
+                TextButton(onClick = onSeeAll) {
+                    Text(text = stringResource(R.string.whats_new_see_all))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values-ar/strings.xml
+++ b/android/app/src/main/res/values-ar/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">ما الجديد</string>
     <string name="settings_changelog_link">ما الجديد</string>
     <string name="changelog_empty">لا تتوفر ملاحظات إصدار حتى الآن.</string>
+    <string name="whats_new_title">ما الجديد</string>
+    <string name="whats_new_dismiss">حسناً</string>
+    <string name="whats_new_see_all">عرض الكل</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">لقد أجريت 10 رسائل في هذه الجلسة! لماذا لا تأخذ استراحة وتستمتع بخليقة الله في الهواء الطلق؟ 🌳</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">Was ist neu</string>
     <string name="settings_changelog_link">Was ist neu</string>
     <string name="changelog_empty">Es sind noch keine Versionshinweise verfügbar.</string>
+    <string name="whats_new_title">Was ist neu</string>
+    <string name="whats_new_dismiss">Verstanden</string>
+    <string name="whats_new_see_all">Alle anzeigen</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">Du hast 10 Nachrichten in dieser Sitzung gehabt! Warum machst du nicht eine Pause und genießt Gottes Schöpfung draußen? 🌳</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">Novedades</string>
     <string name="settings_changelog_link">Novedades</string>
     <string name="changelog_empty">Aún no hay notas de versión disponibles.</string>
+    <string name="whats_new_title">Novedades</string>
+    <string name="whats_new_dismiss">Entendido</string>
+    <string name="whats_new_see_all">Ver todo</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">¡Has tenido 10 mensajes en esta sesión! ¿Por qué no tomar un descanso y disfrutar de la creación de Dios al aire libre? 🌳</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">Nouveautés</string>
     <string name="settings_changelog_link">Nouveautés</string>
     <string name="changelog_empty">Aucune note de version n\'est disponible pour le moment.</string>
+    <string name="whats_new_title">Nouveautés</string>
+    <string name="whats_new_dismiss">J\'ai compris</string>
+    <string name="whats_new_see_all">Tout voir</string>
 
     <!-- Session limit error -->
     <string name="error_session_limit">Vous avez eu 10 messages dans cette session ! Pourquoi ne pas faire une pause et profiter de la création de Dieu en plein air ? 🌳</string>

--- a/android/app/src/main/res/values-hi/strings.xml
+++ b/android/app/src/main/res/values-hi/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">नया क्या है</string>
     <string name="settings_changelog_link">नया क्या है</string>
     <string name="changelog_empty">अभी कोई रिलीज़ नोट्स उपलब्ध नहीं हैं।</string>
+    <string name="whats_new_title">नया क्या है</string>
+    <string name="whats_new_dismiss">समझ गया</string>
+    <string name="whats_new_see_all">सभी देखें</string>
 
     <!-- Errors -->
     <string name="error_session_limit">इस सत्र में आपके 10 संदेश हो चुके हैं! क्यों न एक ब्रेक लें और परमेश्वर की सृष्टि का आनंद लें? 🌳</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">Novità</string>
     <string name="settings_changelog_link">Novità</string>
     <string name="changelog_empty">Nessuna nota di rilascio è ancora disponibile.</string>
+    <string name="whats_new_title">Novità</string>
+    <string name="whats_new_dismiss">Ho capito</string>
+    <string name="whats_new_see_all">Vedi tutto</string>
 
     <!-- Errors -->
     <string name="error_session_limit">Hai avuto 10 messaggi in questa sessione! Perché non fare una pausa e goderti il creato di Dio all\'aria aperta? 🌳</string>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">새로운 기능</string>
     <string name="settings_changelog_link">새로운 기능</string>
     <string name="changelog_empty">아직 릴리스 노트가 없습니다.</string>
+    <string name="whats_new_title">새로운 기능</string>
+    <string name="whats_new_dismiss">확인</string>
+    <string name="whats_new_see_all">모두 보기</string>
 
     <!-- Errors -->
     <string name="error_session_limit">이 세션에서 10개의 메시지를 보내셨습니다! 잠시 쉬면서 하나님의 창조물을 즐겨보시는 건 어떨까요? 🌳</string>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">Novidades</string>
     <string name="settings_changelog_link">Novidades</string>
     <string name="changelog_empty">Ainda não há notas de versão disponíveis.</string>
+    <string name="whats_new_title">Novidades</string>
+    <string name="whats_new_dismiss">Entendi</string>
+    <string name="whats_new_see_all">Ver tudo</string>
 
     <!-- Errors -->
     <string name="error_session_limit">Você teve 10 mensagens nesta sessão! Que tal fazer uma pausa e apreciar a criação de Deus ao ar livre? 🌳</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">Что нового</string>
     <string name="settings_changelog_link">Что нового</string>
     <string name="changelog_empty">Заметки о выпуске пока недоступны.</string>
+    <string name="whats_new_title">Что нового</string>
+    <string name="whats_new_dismiss">Понятно</string>
+    <string name="whats_new_see_all">Показать все</string>
 
     <!-- Errors -->
     <string name="error_session_limit">У вас было 10 сообщений в этой сессии! Почему бы не сделать перерыв и не насладиться творением Божьим на природе? 🌳</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -182,6 +182,9 @@
     <string name="settings_changelog_title">更新内容</string>
     <string name="settings_changelog_link">更新内容</string>
     <string name="changelog_empty">暂无版本说明。</string>
+    <string name="whats_new_title">更新内容</string>
+    <string name="whats_new_dismiss">知道了</string>
+    <string name="whats_new_see_all">查看全部</string>
 
     <!-- Errors -->
     <string name="error_session_limit">您在本次会话中已有10条消息！何不休息一下，欣赏上帝的创造？🌳</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -175,6 +175,9 @@
     <string name="settings_changelog_title">What\'s New</string>
     <string name="settings_changelog_link">What\'s New</string>
     <string name="changelog_empty">No release notes are available yet.</string>
+    <string name="whats_new_title">What\'s New</string>
+    <string name="whats_new_dismiss">Got it</string>
+    <string name="whats_new_see_all">See all</string>
 
     <!-- Offline notice -->
     <string name="offline_notice">You\'re offline. You can read past messages, but sending new ones requires an internet connection.</string>

--- a/android/app/src/test/kotlin/org/voxquieta/app/screens/WhatsNewTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/screens/WhatsNewTest.kt
@@ -1,0 +1,41 @@
+package org.voxquieta.app.screens
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.voxquieta.app.presentation.components.shouldShowWhatsNew
+
+/**
+ * Unit tests for [shouldShowWhatsNew], the version-tracking logic behind the
+ * "What's New" bottom sheet (BITB-058): shown once per update, never on a
+ * fresh install, never repeated for the same version.
+ */
+class WhatsNewTest {
+
+    private val current = 42
+
+    @Test
+    fun `fresh install (stored -1) does not show`() {
+        assertFalse(shouldShowWhatsNew(storedVersionCode = -1, currentVersionCode = current))
+    }
+
+    @Test
+    fun `same version does not show`() {
+        assertFalse(shouldShowWhatsNew(storedVersionCode = current, currentVersionCode = current))
+    }
+
+    @Test
+    fun `updated (stored is current minus 1) shows`() {
+        assertTrue(shouldShowWhatsNew(storedVersionCode = current - 1, currentVersionCode = current))
+    }
+
+    @Test
+    fun `much older stored version shows`() {
+        assertTrue(shouldShowWhatsNew(storedVersionCode = 1, currentVersionCode = current))
+    }
+
+    @Test
+    fun `stored newer than current does not show (downgrade guard)`() {
+        assertFalse(shouldShowWhatsNew(storedVersionCode = current + 1, currentVersionCode = current))
+    }
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -691,9 +691,11 @@ covers only 200/404. These gaps let the bug ship.
 
 ---
 
-### 🎯 BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
+### ✅ BITB-040: Verse-Detail Header Shows English Book Name Instead of Localized
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done (verified against current main 2026-07-15 — `buildSyntheticVerse()` carries
+`localizedBook` through the verse link, `Verse.reference` prefers it, and
+`VerseDetailBottomSheetComposeTest.kt` covers the localized/fallback/non-Latin-script cases)
 **Size:** S (< 4 hours)
 **Created:** 2026-06-04
 
@@ -1134,9 +1136,9 @@ at the `MainActivity` call sites so debug and sideloaded builds are unaffected.
 
 ---
 
-### 🎯 BITB-058: Android — "What's New" Bottom Sheet on First Launch After Update
+### ✅ BITB-058: Android — "What's New" Bottom Sheet on First Launch After Update
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done (2026-07-15)
 **Size:** S (< 1 day)
 **Created:** 2026-07-01
 
@@ -1150,12 +1152,12 @@ asset, `ChangelogEntry` model, and `MarkdownText` dependency (no new library).
 
 **Acceptance Criteria (summary — full story has detail):**
 
-- [ ] `last_seen_version_code` persisted in `app_prefs`; helpers added alongside `hasSplashBeenSeen()` pattern
-- [ ] Modal skipped on fresh install (stored == -1); shown exactly once per update
-- [ ] `WhatsNewBottomSheet.kt` renders top `ChangelogEntry` via `MarkdownText`; graceful empty state
-- [ ] "Dismiss" closes sheet and marks version seen; "See All" navigates to `changelog` route and marks seen
-- [ ] String keys `whats_new_title`, `whats_new_dismiss`, `whats_new_see_all` added in all 11 locales
-- [ ] Unit tests: stored==-1 → false; stored==current → false; stored==current-1 → true
+- [x] `last_seen_version_code` persisted in `app_prefs`; helpers added alongside `hasSplashBeenSeen()` pattern
+- [x] Modal skipped on fresh install (stored == -1); shown exactly once per update
+- [x] `WhatsNewBottomSheet.kt` renders top `ChangelogEntry` via `MarkdownText`; graceful empty state
+- [x] "Dismiss" closes sheet and marks version seen; "See All" navigates to `changelog` route and marks seen
+- [x] String keys `whats_new_title`, `whats_new_dismiss`, `whats_new_see_all` added in all 11 locales
+- [x] Unit tests: stored==-1 → false; stored==current → false; stored==current-1 → true
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-058-android-whats-new-on-launch.md`
 


### PR DESCRIPTION
## Summary

- Adds `WhatsNewBottomSheet.kt`, shown once after an app update (never on fresh install), rendering the latest `changelog.json` entry via the existing `MarkdownText` dependency — no new library.
- `last_seen_version_code` is persisted in the existing `app_prefs` SharedPreferences, following the same `Context` extension idiom as `hasSplashBeenSeen()`/`markSplashSeen()`. It's written eagerly on cold start (in the existing `savedInstanceState == null` block) so a process death before the user dismisses the sheet still counts as "seen".
- "See All" navigates to the existing `changelog` route; "Dismiss" just closes the sheet.
- String keys `whats_new_title`, `whats_new_dismiss`, `whats_new_see_all` added to all 11 locale `strings.xml` files, reusing each locale's existing `settings_changelog_title` wording for consistency.
- `WhatsNewTest.kt` unit-tests the pure `shouldShowWhatsNew(stored, current)` decision function (fresh install, same version, updated, far-older version, downgrade guard).

While auditing the backlog for in-flight duplicates before starting this story, I found two other stories already fully implemented on `main` but still marked "Todo" in `docs/BACKLOG.md` — corrected both as part of this PR:
- **BITB-040** (verse-detail header uses English book name for non-English locales) — `buildSyntheticVerse()` already carries `localizedBook` through the verse link and `VerseDetailBottomSheetComposeTest.kt` already covers it.
- **BITB-058** itself is naturally marked done now that this PR lands.

(Also worth noting, not part of this PR: **BITB-060**, an event-loop-blocking email service story, turns out to already be fixed on `main` too — `api/utils/email_service.py` is fully async with its own regression-guard test — but it isn't tracked in `docs/BACKLOG.md` at all, so I left that doc gap for a follow-up rather than inventing a new backlog section in this PR.)

## Test plan

- [x] `WhatsNewTest.kt` covers all acceptance-criteria version-comparison cases
- [x] All 11 `strings.xml` files validated as well-formed XML
- [ ] CI (Android unit tests / lint) — no Android SDK available in this session's sandbox to run Gradle locally; relying on CI to confirm the build
- [ ] Manual QA: install older build → update → relaunch → modal appears with latest release notes → relaunch again → no modal (per story's manual test note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqR5yFxEje1hcwxrgmfavu)_