### PR TITLE
test(api): close DB/Postgres unit-test coverage gaps

### DIFF
--- a/api/tests/test_blocked_samples.py
+++ b/api/tests/test_blocked_samples.py
@@ -1,0 +1,179 @@
+"""
+Tests for feedback/blocked_samples.py (BITB-057-adjacent privacy-minimal
+capture of messages blocked by the safety pipeline).
+
+Mocks the DB session directly (no real database) and asserts the
+gating/dedup/insert/error-swallow branches, mirroring the mocking style in
+test_feedback_repository.py.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config import settings
+from feedback.blocked_samples import purge_expired_blocked_samples, record_blocked_sample
+
+
+def _async_session_factory_returning(db):
+    """Build a callable that mimics ``async_session_factory()`` — an async
+    context manager whose ``__aenter__`` yields the given mock session."""
+    factory = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=db)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    factory.return_value = cm
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_noop_when_capture_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", False)
+    factory = _async_session_factory_returning(MagicMock())
+
+    with patch("scripture.database.async_session_factory", factory):
+        await record_blocked_sample(message="blocked text", stage="keyword_filter")
+
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_noop_when_message_empty(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", True)
+    factory = _async_session_factory_returning(MagicMock())
+
+    with patch("scripture.database.async_session_factory", factory):
+        await record_blocked_sample(message="", stage="keyword_filter")
+
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_swallows_import_error(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", True)
+    monkeypatch.setitem(sys.modules, "scripture.database", None)
+
+    # Must not raise, even though the lazy import of async_session_factory fails.
+    await record_blocked_sample(message="blocked text", stage="keyword_filter")
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_dedup_increments_hit_count(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", True)
+
+    existing_row = MagicMock(id=7, hit_count=2)
+    select_result = MagicMock(scalar_one_or_none=MagicMock(return_value=existing_row))
+    update_result = MagicMock()
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[select_result, update_result])
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+
+    factory = _async_session_factory_returning(db)
+    with patch("scripture.database.async_session_factory", factory):
+        await record_blocked_sample(message="repeat offender", stage="llama_guard")
+
+    assert db.execute.await_count == 2
+    db.add.assert_not_called()
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_insert_when_no_existing_row(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", True)
+
+    select_result = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=select_result)
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+
+    factory = _async_session_factory_returning(db)
+    with patch("scripture.database.async_session_factory", factory):
+        await record_blocked_sample(message="brand new violation", stage="openai_moderation")
+
+    db.add.assert_called_once()
+    added = db.add.call_args.args[0]
+    assert added.hit_count == 1
+    assert added.reviewed is False
+    assert added.stage == "openai_moderation"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_hashes_session_id_when_provided(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", True)
+
+    select_result = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=select_result)
+    db.commit = AsyncMock()
+    db.add = MagicMock()
+
+    factory = _async_session_factory_returning(db)
+    with patch("scripture.database.async_session_factory", factory):
+        await record_blocked_sample(
+            message="flagged", stage="keyword_filter", session_id="user-session-abc"
+        )
+
+    added = db.add.call_args.args[0]
+    assert added.session_id_hash is not None
+    assert added.session_id_hash != "user-session-abc"  # hashed, not stored raw
+
+
+@pytest.mark.asyncio
+async def test_record_blocked_sample_rollback_and_reraise_swallowed_by_outer(monkeypatch):
+    monkeypatch.setattr(settings, "blocked_sample_capture_enabled", True)
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=ValueError("db exploded"))
+    db.rollback = AsyncMock()
+
+    factory = _async_session_factory_returning(db)
+    with patch("scripture.database.async_session_factory", factory):
+        # Must not raise: record_blocked_sample's contract is to never
+        # propagate failures back to the caller.
+        await record_blocked_sample(message="whatever", stage="azure_content_safety")
+
+    db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_blocked_samples_returns_zero_on_import_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "scripture.database", None)
+
+    result = await purge_expired_blocked_samples()
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_blocked_samples_happy_path_returns_rowcount():
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(rowcount=5))
+    db.commit = AsyncMock()
+
+    factory = _async_session_factory_returning(db)
+    with patch("scripture.database.async_session_factory", factory):
+        result = await purge_expired_blocked_samples()
+
+    assert result == 5
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_blocked_samples_rollback_returns_zero_on_error():
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=RuntimeError("connection dropped"))
+    db.rollback = AsyncMock()
+
+    factory = _async_session_factory_returning(db)
+    with patch("scripture.database.async_session_factory", factory):
+        result = await purge_expired_blocked_samples()
+
+    assert result == 0
+    db.rollback.assert_awaited_once()

--- a/api/tests/test_database_church_coverage.py
+++ b/api/tests/test_database_church_coverage.py
@@ -191,6 +191,53 @@ class TestCloseDb:
             mock_engine.dispose.assert_awaited_once()
 
 
+class TestApplySessionHnswEfSearch:
+    """Tests for the ``connect`` event listener that sets ``hnsw.ef_search``
+    on every new pooled connection. It's a plain module-level function
+    (registered via @event.listens_for but still directly callable)."""
+
+    def test_sets_guc_on_connection(self):
+        from scripture.database import _apply_session_hnsw_ef_search
+
+        cursor = MagicMock()
+        dbapi_connection = MagicMock()
+        dbapi_connection.cursor.return_value = cursor
+
+        with patch("scripture.database.settings") as mock_settings:
+            mock_settings.hnsw_ef_search = 150
+            _apply_session_hnsw_ef_search(dbapi_connection, MagicMock())
+
+        cursor.execute.assert_called_once_with("SET hnsw.ef_search = 150")
+        cursor.close.assert_called_once()
+
+    def test_swallows_exception_when_cursor_unavailable(self):
+        from scripture.database import _apply_session_hnsw_ef_search
+
+        dbapi_connection = MagicMock()
+        dbapi_connection.cursor.side_effect = Exception("connection gone")
+
+        with patch("scripture.database.logger") as mock_logger:
+            # Must not raise -- a failure here would break every connection.
+            _apply_session_hnsw_ef_search(dbapi_connection, MagicMock())
+
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args.kwargs.get("exc_info") is True
+
+    def test_swallows_exception_and_still_closes_cursor_on_execute_failure(self):
+        from scripture.database import _apply_session_hnsw_ef_search
+
+        cursor = MagicMock()
+        cursor.execute.side_effect = Exception("SET failed")
+        dbapi_connection = MagicMock()
+        dbapi_connection.cursor.return_value = cursor
+
+        with patch("scripture.database.logger") as mock_logger:
+            _apply_session_hnsw_ef_search(dbapi_connection, MagicMock())
+
+        cursor.close.assert_called_once()
+        mock_logger.warning.assert_called_once()
+
+
 # ==================== Church Route Tests ====================
 
 

--- a/api/tests/test_feedback_repository.py
+++ b/api/tests/test_feedback_repository.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from feedback.models import ContactRequest, FeedbackRequest
+from feedback.models import ContactRequest, Feedback, FeedbackRequest
 from feedback.repository import FeedbackRepository
 
 
@@ -90,3 +90,42 @@ async def test_save_contact_retries_once_on_disconnect_then_succeeds():
 
     assert result is not None
     assert db.commit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_by_message_id_found():
+    message_id = str(uuid.uuid4())
+    found = Feedback(message_id=uuid.UUID(message_id), rating="positive")
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=found)))
+
+    repo = FeedbackRepository(db)
+    result = await repo.get_feedback_by_message_id(message_id)
+
+    assert result is found
+    db.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_by_message_id_not_found():
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+
+    repo = FeedbackRepository(db)
+    result = await repo.get_feedback_by_message_id(str(uuid.uuid4()))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_by_message_id_invalid_uuid_raises():
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    repo = FeedbackRepository(db)
+
+    with pytest.raises(ValueError):
+        await repo.get_feedback_by_message_id("not-a-uuid")
+
+    db.execute.assert_not_awaited()

--- a/api/tests/test_hybrid_search.py
+++ b/api/tests/test_hybrid_search.py
@@ -121,6 +121,58 @@ class TestSearchVersesHybrid:
         assert "translation" in params
         assert params["translation"] == "kjv"
 
+    @pytest.mark.asyncio
+    async def test_hybrid_search_zero_weights_skips_normalization(self):
+        """When semantic_weight and keyword_weight are both 0, the
+        `if total_weight > 0` guard skips division, avoiding a
+        ZeroDivisionError, and the raw (zero) weights flow through."""
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+
+        mock_sql_result = MagicMock()
+        mock_sql_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_sql_result
+
+        embedding = [0.1] * 1024
+        results = await repo.search_verses_hybrid(
+            query_text="test",
+            query_embedding=embedding,
+            semantic_weight=0,
+            keyword_weight=0,
+        )
+
+        assert results == []
+        params = mock_session.execute.call_args[0][1]
+        assert params["semantic_weight"] == 0
+        assert params["keyword_weight"] == 0
+
+
+class TestSearchVersesHybridBoosted:
+    """Tests for ScriptureRepository.search_verses_hybrid_boosted()."""
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_boosted_zero_weights_skips_normalization(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+
+        mock_sql_result = MagicMock()
+        mock_sql_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_sql_result
+
+        embedding = [0.1] * 1024
+        results = await repo.search_verses_hybrid_boosted(
+            query_text="test",
+            query_embedding=embedding,
+            boost_topics=[],
+            semantic_weight=0,
+            keyword_weight=0,
+        )
+
+        assert results == []
+        params = mock_session.execute.call_args[0][1]
+        assert params["semantic_weight"] == 0
+        assert params["keyword_weight"] == 0
+
 
 class TestRawSqlHasNoPythonComment:
     """Regression: the raw-SQL search builders must not leak a Python ``#`` comment
