### PR TITLE
fix(rate-limiter): apply BITB-061 migrations to local/CI Postgres, add fail-closed alert

### DIFF
--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -188,6 +188,13 @@ jobs:
           OPENROUTER_MODEL=meta-llama/llama-3.3-70b-instruct:free
           OPENROUTER_FALLBACK_MODELS=meta-llama/llama-3.3-70b-instruct
           OPENROUTER_ALLOW_FALLBACKS=true
+          # docker-compose.yml already defaults to this, but pin it explicitly so this
+          # job keeps working even if that default changes. This ephemeral, single-
+          # instance Postgres has no pg_cron purge job (migration 010, BITB-061) for
+          # the Postgres-backed rate limiter's tables, and (the original incident)
+          # once had neither table at all -- which tripped the limiter's circuit
+          # breaker to fail closed (real 429s) after 5 chat/stream requests.
+          RATE_LIMIT_BACKEND=memory
           OLLAMA_HOST=http://ollama:11434
           EMBEDDING_PROVIDER=ollama
           EMBEDDING_MODEL=mxbai-embed-large

--- a/deployment/monitoring.tf
+++ b/deployment/monitoring.tf
@@ -1024,6 +1024,57 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "embedding_fallback_ra
   tags = local.tags
 }
 
+# Rate limiter fail-closed alert (BITB-061 phase 3).
+# api/utils/rate_limiter.py's PostgresStore is wrapped in a circuit breaker
+# (5 consecutive failures / 30s cooldown, same shape as TurnstileVerifier's).
+# A single isolated DB error just falls back to the in-memory store
+# (rate_limiter.fallback_total, not alerted -- degraded but still enforcing
+# something). Once the breaker opens, every rate-limit check fails CLOSED
+# instead: real users get HTTP 429 "Rate limiter temporarily unavailable" on
+# /chat and /chat/stream, with no other user-facing signal (it's not a 5xx,
+# so the backend-5xx-rate alert never sees it). Before this, the three
+# rate_limiter.* counters this migration added (db_error_total,
+# fallback_total, fail_closed_total) had no alert or dashboard panel at all --
+# unlike the near-identical embedding_fallback_rate alert above for the
+# embedding circuit breaker. Severity 1 (not 2, like the embedding alert)
+# because fail-closed means active rejection of chat traffic, not degraded
+# service.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "rate_limiter_fail_closed" {
+  count                = local.alerts_enabled ? 1 : 0
+  name                 = "${local.name_prefix}-rate-limiter-fail-closed"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT10M"
+  scopes               = [azurerm_application_insights.main[0].id]
+  severity             = 1
+  description          = "Postgres-backed rate limiter's circuit breaker is open and failing closed (rate_limiter.fail_closed_total metric) in the last 10 minutes -- chat requests are being rejected with HTTP 429 regardless of actual rate-limit state. Check Postgres connectivity/load; see api/utils/rate_limiter.py."
+
+  criteria {
+    query                   = <<-KQL
+      customMetrics
+      | where timestamp > ago(10m)
+      | where name == "rate_limiter.fail_closed_total"
+      | summarize total = sum(valueSum) by bin(timestamp, 5m)
+      | where total > 0
+    KQL
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.ops_email[0].id]
+  }
+
+  tags = local.tags
+}
+
 # ---------------------------------------------------------------------------
 # Backend catch-all error alerts (BITB-065).
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,16 @@ services:
       - OLLAMA_HOST=http://ollama:11434
       # Defaults to the in-stack Postgres so `make docker-up` works out of the box.
       - DATABASE_URL=${DATABASE_URL:-postgresql://bible:bible123@postgres:5432/bibledb}
+      # BITB-061's Postgres-backed rate limiter exists to keep counters correct
+      # across multiple prod replicas -- meaningless for this single-instance local
+      # stack. Default to the in-memory backend here: (1) local/CI Postgres has no
+      # pg_cron (migration 010), so rate_limit_hits/rate_limit_sessions would grow
+      # unbounded over a long dev session; (2) before this default existed, a fresh
+      # local/CI volume had neither table, so every /chat request errored, tripping
+      # the circuit breaker to fail closed (real 429s) after 5 requests. Prod is
+      # unaffected -- it doesn't set this var, so it keeps Settings' own default of
+      # "postgres" (api/config.py).
+      - RATE_LIMIT_BACKEND=${RATE_LIMIT_BACKEND:-memory}
       # OpenRouter settings
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - OPENROUTER_MODEL=${OPENROUTER_MODEL:-meta-llama/llama-3.3-70b-instruct:free}
@@ -78,6 +88,10 @@ services:
     volumes:
       - ./scripts:/scripts
       - ./data:/data
+      # Read-only: run_migrations.py resolves ../../api relative to its own
+      # path (matching the layout azure-deploy.yml's run-migrations job sees
+      # from a full checkout), so it needs api/ visible at /api here.
+      - ./api:/api:ro
     working_dir: /scripts
     entrypoint: ["/bin/bash", "/scripts/init-db.sh"]
     restart: "no"

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+echo "=== Applying database migrations ==="
+python3 -u migrations/run_migrations.py
+echo ""
+
 echo "=== Translation status before load ==="
 python3 -u load_bible.py --status
 echo ""

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -174,3 +174,33 @@ CREATE TABLE IF NOT EXISTS sessions (
 
 CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(session_token);
 CREATE INDEX IF NOT EXISTS idx_sessions_last_activity ON sessions(last_activity);
+
+-- ============================================================================
+-- Create rate_limit_hits / rate_limit_sessions tables (BITB-061, migration 009)
+-- ============================================================================
+-- Mirrors migration 009 so a fresh local/CI Postgres volume has these tables
+-- even before scripts/migrations/run_migrations.py runs. Two tables because
+-- the semantics differ: rate_limit_hits is a short-lived sliding-window event
+-- log (per-minute IP/session limits); rate_limit_sessions is a durable
+-- per-session lifetime counter. See migration 009 for the full rationale and
+-- migration 010 for the pg_cron purge job (prod-only -- see that file).
+
+CREATE TABLE IF NOT EXISTS rate_limit_hits (
+    id         BIGSERIAL PRIMARY KEY,
+    limit_key  TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_hits_key_time
+    ON rate_limit_hits (limit_key, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_hits_created_at
+    ON rate_limit_hits (created_at);
+
+CREATE TABLE IF NOT EXISTS rate_limit_sessions (
+    session_id     TEXT PRIMARY KEY,
+    total_requests INTEGER NOT NULL DEFAULT 0,
+    last_seen      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_limit_sessions_last_seen
+    ON rate_limit_sessions (last_seen);

--- a/scripts/migrations/002_add_hnsw_indexes.sql
+++ b/scripts/migrations/002_add_hnsw_indexes.sql
@@ -48,7 +48,23 @@ WITH (m = 16, ef_construction = 64);
 
 -- Note: This ALTER DATABASE command sets the default for all sessions.
 -- Individual queries can override with: SET hnsw.ef_search = <value>;
-ALTER DATABASE bibleapp SET hnsw.ef_search = 80;
+--
+-- Hardcoded to the prod database name ("bibleapp"), which fails outright
+-- against any other database (e.g. local/CI's "bibledb"). Also, per migration
+-- 007's docstring, this exact statement already raised "permission denied to
+-- set parameter" on managed Postgres (Azure Flexible Server / AWS RDS) --
+-- which is why the app now sets hnsw.ef_search per-session instead
+-- (api/scripture/database.py). Target the current database dynamically and
+-- treat a privilege error as non-fatal (same idiom as migration 007's
+-- pg_prewarm step) so this migration doesn't block the ones after it on
+-- either front.
+DO $$
+BEGIN
+    EXECUTE format('ALTER DATABASE %I SET hnsw.ef_search = 80', current_database());
+EXCEPTION WHEN insufficient_privilege THEN
+    RAISE NOTICE 'ALTER DATABASE SET hnsw.ef_search skipped (insufficient privilege -- expected on some managed Postgres tiers; the app sets this per-session instead, see migration 007)';
+END
+$$;
 
 COMMIT;
 

--- a/scripts/migrations/005_schedule_blocked_samples_purge.sql
+++ b/scripts/migrations/005_schedule_blocked_samples_purge.sql
@@ -23,27 +23,36 @@
 --   - `CREATE EXTENSION IF NOT EXISTS` is safe to re-run.
 --   - `cron.unschedule` is wrapped in a DO block so re-running this
 --     migration just replaces the schedule without errors.
+--
+-- Local/CI Postgres (pgvector/pgvector image, docker-compose.yml) doesn't have
+-- pg_cron installed and can't get it without a custom image. Unlike a missing
+-- table, `CREATE EXTENSION pg_cron` fails outright when the extension isn't
+-- installed, and any statement referencing the `cron` schema then fails to
+-- even parse -- so the whole body below is gated on pg_available_extensions
+-- and skips with a NOTICE when pg_cron isn't there, instead of taking the
+-- migration runner down on every non-prod environment.
 
-CREATE EXTENSION IF NOT EXISTS pg_cron;
-
--- Drop any prior schedule with the same name before re-creating, so this
--- migration can be re-applied to change the cadence without leaving
--- duplicate jobs behind.
 DO $$
 BEGIN
-    PERFORM cron.unschedule('purge-blocked-message-samples')
-    FROM cron.job
-    WHERE jobname = 'purge-blocked-message-samples';
+    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+        EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_cron';
+
+        -- Drop any prior schedule with the same name before re-creating, so
+        -- this migration can be re-applied to change the cadence without
+        -- leaving duplicate jobs behind.
+        PERFORM cron.unschedule('purge-blocked-message-samples')
+        FROM cron.job
+        WHERE jobname = 'purge-blocked-message-samples';
+
+        PERFORM cron.schedule(
+            'purge-blocked-message-samples',
+            '15 3 * * *',
+            $cron$DELETE FROM blocked_message_samples WHERE expires_at < now()$cron$
+        );
+
+        RAISE NOTICE 'Scheduled pg_cron job purge-blocked-message-samples (15 3 * * *)';
+    ELSE
+        RAISE NOTICE 'pg_cron extension not available -- skipping purge-blocked-message-samples schedule (expected on local/CI Postgres; api/main.py''s startup purge still runs)';
+    END IF;
 END
 $$;
-
-SELECT cron.schedule(
-    'purge-blocked-message-samples',
-    '15 3 * * *',
-    $cmd$DELETE FROM blocked_message_samples WHERE expires_at < now()$cmd$
-);
-
--- Verify
-SELECT jobid, jobname, schedule, command
-FROM cron.job
-WHERE jobname = 'purge-blocked-message-samples';

--- a/scripts/migrations/010_schedule_rate_limit_purge.sql
+++ b/scripts/migrations/010_schedule_rate_limit_purge.sql
@@ -28,34 +28,45 @@
 --   - `CREATE EXTENSION IF NOT EXISTS` is safe to re-run.
 --   - `cron.unschedule` is wrapped in a DO block so re-running this
 --     migration just replaces the schedule without errors.
-
-CREATE EXTENSION IF NOT EXISTS pg_cron;
+--
+-- Local/CI Postgres (pgvector/pgvector image, docker-compose.yml) doesn't have
+-- pg_cron installed and can't get it without a custom image. Unlike a missing
+-- table, `CREATE EXTENSION pg_cron` fails outright when the extension isn't
+-- installed, and any statement referencing the `cron` schema then fails to
+-- even parse -- so the whole body below is gated on pg_available_extensions
+-- and skips with a NOTICE when pg_cron isn't there, instead of taking the
+-- migration runner down on every non-prod environment. The tables themselves
+-- (migration 009) are unaffected either way -- only the purge schedule is
+-- skipped, so rows just accumulate until this runs somewhere with pg_cron.
 
 DO $$
 BEGIN
-    PERFORM cron.unschedule('purge-rate-limit-hits')
-    FROM cron.job
-    WHERE jobname = 'purge-rate-limit-hits';
+    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_cron') THEN
+        EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_cron';
 
-    PERFORM cron.unschedule('purge-rate-limit-sessions')
-    FROM cron.job
-    WHERE jobname = 'purge-rate-limit-sessions';
+        PERFORM cron.unschedule('purge-rate-limit-hits')
+        FROM cron.job
+        WHERE jobname = 'purge-rate-limit-hits';
+
+        PERFORM cron.unschedule('purge-rate-limit-sessions')
+        FROM cron.job
+        WHERE jobname = 'purge-rate-limit-sessions';
+
+        PERFORM cron.schedule(
+            'purge-rate-limit-hits',
+            '*/10 * * * *',
+            $cron$DELETE FROM rate_limit_hits WHERE created_at < now() - interval '1 hour'$cron$
+        );
+
+        PERFORM cron.schedule(
+            'purge-rate-limit-sessions',
+            '15 * * * *',
+            $cron$DELETE FROM rate_limit_sessions WHERE last_seen < now() - interval '1 hour'$cron$
+        );
+
+        RAISE NOTICE 'Scheduled pg_cron jobs purge-rate-limit-hits (*/10 * * * *) and purge-rate-limit-sessions (15 * * * *)';
+    ELSE
+        RAISE NOTICE 'pg_cron extension not available -- skipping rate-limit purge schedules (expected on local/CI Postgres; rate_limit_hits/rate_limit_sessions rows will just accumulate until this runs somewhere with pg_cron)';
+    END IF;
 END
 $$;
-
-SELECT cron.schedule(
-    'purge-rate-limit-hits',
-    '*/10 * * * *',
-    $cmd$DELETE FROM rate_limit_hits WHERE created_at < now() - interval '1 hour'$cmd$
-);
-
-SELECT cron.schedule(
-    'purge-rate-limit-sessions',
-    '15 * * * *',
-    $cmd$DELETE FROM rate_limit_sessions WHERE last_seen < now() - interval '1 hour'$cmd$
-);
-
--- Verify
-SELECT jobid, jobname, schedule, command
-FROM cron.job
-WHERE jobname IN ('purge-rate-limit-hits', 'purge-rate-limit-sessions');


### PR DESCRIPTION
## Summary

Follow-up to PR #866 (BITB-061 phase 3, merged to `main`). That PR added a Postgres-backed shared rate limiter defaulting to `rate_limit_backend=postgres`, requiring the `rate_limit_hits`/`rate_limit_sessions` tables from migration 009. Those migrations are only ever applied by `azure-deploy.yml`'s prod deploy pipeline — never by `scripts/init.sql` (the schema baked into local dev's and CI's Integration Tests job's Postgres). So every `/chat`/`/chat/stream` request in those environments hit `UndefinedTableError`, and after 5 consecutive failures the rate limiter's circuit breaker opens and **fails closed** (real HTTP 429s to users) until the process restarts — the table never appears.

Fixes:
- **`docker-compose.yml` / `test_update.yml`**: default `RATE_LIMIT_BACKEND=memory` for local dev and the Integration Tests job. This single-instance stack gets nothing from the cross-replica Postgres backend, and has no `pg_cron` to purge it.
- **`scripts/init.sql`**: mirror migration 009's tables, matching the existing pattern already used for the `sessions` table (migration 008).
- **`docker-compose.yml` `db-init` / `scripts/init-db.sh`**: actually run `scripts/migrations/run_migrations.py` on bring-up, so this class of drift can't recur for future migrations either.
- **Migrations 005 and 010**: gate `pg_cron` scheduling on `pg_available_extensions` so the runner completes locally instead of dying on `CREATE EXTENSION pg_cron` (not installed in the local Postgres image). Tables/purge-worthy data are unaffected — only the schedule is skipped, with a `NOTICE`.
- **Migration 002**: fixed a second latent bug hit while testing this — `ALTER DATABASE bibleapp SET hnsw.ef_search` hardcoded the prod DB name and, per migration 007's own docstring, already fails with "permission denied" on some managed Postgres tiers. Now targets `current_database()` dynamically and treats a privilege error as non-fatal, matching 007's precedent.
- **`deployment/monitoring.tf`**: added an alert on `rate_limiter.fail_closed_total`, mirroring the existing `embedding_fallback_rate` alert. PR #866 added three `rate_limiter.*` counters but none had an alert or dashboard panel — this exact failure mode (or any other persistent Postgres issue) would have paged nobody in prod.

## Test plan
- [x] Brought up `postgres` + `db-init` in isolation against a fresh volume; all 12 migrations apply cleanly (including 002, 005, 009, 010 with the new guards)
- [x] Re-ran `db-init`; all 12 migrations correctly skipped as already-applied
- [x] Confirmed `rate_limit_hits`/`rate_limit_sessions` tables + indexes exist with the expected schema
- [x] `scripts/migrations/test_run_migrations.py` — 15 passed
- [x] `terraform fmt -check` passes on `monitoring.tf`
- [x] `docker compose config` / YAML validity checks pass
- [ ] Full `docker compose up` end-to-end (frontend/api/ollama) — not exercised in this pass; the isolated postgres+db-init verification above covers the actual bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRdAdpvqc5PfziWLZ9k3pf