### PR TITLE
ci: reuse TF_VAR_OPENROUTER_API_KEY in CI instead of a duplicate secret

### DIFF
--- a/.github/ACTIONS_SECURITY.md
+++ b/.github/ACTIONS_SECURITY.md
@@ -33,7 +33,7 @@
 ```yaml
 env:
   # ✅ GOOD
-  API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+  API_KEY: ${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
   # ❌ BAD

--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -184,7 +184,7 @@ jobs:
           # Primary: free model, Fallback: paid model (minimal cost)
           cat > .env << EOF
           LLM_PROVIDER=openrouter
-          OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_API_KEY=${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
           OPENROUTER_MODEL=meta-llama/llama-3.3-70b-instruct:free
           OPENROUTER_FALLBACK_MODELS=meta-llama/llama-3.3-70b-instruct
           OPENROUTER_ALLOW_FALLBACKS=true


### PR DESCRIPTION
## Summary
- The `Integration Tests` job in `test_update.yml` used its own `OPENROUTER_API_KEY` GitHub secret, separate from `TF_VAR_OPENROUTER_API_KEY` (the one Terraform actually deploys to production).
- The CI-only secret was last rotated 2026-02-01 and went stale after production's key was rotated 2026-04-24 — every OpenRouter call in CI has been failing with `401 User not found` since then (masked because the app has fallback paths for LLM failures, so the job stayed green: [run 29662082068](https://github.com/zioalex/getinspiredbythebible/actions/runs/29662082068/job/88126528729)).
- Points CI at the same secret production uses (`TF_VAR_OPENROUTER_API_KEY`) so there's one source of truth and this class of drift can't happen again. Also updated the example in `.github/ACTIONS_SECURITY.md` for consistency.

## Follow-up (manual, not in this PR)
- Delete the now-unused `OPENROUTER_API_KEY` repo secret once this merges.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML is valid
- [x] Pre-commit hooks (yamllint, prettier-yaml, detect-secrets, etc.) pass
- [ ] After merge: re-run `CI/CD - Test Application` on `main` and confirm no more `401 User not found` in the Integration Tests job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9XK7oUTXDCgyVcwF5J9hD