### PR TITLE
fix(ci): route multi-line docker tags through env:, not raw ${{ }} splice

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -251,10 +251,14 @@ jobs:
       # before this step existed — see incident notes in api/.dockerignore.
       - name: Smoke test — verify backend image imports cleanly
         env:
+          # Routed through env: (not inlined via ${{ }}) because
+          # steps.meta.outputs.tags is a newline-separated multi-line string —
+          # splicing it straight into the script text breaks bash parsing.
+          TAGS: ${{ steps.meta.outputs.tags }}
           DATABASE_URL: postgresql://bible:bible123@localhost:5432/bibledb # pragma: allowlist secret
           LLM_PROVIDER: ollama
         run: |
-          IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          IMAGE=$(head -n1 <<< "$TAGS")
           echo "Smoke-testing $IMAGE"
           docker run --rm \
             -e DATABASE_URL \
@@ -268,11 +272,18 @@ jobs:
 
       - name: Push backend image
         if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # Same reasoning as the smoke-test step above: route the multi-line
+          # tags list through env:, and iterate with `read` (not unquoted `for
+          # tag in $TAGS`) so a raw ${{ }} splice can't reintroduce a syntax
+          # error and word-splitting quirks can't drop/mangle a tag.
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          for tag in ${{ steps.meta.outputs.tags }}; do
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
             echo "Pushing $tag"
             docker push "$tag"
-          done
+          done <<< "$TAGS"
 
   # ---------------------------------------------------------------------------
   # Build and Push Frontend


### PR DESCRIPTION
## Summary

Follow-up to #920. That PR's fix for the `reports/` `.dockerignore` bug is confirmed working — the new "Smoke test — verify backend image imports cleanly" step passed on the PR build-backend job. But the automatic post-merge deploy (workflow run [29871764567](https://github.com/zioalex/getinspiredbythebible/actions/runs/29871764567)) failed one step later, at "Push backend image":

```
/home/runner/.../xxx.sh: line 2: syntax error near unexpected token `bibleappacrmb0172.azurecr.io/bible-backend:729412210ad1bb9d2de03acce5eccad7dc5883f3'
```

`steps.meta.outputs.tags` is a newline-separated multi-line string (one tag per line). Splicing it directly into a `run:` script via `${{ }}` (`for tag in ${{ steps.meta.outputs.tags }}; do`) inserts *literal newlines* into the shell script's source text, not into a shell variable's value — breaking the `for ... in <list>; do` clause across multiple raw lines. The build-backend job failed as a result, so `tf-plan`/`deploy` were correctly skipped (gated on `build-backend` not failing) — **the fixed image from #920 was never actually pushed to ACR or deployed.** Prod is still on whatever revision was live before, likely still crash-looping.

## Fix

- "Push backend image" step: route the tags through `env: TAGS: ${{ steps.meta.outputs.tags }}` (GitHub Actions passes multi-line `env:` values safely, unlike raw expression substitution) and iterate with `while IFS= read -r tag; do ... done <<< "$TAGS"` instead of an unquoted `for tag in $TAGS`.
- "Smoke test" step: switched `IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)` to the same `TAGS` env var for consistency — that one happened to work today because it was quoted, but it's the same fragile pattern.

## Test plan

- [ ] `build-backend` job passes (smoke test + push, since this will run as a `push`/`workflow_run` event once merged, not a PR)
- [ ] Confirm the backend Container App comes up healthy after the next deploy (`curl https://api.voxquieta.org/health/live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013v3qc4wCQkSE7ZL7zfAfAR