@@ -325,6 +377,28 @@ class TestSearchPassagesHybrid:
         )
 
         assert results == []
+
+    @pytest.mark.asyncio
+    async def test_passages_hybrid_zero_weights_skips_normalization(self):
+        mock_session = AsyncMock()
+        repo = ScriptureRepository(mock_session)
+
+        mock_sql_result = MagicMock()
+        mock_sql_result.fetchall.return_value = []
+        mock_session.execute.return_value = mock_sql_result
+
+        embedding = [0.1] * 1024
+        results = await repo.search_passages_hybrid(
+            query_text="xyz",
+            query_embedding=embedding,
+            semantic_weight=0,
+            keyword_weight=0,
+        )
+
+        assert results == []
+        params = mock_session.execute.call_args[0][1]
+        assert params["semantic_weight"] == 0
+        assert params["keyword_weight"] == 0
 
 
 # ==================== SearchService Tests ====================

--- a/api/tests/test_hybrid_search_integration.py
+++ b/api/tests/test_hybrid_search_integration.py
@@ -33,13 +33,14 @@ from sqlalchemy.pool import NullPool
 
 from config import settings
 from scripture.database import get_async_database_url
-from scripture.models import Base, Book, Chapter, Passage, Translation, Verse
+from scripture.models import Base, Book, Chapter, Passage, Topic, Translation, Verse
 from scripture.repository import ScriptureRepository
 
 # Sentinel identifiers so the rolled-back seed never collides with real data.
 _TRANSLATION = "zzint"
 _BOOK_NAME = "ZZ Integration Book"
 _VERSE_TEXT = "For God so loved the world that he gave his only Son."
