### PR TITLE
docs(backlog): mark BITB-071 done, move story to docs/DONE/

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -182,11 +182,12 @@ positives on Bible queries. This unblocks it.
 > `docs/TURBOVEC_EVALUATION.md` (turbovec evaluated and rejected — relevance, not infra,
 > is the lever).
 
-### 🚧 BITB-071: Verse Link Click Sends NaN Chapter for Non-ASCII (Devanagari/Eastern Arabic) Digits
+### ✅ BITB-071: Verse Link Click Sends NaN Chapter for Non-ASCII (Devanagari/Eastern Arabic) Digits
 
-**Status:** 🚧 In Progress (PR #893 — all CI checks green, awaiting review/merge)
+**Status:** ✅ Done (PR #893 merged 2026-07-17)
 **Size:** S (< 4 hrs)
 **Created:** 2026-07-17
+**Completed:** 2026-07-17
 
 **As** a Hindi (or Arabic) user, **I want** clicking a cited verse reference to open the
 correct chapter, **so that** I can read the scripture the assistant quoted instead of
@@ -201,7 +202,7 @@ mode (no link at all) from the same root cause — the "three parsers diverge su
 trap `AGENTS.md` calls out. Backend unaffected (Python's `re`/`int()` are Unicode-digit
 aware natively) and already had test coverage for this exact scenario.
 
-Full story: `docs/BACKLOG_STORIES/BITB-071-verse-link-non-ascii-digit-parsing.md`
+Full story: `docs/DONE/BITB-071-verse-link-non-ascii-digit-parsing.md`
 
 ---
 

--- a/docs/DONE/BITB-071-verse-link-non-ascii-digit-parsing.md
+++ b/docs/DONE/BITB-071-verse-link-non-ascii-digit-parsing.md
@@ -1,10 +1,11 @@
 # BITB-071: Verse Link Click Sends NaN Chapter for Non-ASCII (Devanagari/Eastern Arabic) Digits
 
-**Status:** 🚧 In Progress (PR #893 — all CI checks green, awaiting review/merge)
+**Status:** ✅ Done (PR #893 merged 2026-07-17)
 **Priority:** P1 (High) — breaks the core "click a cited verse" flow for every Hindi
 response and any Arabic response that uses native Eastern Arabic numerals.
 **Size:** S (< 4 hrs)
 **Created:** 2026-07-17
+**Completed:** 2026-07-17
 
 ## User Story
 


### PR DESCRIPTION
## Summary

- PR #893 (Hindi/Arabic verse-link `NaN`-chapter fix, frontend + Android parity) merged.
- Docs-only follow-up: mark `BITB-071` as ✅ Done in `docs/BACKLOG.md`, and move the full story from `docs/BACKLOG_STORIES/` to `docs/DONE/` per this repo's backlog hygiene convention.

## Test plan

N/A — documentation-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF6Jgc7n7RqrYYPDdMjD7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01CF6Jgc7n7RqrYYPDdMjD7Y)_