### PR TITLE
test(verse-parser): shared cross-platform regression corpus (BITB-059 AC#4)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - "android/**"
+      - "tests/**"
       - ".github/workflows/android-ci.yml"
   push:
     # No paths filter on main: every commit landing on main must produce an

--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -14,6 +14,7 @@ run-name: >-
     paths:
       - "api/**"
       - "frontend/**"
+      - "tests/**"
       - "docker-compose*.yml"
       - "scripts/**"
       - ".github/workflows/test_update.yml"
@@ -24,6 +25,7 @@ run-name: >-
     paths:
       - "api/**"
       - "frontend/**"
+      - "tests/**"
       - "docker-compose*.yml"
       - "scripts/**"
       - ".github/workflows/test_update.yml"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -172,6 +172,16 @@ android {
         }
     }
 
+    // BITB-059 AC#4: make the shared cross-platform verse-reference regression corpus
+    // (repo-root tests/fixtures/verse_reference_corpus.json — also consumed by the Python and
+    // web test suites) available on the JVM unit-test classpath as a plain resource, so
+    // VerseCorpusParityTest can load it without duplicating the file into the Android module.
+    sourceSets {
+        getByName("test") {
+            resources.srcDir("../../tests/fixtures")
+        }
+    }
+
     lint {
         baseline = file("lint-baseline.xml")
         checkDependencies = false

--- a/android/app/src/test/kotlin/org/voxquieta/app/components/VerseCorpusParityTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/components/VerseCorpusParityTest.kt
@@ -1,0 +1,150 @@
+package org.voxquieta.app.components
+
+import org.voxquieta.app.presentation.components.buildVerseRefRegex
+import org.voxquieta.app.presentation.components.injectVerseLinks
+import org.voxquieta.app.presentation.components.parseVerseLink
+import org.voxquieta.app.utils.LOCALIZED_BOOK_TO_ENGLISH
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * BITB-059 AC#4 — shared cross-platform verse-reference regression corpus (Android side).
+ *
+ * Loads tests/fixtures/verse_reference_corpus.json (shared with the Python and web test suites
+ * — see tests/fixtures/README.md) and asserts that injectVerseLinks()/parseVerseLink() resolve
+ * each non-skipped case to the expected book/chapter/verseStart. The file lives outside the
+ * Android module (at the repo root) and is made available to this JVM unit test via the extra
+ * `sourceSets["test"].resources.srcDir("../../tests/fixtures")` entry in build.gradle.kts.
+ *
+ * This is a test-only regression net: it does not change ChatMessageItem.kt.
+ *
+ * NOTE: this file cannot be run in this environment (no Android SDK). It was written by closely
+ * mirroring VerseRefLinkTest.kt's imports/usage of injectVerseLinks / parseVerseLink /
+ * buildVerseRefRegex, and ChatScreen.kt's real construction of the multiWordNames /
+ * cjkBookNames arguments to buildVerseRefRegex (see the comments below for why).
+ */
+
+@Serializable
+private data class CorpusExpected(
+    val book: String,
+    val chapter: Int,
+    val verseStart: Int,
+    val verseEnd: Int? = null,
+)
+
+@Serializable
+private data class CorpusCase(
+    val id: String,
+    val input: String,
+    val language: String,
+    val expected: CorpusExpected? = null,
+    val expectNone: Boolean = false,
+    val origin: String,
+    val skip: List<String> = emptyList(),
+    val skipReason: String = "",
+)
+
+@Serializable
+private data class VerseReferenceCorpus(
+    val description: String,
+    @SerialName("test_cases") val testCases: List<CorpusCase>,
+)
+
+// Matches the verse:// URL embedded in an injectVerseLinks() markdown link, e.g.
+// "**[John 3:16](verse://John/3/16)**" -> "verse://John/3/16". Stops before the closing ')' /
+// ']' of the markdown link or any whitespace, so a trailing query string (?localizedBook=...)
+// is kept but the surrounding markdown is not.
+private val VERSE_URL_REGEX = Regex("""verse://[^)\]\s]+""")
+
+class VerseCorpusParityTest {
+
+    private fun loadCorpus(): VerseReferenceCorpus {
+        val stream = javaClass.classLoader?.getResourceAsStream("verse_reference_corpus.json")
+            ?: error(
+                "verse_reference_corpus.json not found on the test classpath — check the " +
+                    "sourceSets[\"test\"].resources.srcDir(\"../../tests/fixtures\") entry in " +
+                    "android/app/build.gradle.kts"
+            )
+        val raw = stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+        return Json { ignoreUnknownKeys = true }.decodeFromString<VerseReferenceCorpus>(raw)
+    }
+
+    @Test
+    fun `corpus cases resolve to the expected book, chapter, and verse`() {
+        val corpus = loadCorpus()
+
+        // Multi-word (non-CJK) book names from the bundled fallback map, excluding
+        // number-prefixed keys. This mirrors ChatScreen.kt's `bundledMultiWord` construction
+        // exactly (see its comment there): the numbered-prefix branch (Alt 1 in
+        // buildVerseRefRegex) already consumes a leading "1"/"2"/"3" itself, so feeding a
+        // pre-numbered key like "1 كورنثوس" into the book-name alternation would try to
+        // double-consume the digit. Number-prefixed references are still matched fine — via
+        // the generic book-name pattern inside Alt 1 — without needing an explicit alternation.
+        val multiWordNames = LOCALIZED_BOOK_TO_ENGLISH.keys.filter { it.contains(' ') && !it.first().isDigit() }
+
+        // CJK (Han) and Hangul book names, length >= 2, from the bundled fallback map (there is
+        // no runtime API map in a unit test). Both scripts must be included, not just Han:
+        // buildVerseRefRegex excludes BOTH \p{IsHan} and \p{IsHangul} from the generic
+        // book-name pattern as soon as cjkBookNames is non-empty (see its kdoc), so a Korean
+        // case like "요한복음" would stop matching via the generic pattern the moment any Han
+        // name is supplied — it must also be present in this list to still match.
+        val cjkBookNames = LOCALIZED_BOOK_TO_ENGLISH.keys.filter { key ->
+            key.length >= 2 && key.all { ch ->
+                val script = Character.UnicodeScript.of(ch.code)
+                script == Character.UnicodeScript.HAN || script == Character.UnicodeScript.HANGUL
+            }
+        }
+
+        val regex = buildVerseRefRegex(multiWordNames, cjkBookNames)
+        val failures = mutableListOf<String>()
+
+        for (case in corpus.testCases) {
+            if ("android" in case.skip) {
+                // Known, tracked divergence (see skipReason in the corpus JSON) — not fixed in
+                // this test-only PR. Equivalent to Assume.assumeTrue(false) scoped to this case.
+                continue
+            }
+
+            val result = injectVerseLinks(case.input, regex)
+            val url = VERSE_URL_REGEX.find(result)?.value
+
+            if (case.expectNone) {
+                if (url != null) {
+                    failures += "${case.id}: expected no verse link for '${case.input}', but got $url"
+                }
+                continue
+            }
+
+            val expected = case.expected
+            if (expected == null) {
+                failures += "${case.id}: corpus entry has no 'expected' and expectNone is not true"
+                continue
+            }
+            if (url == null) {
+                failures += "${case.id}: expected a verse link for '${case.input}', got none (result: $result)"
+                continue
+            }
+
+            val link = parseVerseLink(url, null)
+            if (link == null) {
+                failures += "${case.id}: parseVerseLink returned null for $url"
+                continue
+            }
+
+            if (!link.book.equals(expected.book, ignoreCase = true)) {
+                failures += "${case.id}: book mismatch — expected '${expected.book}', got '${link.book}'"
+            }
+            if (link.chapter != expected.chapter) {
+                failures += "${case.id}: chapter mismatch — expected ${expected.chapter}, got ${link.chapter}"
+            }
+            if (link.verseNumber != expected.verseStart) {
+                failures += "${case.id}: verseStart mismatch — expected ${expected.verseStart}, got ${link.verseNumber}"
+            }
+        }
+
+        assertTrue("Corpus mismatches:\n" + failures.joinToString("\n"), failures.isEmpty())
+    }
+}

--- a/api/tests/test_verse_parser_corpus.py
+++ b/api/tests/test_verse_parser_corpus.py
@@ -1,0 +1,60 @@
+"""BITB-059 AC#4 — shared cross-platform verse-reference regression corpus (Python side).
+
+Loads ``tests/fixtures/verse_reference_corpus.json`` (shared with the web and Android test
+suites — see ``tests/fixtures/README.md``) and asserts that ``parse_verse_reference`` produces
+the expected book/chapter/verse_start/verse_end for every non-skipped case.
+
+This is a test-only regression net: it does not change ``api/utils/verse_parser.py``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from utils.verse_parser import parse_verse_reference
+
+_CORPUS_PATH = Path(__file__).resolve().parents[2] / "tests/fixtures/verse_reference_corpus.json"
+
+with open(_CORPUS_PATH, encoding="utf-8") as f:
+    _CORPUS = json.load(f)
+
+_TEST_CASES = _CORPUS["test_cases"]
+
+
+@pytest.mark.parametrize("case", _TEST_CASES, ids=[c["id"] for c in _TEST_CASES])
+def test_corpus_case(case):
+    if "python" in case["skip"]:
+        pytest.skip(case["skipReason"] or "skipped for python")
+
+    result = parse_verse_reference(case["input"])
+
+    if case.get("expectNone"):
+        assert (
+            result is None
+        ), f"{case['id']!r}: expected no reference for {case['input']!r}, got {result}"
+        return
+
+    expected = case["expected"]
+    assert (
+        result is not None
+    ), f"{case['id']!r}: expected a reference for {case['input']!r}, got None"
+    assert (
+        result.book.lower() == expected["book"]
+    ), f"{case['id']!r}: book mismatch — expected {expected['book']!r}, got {result.book!r}"
+    assert (
+        result.chapter == expected["chapter"]
+    ), f"{case['id']!r}: chapter mismatch — expected {expected['chapter']!r}, got {result.chapter!r}"
+    assert result.verse_start == expected["verseStart"], (
+        f"{case['id']!r}: verse_start mismatch — "
+        f"expected {expected['verseStart']!r}, got {result.verse_start!r}"
+    )
+    if expected["verseEnd"] is not None:
+        assert result.verse_end == expected["verseEnd"], (
+            f"{case['id']!r}: verse_end mismatch — "
+            f"expected {expected['verseEnd']!r}, got {result.verse_end!r}"
+        )
+    else:
+        assert (
+            not result.verse_end
+        ), f"{case['id']!r}: expected no verse range, got verse_end={result.verse_end!r}"

--- a/docs/AUDIT_PLAYBOOK.md
+++ b/docs/AUDIT_PLAYBOOK.md
@@ -67,7 +67,7 @@ This project maintains hand-synchronized logic across platforms. Every audit mus
 
 | Logic | Copies |
 |---|---|
-| Verse-reference regex | `frontend/src/lib/versePatterns.ts` · `android/.../ChatMessageItem.kt` · `api/utils/verse_parser.py` |
+| Verse-reference regex | `frontend/src/lib/versePatterns.ts` · `android/.../ChatMessageItem.kt` · `api/utils/verse_parser.py` — cross-checked by the shared regression corpus `tests/fixtures/verse_reference_corpus.json` (BITB-059 AC#4) |
 | Localized book-name map | `frontend/src/lib/verseExtraction.ts` · `android/.../utils/LocalizedBookToEnglish.kt` · `api/utils/translation_registry.py` |
 | Session/message limits | `api/config.py` · `android/.../ChatViewModel.kt` (`MAX_INTERACTIONS`, `MAX_MESSAGE_LENGTH`) |
 | Error contracts | provider error strings ↔ route/client substring matches (backend routes, Android `mapExceptionToMessage`) |

--- a/frontend/src/lib/verseCorpus.crossplatform.test.ts
+++ b/frontend/src/lib/verseCorpus.crossplatform.test.ts
@@ -1,0 +1,69 @@
+/**
+ * BITB-059 AC#4 — shared cross-platform verse-reference regression corpus (web side).
+ *
+ * Loads tests/fixtures/verse_reference_corpus.json (shared with the Python and Android test
+ * suites — see tests/fixtures/README.md) and asserts that extractVerseReferences() produces the
+ * expected "book chapter:verseStart" entry for every non-skipped case.
+ *
+ * The corpus is read via Node fs/path (not a TS/JSON import) to avoid coupling this test to the
+ * bundler's JSON-import resolution — the file lives outside frontend/ (at the repo root) and is
+ * shared verbatim with the other two platforms.
+ *
+ * This is a test-only regression net: it does not change verseExtraction.ts / versePatterns.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { extractVerseReferences } from "./verseExtraction";
+
+interface CorpusExpected {
+  book: string;
+  chapter: number;
+  verseStart: number;
+  verseEnd: number | null;
+}
+
+interface CorpusCase {
+  id: string;
+  input: string;
+  language: string;
+  expected: CorpusExpected | null;
+  expectNone?: boolean;
+  origin: string;
+  skip: string[];
+  skipReason: string;
+}
+
+interface Corpus {
+  description: string;
+  test_cases: CorpusCase[];
+}
+
+// frontend/src/lib/ -> repo root is four levels up: lib -> src -> frontend -> repo root.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CORPUS_PATH = resolve(
+  __dirname,
+  "../../../tests/fixtures/verse_reference_corpus.json",
+);
+
+const corpus: Corpus = JSON.parse(readFileSync(CORPUS_PATH, "utf-8"));
+
+describe("verse reference corpus (cross-platform, web)", () => {
+  for (const testCase of corpus.test_cases) {
+    const testFn = testCase.skip.includes("web") ? it.skip : it;
+
+    testFn(`${testCase.id}: ${JSON.stringify(testCase.input)}`, () => {
+      const refs = extractVerseReferences(testCase.input);
+
+      if (testCase.expectNone) {
+        expect(refs.size).toBe(0);
+        return;
+      }
+
+      const expected = testCase.expected as CorpusExpected;
+      const expectedRef = `${expected.book} ${expected.chapter}:${expected.verseStart}`;
+      expect(Array.from(refs)).toContain(expectedRef);
+    });
+  }
+});

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,94 @@
+# tests/fixtures/
+
+## `verse_reference_corpus.json`
+
+Shared cross-platform regression corpus for BITB-059
+(`docs/BACKLOG_STORIES/BITB-059-unify-verse-parser-single-source-of-truth.md`), acceptance
+criterion #4:
+
+> A shared cross-platform test corpus (citation string → expected book/chapter/verse, including
+> the #799/#801/#804 regression cases and non-Latin numerals) runs against all three
+> implementations in their respective CI jobs.
+
+Vox Quieta hand-maintains three independent verse-reference parsers — Python
+(`api/utils/verse_parser.py`), TypeScript (`frontend/src/lib/versePatterns.ts` +
+`verseExtraction.ts`), and Kotlin (`android/.../ChatMessageItem.kt` +
+`LocalizedBookToEnglish.kt`). They have drifted apart before (PRs #799, #801, #804, #893, #903),
+each time as a hand-discovered, hand-repaired bug. This corpus gives all three platforms one
+shared, versioned set of inputs and expected outputs so a future regression in *any* parser is
+caught by *that platform's own CI job*, without needing a human to notice the drift first.
+
+This file is consumed by:
+
+- `api/tests/test_verse_parser_corpus.py` (pytest)
+- `frontend/src/lib/verseCorpus.crossplatform.test.ts` (vitest)
+- `android/app/src/test/kotlin/org/voxquieta/app/components/VerseCorpusParityTest.kt` (JUnit)
+
+This PR is test-only: it does not change any parsing behavior. It is scoped to AC #4 alone; the
+full single-source-of-truth generator (AC #1–#3, #5) is a separate, larger follow-up.
+
+### Schema
+
+```jsonc
+{
+  "description": "…",
+  "test_cases": [
+    {
+      "id": "unique_snake_case_id",
+      "input": "the raw text to parse",
+      "language": "en", // BCP-47-ish language tag, informational only
+      "expected": {
+        "book": "john",            // lowercase, English canonical (e.g. "1 corinthians", "song of solomon")
+        "chapter": 3,
+        "verseStart": 16,
+        "verseEnd": null           // int, or null when the reference is not a range
+      },
+      "origin": "free-text provenance — which PR/incident/behavior this case guards",
+      "skip": [],                  // subset of ["python", "web", "android"] — platforms that must skip this case
+      "skipReason": ""             // required (non-empty) whenever "skip" is non-empty
+    }
+  ]
+}
+```
+
+Negative-control cases (text that must NOT resolve to a verse reference — e.g. a decimal amount
+or a clock time) use `"expectNone": true` and `"expected": null` instead of an `expected` object.
+
+### Why `book` is lowercase-English-canonical
+
+All three parsers ultimately resolve a localized book name (Italian "Giovanni", German
+"Matthäus", Chinese "约翰福音", …) to the same English canonical name so that verse lookups hit
+the same database rows regardless of the language the reference was written in. Comparing against
+that shared English form — rather than the raw localized token — is what lets one JSON file
+express expectations that are valid across all three parsers and all supported languages at once.
+Lowercase is used because the web parser (`extractVerseReferences`) normalizes to lowercase by
+construction (its `Set<string>` entries are always lowercase), so lowercase is the least common
+denominator all three can be compared against.
+
+### Why only Python asserts `verseEnd`
+
+- **Python** (`parse_verse_reference` → `VerseReference`) has an explicit `verse_end: int | None`
+  field, so a range like "Romans 8:28-30" can be asserted precisely (`verse_start=28,
+  verse_end=30`).
+- **Web** (`extractVerseReferences`) returns a `Set<string>` of `"book chapter:verse"` strings
+  with no range information at all — a range collapses to just its start verse (e.g. "Romans
+  8:28-30" → the set contains `"romans 8:28"`, never `"...28-30"` or `"...30"`). There is nothing
+  to assert `verseEnd` against.
+- **Android** (`parseVerseLink` → `PendingVerseLink`) has no range field either; `verseNumber` is
+  a single `Int` (the *display* text keeps the written range, e.g. `[Romans 8:38-39]`, but the
+  parsed link data does not carry an end verse).
+
+So the corpus's `verseEnd` field exists for the Python test only; the web and Android tests
+compare book/chapter/verseStart (web) or book/chapter/verseNumber (Android) and ignore
+`verseEnd` entirely — this is expected, not an omission.
+
+### `skip` / `skipReason` convention
+
+A case is skipped on a platform when that platform has a **known, tracked** behavioral gap for
+it — not when a test is merely inconvenient to write. Every non-empty `skip` entry must be paired
+with a non-empty `skipReason` explaining *why* (ideally referencing a backlog story or PR), so a
+skip never silently rots into "nobody remembers why this is disabled." The one skip currently in
+the corpus (`known_divergence_android_russian_lamentations`, skipped for `"android"`) is a real,
+deliberate gap: Android's regex resolves a two-word Russian book name differently from Python and
+web. It is captured here on purpose so the follow-up unification work (BITB-059 AC #1–#3) has a
+concrete regression case to close, rather than being fixed ad hoc in this test-only PR.

--- a/tests/fixtures/verse_reference_corpus.json
+++ b/tests/fixtures/verse_reference_corpus.json
@@ -1,0 +1,232 @@
+{
+  "description": "BITB-059 AC#4 — shared cross-platform regression corpus for verse-reference parsing. Each case is run against the Python (api/utils/verse_parser.py), web (frontend/src/lib/verseExtraction.ts), and Android (android/.../ChatMessageItem.kt) implementations so that a citation-parsing fix or regression in one platform is caught everywhere. See tests/fixtures/README.md for the schema and the skip/skipReason convention.",
+  "test_cases": [
+    {
+      "id": "baseline_john_3_16",
+      "input": "John 3:16",
+      "language": "en",
+      "expected": { "book": "john", "chapter": 3, "verseStart": 16, "verseEnd": null },
+      "origin": "Baseline sanity case — the canonical example reference.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "baseline_romans_8_28_30",
+      "input": "Romans 8:28-30",
+      "language": "en",
+      "expected": { "book": "romans", "chapter": 8, "verseStart": 28, "verseEnd": 30 },
+      "origin": "Baseline sanity case — a verse range with a hyphen separator.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "baseline_1_corinthians_13_4",
+      "input": "1 Corinthians 13:4",
+      "language": "en",
+      "expected": { "book": "1 corinthians", "chapter": 13, "verseStart": 4, "verseEnd": null },
+      "origin": "Baseline sanity case — a numbered book name.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "baseline_song_of_solomon_1_1",
+      "input": "Song of Solomon 1:1",
+      "language": "en",
+      "expected": { "book": "song of solomon", "chapter": 1, "verseStart": 1, "verseEnd": null },
+      "origin": "Baseline sanity case — a multi-word book name with a connector word ('of').",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_801_greedy_rewind_english_of",
+      "input": "I also want to remind you of Psalm 56:9, which says.",
+      "language": "en",
+      "expected": { "book": "psalms", "chapter": 56, "verseStart": 9, "verseEnd": null },
+      "origin": "PR #801 — greedy over-match regression: a connector word ('of') before a real book name used to let a greedy alternative swallow the preceding prose ('you of Psalm'), which then failed the known-book check and hid the real reference. Parsers must rewind and recover the embedded reference.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_801_greedy_rewind_german_numbered_prefix",
+      "input": "Wie in 1 day of Psalm 56:9 beschrieben.",
+      "language": "de",
+      "expected": { "book": "psalms", "chapter": 56, "verseStart": 9, "verseEnd": null },
+      "origin": "PR #801 — greedy over-match hidden by a leading digit ('1 day of Psalm 56:9'), which can be mistaken for a numbered-book prefix. Parsers must still recover 'Psalm 56:9'.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_801_greedy_rewind_spanish_connector",
+      "input": "Recuerda la palabra de Isaías 41:10 hoy.",
+      "language": "es",
+      "expected": { "book": "isaiah", "chapter": 41, "verseStart": 10, "verseEnd": null },
+      "origin": "PR #801 — greedy over-match regression via the Spanish connector word 'de' before 'Isaías'.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_804_comma_german_range",
+      "input": "Das steht in Römer 13,1-2 geschrieben.",
+      "language": "de",
+      "expected": { "book": "romans", "chapter": 13, "verseStart": 1, "verseEnd": 2 },
+      "origin": "PR #804 — German/French/Italian citation style uses a comma instead of a colon as the chapter:verse separator ('Römer 13,1-2'), including a hyphenated range.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_804_comma_german_no_range",
+      "input": "Jakobus 1,27",
+      "language": "de",
+      "expected": { "book": "james", "chapter": 1, "verseStart": 27, "verseEnd": null },
+      "origin": "PR #804 — German comma separator without a verse range.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_804_comma_french",
+      "input": "Jean 3,16",
+      "language": "fr",
+      "expected": { "book": "john", "chapter": 3, "verseStart": 16, "verseEnd": null },
+      "origin": "PR #804 — French comma separator citation style.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "negative_decimal_amount",
+      "input": "Ich habe 3,50 Euro gespart.",
+      "language": "de",
+      "expected": null,
+      "expectNone": true,
+      "origin": "Negative control — a German decimal amount ('3,50 Euro') must not be mistaken for a comma-separated chapter:verse reference.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "negative_clock_time",
+      "input": "um 14:30",
+      "language": "de",
+      "expected": null,
+      "expectNone": true,
+      "origin": "Negative control — a clock time ('um 14:30') has no book name and must not be parsed as a verse reference.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_893_devanagari_digits",
+      "input": "यूहन्ना ५:२४",
+      "language": "hi",
+      "expected": { "book": "john", "chapter": 5, "verseStart": 24, "verseEnd": null },
+      "origin": "BITB-071 / #893 — Devanagari numerals (५:२४ = 5:24) must be normalized to ASCII digits so the reference is recognized instead of silently dropped or producing NaN.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_893_eastern_arabic_digits",
+      "input": "يوحنا ٣:١٦",
+      "language": "ar",
+      "expected": { "book": "john", "chapter": 3, "verseStart": 16, "verseEnd": null },
+      "origin": "BITB-071 / #893 — Eastern Arabic numerals (٣:١٦ = 3:16) must be normalized to ASCII digits so the reference is recognized.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "regression_903_hindi_range",
+      "input": "रोमियों 12:1-2",
+      "language": "hi",
+      "expected": { "book": "romans", "chapter": 12, "verseStart": 1, "verseEnd": 2 },
+      "origin": "#903 — Hindi book name 'रोमियों' (Romans) with a verse range.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_german_matthew",
+      "input": "Matthäus 5:7",
+      "language": "de",
+      "expected": { "book": "matthew", "chapter": 5, "verseStart": 7, "verseEnd": null },
+      "origin": "Non-Latin/diacritic single-word book name parity — German 'Matthäus' (Matthew).",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_german_genesis_numbered",
+      "input": "1. Mose 1:1",
+      "language": "de",
+      "expected": { "book": "genesis", "chapter": 1, "verseStart": 1, "verseEnd": null },
+      "origin": "Numbered-word book name parity — German '1. Mose' (Genesis) uses a period after the numeral instead of a space.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_german_2_kings",
+      "input": "2. Könige 5:14",
+      "language": "de",
+      "expected": { "book": "2 kings", "chapter": 5, "verseStart": 14, "verseEnd": null },
+      "origin": "Numbered-word book name parity — German '2. Könige' (2 Kings) with an umlaut.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_arabic_psalms",
+      "input": "المزامير 23:1",
+      "language": "ar",
+      "expected": { "book": "psalms", "chapter": 23, "verseStart": 1, "verseEnd": null },
+      "origin": "Non-Latin single-word book name parity — Arabic 'المزامير' (Psalms).",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_arabic_1_corinthians",
+      "input": "1 كورنثوس 13:4",
+      "language": "ar",
+      "expected": { "book": "1 corinthians", "chapter": 13, "verseStart": 4, "verseEnd": null },
+      "origin": "Numbered-word book name parity — Arabic '1 كورنثوس' (1 Corinthians).",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_chinese_john",
+      "input": "约翰福音 3:16",
+      "language": "zh",
+      "expected": { "book": "john", "chapter": 3, "verseStart": 16, "verseEnd": null },
+      "origin": "Non-Latin single-word (CJK) book name parity — Chinese '约翰福音' (John).",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_korean_john",
+      "input": "요한복음 3:16",
+      "language": "ko",
+      "expected": { "book": "john", "chapter": 3, "verseStart": 16, "verseEnd": null },
+      "origin": "Non-Latin single-word (Hangul) book name parity — Korean '요한복음' (John).",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "nonlatin_russian_1_corinthians",
+      "input": "1 Коринфянам 13:4",
+      "language": "ru",
+      "expected": { "book": "1 corinthians", "chapter": 13, "verseStart": 4, "verseEnd": null },
+      "origin": "Numbered-word book name parity — Russian '1 Коринфянам' (1 Corinthians).",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "embedded_cjk_no_space_john",
+      "input": "请阅读约翰福音10:28来获得鼓励",
+      "language": "zh",
+      "expected": { "book": "john", "chapter": 10, "verseStart": 28, "verseEnd": null },
+      "origin": "CJK reference embedded in surrounding Chinese text with no space between the book name and the chapter number ('约翰福音10:28'), and no space/punctuation boundary before the book name.",
+      "skip": [],
+      "skipReason": ""
+    },
+    {
+      "id": "known_divergence_android_russian_lamentations",
+      "input": "Плач Иеремии 3:3",
+      "language": "ru",
+      "expected": { "book": "lamentations", "chapter": 3, "verseStart": 3, "verseEnd": null },
+      "origin": "Known cross-platform divergence (tracked by BITB-059): the two-word Russian book name 'Плач Иеремии' (Lamentations of Jeremiah) is resolved correctly by Python and web, but Android's default/dynamic regex only captures the second word ('Иеремии') when there is no connector word between them, which can resolve to Jeremiah instead of Lamentations depending on which book-name alternation wins. Left as a deliberate, tracked gap for this test-only PR — the fix belongs to the full BITB-059 unification.",
+      "skip": ["android"],
+      "skipReason": "BITB-059 — Android's default/dynamic regex may resolve multi-word Russian 'Плач Иеремии' to Jeremiah instead of Lamentations; tracked for the full-unification follow-up, not fixed here (test-only scope)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `tests/fixtures/verse_reference_corpus.json` — a single shared set of citation-string → expected book/chapter/verse cases, run against the Python, web, and Android verse-reference parsers in their own CI jobs.

**Why:** The three parsers (`api/utils/verse_parser.py`, `frontend/src/lib/verseExtraction.ts`, Android's `ChatMessageItem.kt`) are hand-synchronized and have drifted apart repeatedly, shipping real bugs: PRs #799, #801, #804, #893 (non-ASCII digit chapter/verse), and #903 (Hindi verse-range alias). This is the **top-ranked finding of the 2026-07 adversarial audit** (`docs/BACKLOG_STORIES/BITB-059-unify-verse-parser-single-source-of-truth.md`, A1). This corpus encodes those incidents plus non-Latin numerals and CJK/embedded-script cases as a durable regression net, so a fix landed on one platform's parser but not mirrored elsewhere is caught by CI instead of a user report.

**Scope:** this PR satisfies **BITB-059 AC#4 only** (the shared test corpus). It is test-only and changes **no parsing logic**, so the citation-linking feature cannot regress. AC#1–3/5/6 (a single-source-of-truth spec + codegen pipeline that actually unifies the three implementations) is Size L and is left for a follow-up PR — that's the harder, riskier part and deserves its own design review rather than being bundled into an unattended same-day change.

One case, Russian "Плач Иеремии" (Lamentations), is marked `skip: ["android"]` with a `skipReason` in the corpus — the Android dynamic regex may resolve it to "Jeremiah" instead of "Lamentations" (a real, pre-existing multi-word-book edge case), which is exactly the kind of gap this corpus exists to surface. Fixing it belongs to the full-unification follow-up, not this PR.

## Changes

- `tests/fixtures/verse_reference_corpus.json` + `tests/fixtures/README.md` — the shared corpus (25 cases) and its schema/conventions doc
- `api/tests/test_verse_parser_corpus.py` — Python shim (parametrized pytest over the corpus)
- `frontend/src/lib/verseCorpus.crossplatform.test.ts` — web shim (vitest)
- `android/app/src/test/kotlin/org/voxquieta/app/components/VerseCorpusParityTest.kt` — Android shim (JUnit4), plus a `sourceSets["test"].resources.srcDir(...)` addition in `android/app/build.gradle.kts` so the shared JSON is available on the Android unit-test classpath without duplicating it into the module
- `.github/workflows/test_update.yml` / `.github/workflows/android-ci.yml` — widened `paths:` filters to include `tests/**`, so a corpus-only edit still triggers both CI jobs (previously neither would have fired)
- `docs/AUDIT_PLAYBOOK.md` — one-line note on the verse-regex parity-ledger row pointing at the new corpus

## Test plan

- [x] `cd api && pytest tests/test_verse_parser_corpus.py -v` — 25 passed (verified independently, not just by the implementing session)
- [x] `cd frontend && npx vitest run src/lib/verseCorpus.crossplatform.test.ts` — 25 passed (verified independently)
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] Full existing suites unaffected: backend 272/272 (247 pre-existing + 25 new), frontend 738/738 across 32 files
- [x] Pre-commit hooks (black, ruff, mypy, bandit, prettier, eslint, yamllint, etc.) pass on all touched/new files
- [ ] Android: **cannot be run locally** (no Android SDK in this environment) — written by closely mirroring the real APIs and the existing `VerseRefLinkTest.kt`'s usage of `injectVerseLinks`/`parseVerseLink`/`buildVerseRefRegex`; relying on `android-ci.yml` to validate, same pattern already used successfully in PR #893 and PR #866 for changes that couldn't be locally verified in this sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTxXmvfE993fA9n6Asy8uL)_