+_TOPIC_NAME = "ZZ Integration Topic"
 
 
 def _seed_vector() -> list[float]:
@@ -119,6 +120,8 @@ async def seeded_repo():
                 embedding=vec,
             )
         )
+        await session.flush()
+        session.add(Topic(name=_TOPIC_NAME, embedding=vec))
         await session.flush()
         yield ScriptureRepository(session)
     finally:
@@ -200,4 +203,44 @@ async def test_get_verses_in_range_executes_against_real_db(seeded_repo):
         _BOOK_NAME, 3, start_verse=16, end_verse=18, translation=_TRANSLATION
     )
     assert verses, "get_verses_in_range returned empty for the seeded range"
+    assert any(v.text == _VERSE_TEXT for v in verses)
+
+
+# ── Plain (non-boosted/non-hybrid) semantic-search builders ───────────────
+# These use pgvector's cosine_distance operator directly via the ORM but,
+# unlike the raw-SQL builders above, were previously only ever asserted
+# against a mock's canned return value -- never executed against real
+# Postgres+pgvector.
+
+
+async def test_search_verses_semantic_executes_against_real_db(seeded_repo):
+    rows = await seeded_repo.search_verses_semantic(
+        query_embedding=_seed_vector(), translation=_TRANSLATION
+    )
+    assert rows, "semantic search returned no rows from the real DB"
+    verse, similarity = rows[0]
+    assert verse.text == _VERSE_TEXT
+    # Identical vector -> cosine distance 0 -> similarity 1.0.
+    assert similarity == pytest.approx(1.0)
+
+
+async def test_search_passages_semantic_executes_against_real_db(seeded_repo):
+    rows = await seeded_repo.search_passages_semantic(query_embedding=_seed_vector())
+    assert rows, "passage semantic search returned no rows from the real DB"
+    passage, similarity = rows[0]
+    assert passage.text == _VERSE_TEXT
+    assert similarity == pytest.approx(1.0)
+
+
+async def test_search_topics_semantic_executes_against_real_db(seeded_repo):
+    rows = await seeded_repo.search_topics_semantic(query_embedding=_seed_vector())
+    assert rows, "topic semantic search returned no rows from the real DB"
+    topic, similarity = rows[0]
+    assert topic.name == _TOPIC_NAME
+    assert similarity == pytest.approx(1.0)
+
+
+async def test_search_verses_text_executes_against_real_db(seeded_repo):
+    verses = await seeded_repo.search_verses_text(query="loved the world")
+    assert verses, "text search returned no rows from the real DB"
     assert any(v.text == _VERSE_TEXT for v in verses)

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -502,6 +502,194 @@ class TestMainLifespan:
             mock_close.assert_awaited_once()
 
 
