### PR TITLE
fix(api): stop .dockerignore from excluding the reports/ package

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -227,17 +227,52 @@ jobs:
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push backend
+      - name: Build backend image
         uses: docker/build-push-action@v7
         with:
           context: ./api
           file: ./api/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Catches images that build fine but can't actually start — e.g. a
+      # .dockerignore pattern that (intentionally or not) excludes a runtime
+      # package. `docker build` succeeding says nothing about `COPY . .`
+      # having shipped every module main.py's import chain needs; only
+      # actually importing it inside the built image proves that. This
+      # exact class of bug reached production once (api/reports/ excluded
+      # by a `reports/` .dockerignore line meant for coverage-report
+      # output, breaking routes/admin.py's import at container startup)
+      # before this step existed — see incident notes in api/.dockerignore.
+      - name: Smoke test — verify backend image imports cleanly
+        env:
+          DATABASE_URL: postgresql://bible:bible123@localhost:5432/bibledb # pragma: allowlist secret
+          LLM_PROVIDER: ollama
+        run: |
+          IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "Smoke-testing $IMAGE"
+          docker run --rm \
+            -e DATABASE_URL \
+            -e LLM_PROVIDER \
+            "$IMAGE" python -c "
+          import main
+          from routes import admin, chat, scripture
+          from reports.weekly_report import build_weekly_report
+          print('backend image imports cleanly')
+          "
+
+      - name: Push backend image
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            echo "Pushing $tag"
+            docker push "$tag"
+          done
 
   # ---------------------------------------------------------------------------
   # Build and Push Frontend

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -7,8 +7,19 @@
 !.env.example
 
 # Tests and tooling config not needed at runtime
+#
+# Incident: this file previously listed `reports/`, intending to drop
+# generated test/coverage report output. There is no such directory —
+# coverage output goes to htmlcov/ and .coverage (excluded below). Instead
+# it matched api/reports/, a real runtime package (weekly_report.py) that
+# routes/admin.py imports, so `docker build` shipped a backend image
+# main.py couldn't start. `docker build` succeeding proves nothing about
+# imports; CI now also runs the built image with `python -c "import main"`
+# before pushing (see .github/workflows/azure-deploy.yml,
+# "Smoke test — verify backend image imports cleanly") so this class of
+# bug fails the build instead of reaching production. Don't add a bare
+# package-looking name here without checking `ls api/` first.
 tests/
-reports/
 pytest.ini
 .flake8
 .safety-policy.yml

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1157,6 +1157,47 @@ curl -sI https://voxquieta.org/health | grep -E 'HTTP|cf-ray'
 curl -sI https://api.voxquieta.org/health | grep -E 'HTTP|cf-ray'
 ```
 
+## Rollback: Broken Backend/Frontend Revision
+
+Both Container Apps run `revision_mode = "Single"` — there is no traffic-split/revert between
+revisions, so a bad deploy fully replaces the serving image immediately (see the
+2026-07-21 `api/reports/` `.dockerignore` incident, where the deployed backend
+crash-looped on `ModuleNotFoundError: No module named 'reports'`). The fastest fix is to
+push a previously-good image straight to the Container App with `az containerapp update`,
+which bypasses the full CI/Terraform cycle. Follow up with a real fix-forward PR — this is
+a break-glass step, not a substitute for one.
+
+```bash
+RG="bible-app-rg"
+ACR="bibleappacrmb0172"
+APP="bible-app-backend"     # or bible-app-frontend
+
+# 1. Confirm it's actually crash-looping (ProvisioningState/RunningState, restart count)
+az containerapp revision list -n $APP -g $RG -o table
+az containerapp logs show -n $APP -g $RG --tail 50
+
+# 2. Find the last known-good image tag. Tags are the deploying commit SHA
+#    (see .github/workflows/azure-deploy.yml "Extract metadata" step) — pick the SHA
+#    from the last commit before the one that broke it (`git log --oneline -- api/`),
+#    or list what's actually in ACR ordered by push time:
+az acr repository show-tags -n $ACR --repository bible-backend \
+  --orderby time_desc --top 10 -o table
+
+# 3. Point the Container App straight at that image (creates + activates a new
+#    revision immediately; no terraform apply needed)
+az containerapp update \
+  --name $APP \
+  --resource-group $RG \
+  --image "$ACR.azurecr.io/bible-backend:<GOOD_SHA>"
+
+# 4. Verify
+curl -sf https://api.voxquieta.org/health/live && echo OK
+```
+
+Once the app is healthy again, land the real fix as a normal PR — the next `main` deploy
+will overwrite this manual revision with the fixed image anyway, so there's nothing to
+"undo" afterwards.
+
 ## 📝 License
 
 MIT License - see repository root for details.


### PR DESCRIPTION
## Summary

**Prod is currently down** — the backend Container App (revision `bible-app-backend--0000018`) is crash-looping on startup:

```
File "/app/routes/admin.py", line 13, in <module>
    from reports.weekly_report import build_weekly_report, render_html, render_text
ModuleNotFoundError: No module named 'reports'
```

Root cause: `api/.dockerignore` (added today in #916, "360-degree project review") has a `reports/` line meant to exclude generated test/coverage report output — no such directory actually exists (coverage goes to `htmlcov/`/`.coverage`, already excluded separately). Instead it matched the real `api/reports/` runtime package (`weekly_report.py`), which `routes/admin.py` imports, so the production image built from `main` no longer contains it. `docker build` succeeds regardless, since it's just `COPY . .` — the missing module only surfaces at `import main` time inside the running container.

- `api/.dockerignore`: remove the `reports/` line; add an incident comment so a future cleanup pass doesn't reintroduce it.
- `.github/workflows/azure-deploy.yml` (`build-backend` job): split "build and push" into build (`load: true`) → smoke test → push. The smoke test runs `docker run <built-image> python -c "import main; from routes import admin, chat, scripture; from reports.weekly_report import build_weekly_report"` against the actual built image and only pushes to ACR if it succeeds. This runs on PR builds too, so this whole class of bug (any runtime module missing from the built image, for any reason) fails CI before merge instead of reaching prod. Deploy is already gated on `build-backend` not failing.
- `deployment/README.md`: new "Rollback: Broken Backend/Frontend Revision" runbook (mirrors the existing "Emergency Cert Rebind" one) documenting the `az containerapp update --image <last-good-tag>` break-glass path, since both Container Apps run `revision_mode = "Single"` and have no traffic-split/revert between revisions.

## Test plan

- [ ] CI `build-backend` job's new "Smoke test — verify backend image imports cleanly" step passes (proves the fix actually restores `reports/` to the image)
- [ ] Full CI suite passes
- [ ] Merge and confirm the backend Container App comes up healthy (`curl https://api.voxquieta.org/health/live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013v3qc4wCQkSE7ZL7zfAfAR