+def _session_factory_mock(session=None):
+    """Build a MagicMock mimicking ``async_session_factory()`` — an async
+    context manager whose __aenter__ yields ``session`` (or a fresh mock)."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session if session is not None else MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=cm)
+
+
+class TestCheckTranslationCoverageAtStartup:
+    """Tests for main.py's _check_translation_coverage_at_startup()."""
+
+    @pytest.mark.asyncio
+    async def test_logs_and_counts_unusable_languages(self):
+        from main import _check_translation_coverage_at_startup
+        from scripture.coverage import UnusableLanguage
+
+        unusable = [UnusableLanguage(language="fr", translation="fr1910", problem="no_embeddings")]
+
+        with (
+            patch("scripture.database.async_session_factory", _session_factory_mock()),
+            patch(
+                "main.check_translation_coverage",
+                new_callable=AsyncMock,
+                return_value=([], unusable),
+            ),
+            patch("main.translation_data_missing_counter") as mock_counter,
+        ):
+            await _check_translation_coverage_at_startup()
+
+        mock_counter.add.assert_called_once_with(
+            1, {"language": "fr", "translation": "fr1910", "problem": "no_embeddings"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions(self):
+        from main import _check_translation_coverage_at_startup
+
+        with (
+            patch("scripture.database.async_session_factory", _session_factory_mock()),
+            patch(
+                "main.check_translation_coverage",
+                new_callable=AsyncMock,
+                side_effect=Exception("db down"),
+            ),
+            patch("main.logger") as mock_logger,
+        ):
+            # Must not raise -- a cold/unreachable DB must never block startup.
+            await _check_translation_coverage_at_startup()
+
+        mock_logger.warning.assert_called_once()
+
+
+class TestWarmReadyTranslations:
+    """Tests for main.py's _warm_ready_translations()."""
+
+    @pytest.mark.asyncio
+    async def test_calls_refresh_ready_translations(self):
+        from main import _warm_ready_translations
+
+        mock_session = MagicMock()
+
+        with (
+            patch("scripture.database.async_session_factory", _session_factory_mock(mock_session)),
+            patch(
+                "scripture.coverage.refresh_ready_translations", new_callable=AsyncMock
+            ) as mock_refresh,
+        ):
+            await _warm_ready_translations()
+
+        mock_refresh.assert_awaited_once_with(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions(self):
+        from main import _warm_ready_translations
+
+        with (
+            patch("scripture.database.async_session_factory", _session_factory_mock()),
+            patch(
+                "scripture.coverage.refresh_ready_translations",
+                new_callable=AsyncMock,
+                side_effect=Exception("db down"),
+            ),
+            patch("main.logger") as mock_logger,
+        ):
+            await _warm_ready_translations()
+
+        mock_logger.warning.assert_called_once()
+
+
+class TestPurgeBlockedSamplesAtStartup:
+    """Tests for main.py's _purge_blocked_samples_at_startup()."""
+
+    @pytest.mark.asyncio
+    async def test_logs_when_deleted(self):
+        from main import _purge_blocked_samples_at_startup
+
+        with (
+            patch(
+                "feedback.blocked_samples.purge_expired_blocked_samples",
+                new_callable=AsyncMock,
+                return_value=3,
+            ),
+            patch("main.logger") as mock_logger,
+        ):
+            await _purge_blocked_samples_at_startup()
+
+        mock_logger.info.assert_called_once_with(
+            "Purged expired blocked-message samples", extra={"deleted": 3}
+        )
+
+    @pytest.mark.asyncio
+    async def test_silent_when_zero_deleted(self):
+        from main import _purge_blocked_samples_at_startup
+
+        with (
+            patch(
+                "feedback.blocked_samples.purge_expired_blocked_samples",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch("main.logger") as mock_logger,
+        ):
+            await _purge_blocked_samples_at_startup()
+
+        mock_logger.info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_exceptions(self):
+        from main import _purge_blocked_samples_at_startup
+
+        with (
+            patch(
+                "feedback.blocked_samples.purge_expired_blocked_samples",
+                new_callable=AsyncMock,
+                side_effect=Exception("db down"),
+            ),
+            patch("main.logger") as mock_logger,
+        ):
+            await _purge_blocked_samples_at_startup()
+
+        mock_logger.warning.assert_called_once()
+
+
+class TestReadinessRefreshLoop:
+    """Tests for main.py's _readiness_refresh_loop() (infinite loop)."""
+
+    @pytest.mark.asyncio
+    async def test_runs_then_cancels(self):
+        from main import _readiness_refresh_loop
+
+        with (
+            patch(
+                "main.asyncio.sleep",
+                new_callable=AsyncMock,
+                side_effect=[None, asyncio.CancelledError()],
+            ),
+            patch("main._warm_ready_translations", new_callable=AsyncMock) as mock_warm,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _readiness_refresh_loop()
+
+        mock_warm.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_swallows_warm_up_exception_and_loops(self):
+        from main import _readiness_refresh_loop
+
+        with (
+            patch(
+                "main.asyncio.sleep",
+                new_callable=AsyncMock,
+                side_effect=[None, None, asyncio.CancelledError()],
+            ),
+            patch(
+                "main._warm_ready_translations",
+                new_callable=AsyncMock,
+                side_effect=[Exception("transient"), None],
+            ) as mock_warm,
+            patch("main.logger") as mock_logger,
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await _readiness_refresh_loop()
+
+        assert mock_warm.await_count == 2
+        mock_logger.warning.assert_called_once()
+
+
 # ==================== Feedback Route Tests ====================
 
 

--- a/api/tests/test_session_tracker.py
+++ b/api/tests/test_session_tracker.py
@@ -1,0 +1,86 @@
+"""
+Tests for utils/session_tracker.py (DAU/MAU session upsert tracking).
+
+Mocks the DB session directly (no real database). track_session's ON
+CONFLICT upsert semantics against a real Postgres are covered separately by
+tests/test_session_tracker_integration.py.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.session_tracker import _detect_mobile, track_session
+
+
+@pytest.mark.asyncio
+async def test_track_session_returns_immediately_when_no_token():
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    await track_session(db, session_token=None, user_agent="Mozilla/5.0")
+
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_track_session_builds_upsert_with_bind_params():
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    await track_session(
+        db,
+        session_token="tok-123",
+        user_agent="Mozilla/5.0 (iPhone; CPU iPhone OS)",
+        language="en",
+    )
+
+    db.execute.assert_awaited_once()
+    query, params = db.execute.call_args.args
+    assert "ON CONFLICT (session_token) DO UPDATE" in str(query)
+    assert params == {
+        "token": "tok-123",
+        "lang": "en",
+        "ua": "Mozilla/5.0 (iPhone; CPU iPhone OS)",
+        "mobile": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_track_session_mobile_false_when_no_user_agent():
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    await track_session(db, session_token="tok-456", user_agent=None, language="fr")
+
+    _, params = db.execute.call_args.args
+    assert params["mobile"] is False
+
+
+@pytest.mark.asyncio
+async def test_track_session_swallows_execute_exception_and_logs_warning():
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=Exception("connection closed mid-operation"))
+
+    with patch("utils.session_tracker.logger") as mock_logger:
+        # Must not raise -- tracking failures never affect the chat response.
+        await track_session(db, session_token="tok-789", user_agent="Mozilla/5.0")
+
+    mock_logger.warning.assert_called_once()
+    assert mock_logger.warning.call_args.kwargs.get("exc_info") is True
+
+
+@pytest.mark.parametrize(
+    "user_agent,expected",
+    [
+        ("Mozilla/5.0 (Linux; Android 14)", True),
+        ("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)", True),
+        ("Mozilla/5.0 (iPad; CPU OS 17_0)", True),
+        ("SomeApp/1.0 Mobile", True),
+        ("MOZILLA/5.0 (IPHONE)", True),
+        ("Mozilla/5.0 (Windows NT 10.0; Win64; x64)", False),
+        ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)", False),
+    ],
+)
+def test_detect_mobile_matches_keywords(user_agent, expected):
+    assert _detect_mobile(user_agent) is expected

--- a/api/tests/test_session_tracker_integration.py
+++ b/api/tests/test_session_tracker_integration.py
@@ -1,0 +1,143 @@
+"""
+Integration test for utils/session_tracker.py's session upsert, run against a
+real database instead of mocking the session.
+
+Why this file exists
+---------------------
+track_session's `INSERT ... ON CONFLICT (session_token) DO UPDATE ...
+COALESCE(...)` upsert is only ever asserted against a mock's canned return
+value elsewhere (test_session_tracker.py) — real `ON CONFLICT`/`COALESCE`
+semantics can't be verified by a mock.
+
+Applies migration 008's DDL (idempotent) against whatever `DATABASE_URL`
+points at. Cleans up only the rows it created, keyed by a unique sentinel
+token prefix, so it never touches unrelated data in a shared test database.
+
+Skips automatically when no Postgres is reachable (e.g. local runs without a
+DB). CI's `backend-tests` job provides a service container with
+`DATABASE_URL` set, so this runs on every PR.
+"""
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from scripture.database import get_async_database_url
+from utils.session_tracker import track_session
+
+_MIGRATION_008 = (
+    Path(__file__).resolve().parents[2] / "scripts" / "migrations" / "008_add_sessions_table.sql"
+)
+_TOKEN_PREFIX = "zz-itest-session-tracker-"
+
+
+@pytest_asyncio.fixture
+async def sessions_table():
+    """Ensures migration 008's ``sessions`` table exists against the real
+    ``DATABASE_URL``. Skips when Postgres is unreachable. Yields a live
+    ``AsyncSession`` for the test to use; deletes only its own sentinel rows
+    on teardown."""
+    from scripture import database as scripture_database
+
+    # scripture.database's engine/pool is a module-level singleton bound to
+    # whichever event loop created it; pytest-asyncio gives each test its own
+    # loop, so dispose first to force fresh connections on this test's loop.
+    await scripture_database.engine.dispose()
+
+    url, connect_args = get_async_database_url()
+    engine = create_async_engine(url, poolclass=NullPool, connect_args=connect_args)
+
+    try:
+        # Strip comment lines before splitting on ";" (mirrors
+        # test_rate_limiter_integration.py's approach for migration 009).
+        sql_lines = (
+            line
+            for line in _MIGRATION_008.read_text().splitlines()
+            if not line.strip().startswith("--")
+        )
+        async with engine.begin() as conn:
+            for statement in "\n".join(sql_lines).split(";"):
+                statement = statement.strip()
+                if statement:
+                    await conn.execute(text(statement))
+    except Exception as exc:  # connection refused, auth failure, etc.
+        await engine.dispose()
+        pytest.skip(f"Postgres not reachable: {exc}")
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    session = factory()
+    try:
+        yield session
+    finally:
+        await session.rollback()
+        await session.execute(
+            text("DELETE FROM sessions WHERE session_token LIKE :prefix"),
+            {"prefix": f"{_TOKEN_PREFIX}%"},
+        )
+        await session.commit()
+        await session.close()
+        await engine.dispose()
+
+
+async def _fetch(session: AsyncSession, token: str):
+    return (
+        await session.execute(
+            text(
+                "SELECT message_count, is_mobile, language, user_agent "
+                "FROM sessions WHERE session_token = :t"
+            ),
+            {"t": token},
+        )
+    ).one()
+
+
+@pytest.mark.asyncio
+async def test_track_session_inserts_new_row(sessions_table):
+    session = sessions_table
+    token = f"{_TOKEN_PREFIX}insert"
+
+    await track_session(
+        session, session_token=token, user_agent="Mozilla/5.0 (iPhone)", language="en"
+    )
+    await session.commit()
+
+    row = await _fetch(session, token)
+    assert row.message_count == 1
+    assert row.is_mobile is True
+    assert row.language == "en"
+    assert row.user_agent == "Mozilla/5.0 (iPhone)"
+
+
+@pytest.mark.asyncio
+async def test_track_session_upserts_existing_row_increments_count(sessions_table):
+    session = sessions_table
+    token = f"{_TOKEN_PREFIX}upsert"
+
+    await track_session(
+        session, session_token=token, user_agent="Mozilla/5.0 (iPhone)", language="en"
+    )
+    await session.commit()
+
+    # Second visit with no user_agent/language: language/user_agent are
+    # passed through as NULL, so COALESCE(:lang, sessions.language) and
+    # COALESCE(:ua, sessions.user_agent) retain the first call's values --
+    # real Postgres semantics a mock can't validate.
+    await track_session(session, session_token=token, user_agent=None, language=None)
+    await session.commit()
+
+    row = await _fetch(session, token)
+    assert row.message_count == 2
+    assert row.language == "en"
+    assert row.user_agent == "Mozilla/5.0 (iPhone)"
+    # is_mobile is NOT retained: track_session computes it as a concrete
+    # bool (`_detect_mobile(user_agent) if user_agent else False`) before it
+    # ever reaches SQL, so :mobile is always False (never NULL) when
+    # user_agent is absent -- COALESCE(:mobile, sessions.is_mobile) then
+    # resolves to that False, overwriting the previous True. Unlike
+    # language/user_agent, a missing UA on a later visit silently flips
+    # is_mobile back to False rather than preserving the earlier detection.
+    assert row.is_mobile is False

--- a/api/tests/test_weekly_report.py
+++ b/api/tests/test_weekly_report.py
@@ -167,6 +167,46 @@ async def test_build_report_falls_back_when_sessions_schema_is_missing(
     db.rollback.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_build_report_reraises_unrelated_programming_error():
+    """A ProgrammingError that isn't the missing-sessions-schema case (e.g. a
+    genuine SQL syntax error) must propagate, not be swallowed into the
+    zero-engagement fallback."""
+
+    class DummyOrigError(Exception):
+        def __init__(self, message: str, *, pgcode: str | None):
+            super().__init__(message)
+            self.pgcode = pgcode
+
+    db = MagicMock()
+    actions = iter(
+        [
+            _result(all_=[("positive", 2)]),
+            _result(all_=[]),
+            _result(all_=[("bug", 1)]),
+            ProgrammingError(
+                "SELECT active_sessions FROM sessions",
+                {},
+                DummyOrigError('syntax error at or near "SELECT"', pgcode="42601"),
+            ),
+        ]
+    )
+
+    async def execute(*_args, **_kwargs):
+        action = next(actions)
+        if isinstance(action, Exception):
+            raise action
+        return action
+
+    db.execute = AsyncMock(side_effect=execute)
+    db.rollback = AsyncMock()
+
+    with pytest.raises(ProgrammingError):
+        await build_weekly_report(db, now=NOW)
+
+    db.rollback.assert_not_awaited()
+
+
 def _report_with_comment(comment: str) -> WeeklyReport:
     return WeeklyReport(
         window_start=NOW,


### PR DESCRIPTION
## Summary

Follow-up to the `TF_VAR_OPENROUTER_API_KEY` CI-secret fix (#908) — while investigating that, flagged that CI wasn't really exercising "the entire POSTGRESQL machinery" and unit-test coverage had real gaps. Two Explore + one Plan pass mapped the gaps; this PR closes them in two tracks.

**Track A — mocked unit tests** (no DB required, run in every CI job) for code that was previously untested:
- `feedback/blocked_samples.py` and `utils/session_tracker.py` had **zero test coverage of any kind** — now `test_blocked_samples.py` / `test_session_tracker.py` (new files).
- `scripture/database.py`'s `_apply_session_hnsw_ef_search` connect-event listener, `feedback/repository.py`'s `get_feedback_by_message_id`, the `ProgrammingError` re-raise branch in `reports/weekly_report.py`, the `total_weight <= 0` normalization-skip guard in `scripture/repository.py`'s three hybrid-search builders, and four startup helpers in `main.py`'s lifespan (`_check_translation_coverage_at_startup`, `_warm_ready_translations`, `_purge_blocked_samples_at_startup`, `_readiness_refresh_loop`) — all previously exercised only indirectly (or not at all).

**Track B — real-Postgres integration tests**, extending the repo's existing self-skip pattern (`test_hybrid_search_integration.py` / `test_rate_limiter_integration.py` / `test_weekly_report_integration.py` — connect to `DATABASE_URL`, `pytest.skip()` if unreachable):
- Four semantic-search builders (`search_verses_semantic`, `search_passages_semantic`, `search_topics_semantic`, `search_verses_text`) use pgvector's `<=>` operator but were previously only ever asserted against a mock's canned return value — now run against a real seeded pgvector DB.
- New `test_session_tracker_integration.py` validates `track_session`'s `ON CONFLICT ... DO UPDATE ... COALESCE(...)` upsert against real Postgres semantics. This surfaced a genuine (if minor) real-world quirk: `is_mobile` is *not* retained across a UA-less follow-up call the way `language`/`user_agent` are — see the comment in that test for why.

**No CI workflow changes needed** — the new integration-style tests automatically run in the existing `backend-tests` job's real `pgvector/pgvector:pg16` service container via the same self-skip mechanism the existing three files use.

## Test plan
- [x] Full suite passes locally with **no** DB running: all mocked (Track A) tests pass, Track B tests skip cleanly.
- [x] Full suite passes locally against a real local `pgvector/pgvector:pg16` container: **3670 passed, 0 failed**, 51 skipped (unrelated services like Ollama not running locally).
- [x] `--cov-report=term-missing` confirms the previously-0%-covered files now sit at 98–100%, and the specific previously-missing lines (`scripture/database.py:94-119`, `feedback/repository.py:100-113`, `reports/weekly_report.py:258-260`, `scripture/repository.py`'s three `total_weight` guards, `main.py:66-141`) no longer appear as missing.
- [x] `black --check`, `ruff check`, `mypy` all pass on the changed files.
- [x] Pre-commit hooks (black/ruff/mypy/bandit/detect-secrets/etc.) pass on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9XK7oUTXDCgyVcwF5J9hD