### PR TITLE
feat(api): propagate request ID into SQL queries as a comment (BITB-008)

### DIFF
--- a/api/scripture/database.py
+++ b/api/scripture/database.py
@@ -12,6 +12,7 @@ from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from config import settings
+from middleware.context import REQUEST_ID_CTX_VAR
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,30 @@ def _apply_session_hnsw_ef_search(dbapi_connection, connection_record):
             cursor.close()
     except Exception:  # noqa: BLE001 - never let this take down a connection
         logger.warning("Failed to set hnsw.ef_search on new connection", exc_info=True)
+
+
+def _prepend_request_id_comment(statement: str) -> str:
+    """Prefix ``statement`` with a ``/* request_id=... */`` SQL comment.
+
+    Lets a slow or stuck query be matched back to the request that issued it
+    via ``pg_stat_activity``/server logs. The id may come from a client-supplied
+    ``X-Request-ID`` header (see ``CorrelationIDMiddleware``), so it is
+    sanitized to prevent breaking out of the comment.
+    """
+    request_id = REQUEST_ID_CTX_VAR.get("")
+    if not request_id:
+        return statement
+    safe_id = request_id.replace("*/", "").replace("\n", " ")
+    return f"/* request_id={safe_id} */ {statement}"
+
+
+@event.listens_for(engine.sync_engine, "before_cursor_execute", retval=True)
+def _tag_query_with_request_id(conn, cursor, statement, parameters, context, executemany):
+    # Note: making every statement string unique defeats asyncpg's prepared-statement
+    # cache (keyed on SQL text), trading a per-query re-parse for traceability. Given
+    # this app's read-mostly, low-QPS load, shipping as-is; revisit if profiling shows
+    # a regression.
+    return _prepend_request_id_comment(statement), parameters
 
 
 # Session factory

--- a/api/tests/test_db_request_id_comment.py
+++ b/api/tests/test_db_request_id_comment.py
@@ -1,0 +1,58 @@
+"""
+Tests for the request-ID SQL comment tagging in scripture.database.
+
+Verifies that:
+- Queries issued during a request get a `/* request_id=... */` comment prefix
+- No comment is added when there is no active request ID
+- A malicious request ID cannot break out of the SQL comment
+"""
+
+from middleware.context import REQUEST_ID_CTX_VAR
+from scripture.database import _prepend_request_id_comment
+
+
+class TestPrependRequestIdComment:
+    """Test suite for _prepend_request_id_comment."""
+
+    def test_adds_comment_when_request_id_set(self):
+        """A statement is prefixed with the active request ID."""
+        token = REQUEST_ID_CTX_VAR.set("test-request-123")
+        try:
+            result = _prepend_request_id_comment("SELECT 1")
+            assert result == "/* request_id=test-request-123 */ SELECT 1"
+        finally:
+            REQUEST_ID_CTX_VAR.reset(token)
+
+    def test_no_comment_when_request_id_unset(self):
+        """The statement is returned unchanged when no request ID is active."""
+        result = _prepend_request_id_comment("SELECT 1")
+        assert result == "SELECT 1"
+
+    def test_no_comment_when_request_id_empty(self):
+        """An explicitly empty request ID is treated as absent."""
+        token = REQUEST_ID_CTX_VAR.set("")
+        try:
+            result = _prepend_request_id_comment("SELECT 1")
+            assert result == "SELECT 1"
+        finally:
+            REQUEST_ID_CTX_VAR.reset(token)
+
+    def test_sanitizes_comment_breakout(self):
+        """A request ID containing `*/` cannot terminate the comment early."""
+        token = REQUEST_ID_CTX_VAR.set("evil*/ DROP TABLE users; --")
+        try:
+            result = _prepend_request_id_comment("SELECT 1")
+            assert "*/" not in result.split(" */ ", 1)[0]
+            assert result.startswith("/* request_id=evil DROP TABLE users; -- */ SELECT 1")
+        finally:
+            REQUEST_ID_CTX_VAR.reset(token)
+
+    def test_sanitizes_newlines(self):
+        """Newlines in the request ID cannot inject additional SQL lines."""
+        token = REQUEST_ID_CTX_VAR.set("abc\n--comment")
+        try:
+            result = _prepend_request_id_comment("SELECT 1")
+            assert "\n" not in result
+            assert result == "/* request_id=abc --comment */ SELECT 1"
+        finally:
+            REQUEST_ID_CTX_VAR.reset(token)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1670,9 +1670,9 @@ because it's data work gated behind BITB-043's eval set, not a live regression.
 
 ---
 
-### 🎯 BITB-008: Add Request Tracing with Correlation IDs
+### ✅ BITB-008: Add Request Tracing with Correlation IDs
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done
 **Size:** S
 
 **As a** developer debugging production issues,
@@ -1681,11 +1681,13 @@ because it's data work gated behind BITB-043's eval set, not a live regression.
 
 **Acceptance Criteria:**
 
-- [ ] Middleware generates UUID for each request
-- [ ] `X-Request-ID` header added to all responses
-- [ ] Trace ID logged in every log entry for that request
-- [ ] Trace ID propagated to database queries (as SQL comment)
-- [ ] Documentation includes how to search logs by trace ID
+- [x] Middleware generates UUID for each request (`api/middleware/correlation_id.py`)
+- [x] `X-Request-ID` header added to all responses, including error responses
+- [x] Trace ID logged in every log entry for that request (`api/utils/logging_config.py`)
+- [x] Trace ID propagated to database queries as a SQL comment (`before_cursor_execute` listener
+      in `api/scripture/database.py`)
+- [x] Documentation includes how to search logs by trace ID (`docs/TROUBLESHOOTING.md`,
+      "Tracing a single request by its correlation ID")
 
 **Tech Constraints:**
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -175,7 +175,7 @@ Organized by priority and category. Each item includes effort estimate and impac
 - **File**: `api/utils/logging_config.py`
 - **Issue**: Logs include session_id but no request_id/trace_id. Cannot trace a single request through the system.
 - **Fix**: Add request-id middleware that generates and propagates a unique ID per request.
-- **Effort**: S | **Impact**: High | **Status**: Open
+- **Effort**: S | **Impact**: High | **Status**: Done (BITB-008)
 
 ### 5.2 No Metrics / APM
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -545,6 +545,52 @@ BITB-065). If none fired, verify `TF_VAR_ALERT_EMAIL` / `TELEGRAM_CHAT_ID` are s
 
 ---
 
+### Tracing a single request by its correlation ID
+
+Every API response carries an `X-Request-ID` header (a client-supplied value is echoed back
+verbatim; otherwise the `CorrelationIDMiddleware` generates a UUID v4). Use it to pull every trace of
+that one request back out of logs, traces, and the database:
+
+- **Console / Container App logs** — every log line includes the ID in brackets
+  (`api/utils/logging_config.py`'s formatter: `... | [%(request_id)s] | <message>`):
+
+  ```bash
+  az containerapp logs show \
+    --name bible-app-backend --resource-group bible-app-rg --follow \
+    | grep '[<request-id>]'
+  ```
+
+- **Application Insights `traces`** — the same ID is attached to OTel spans as the `request_id`
+  attribute (`scripture/repository.py`), so it's queryable as a `customDimension`:
+
+  ```kusto
+  traces
+  | where customDimensions.request_id == "<request-id>"
+  | order by timestamp asc
+  ```
+
+  ```bash
+  az monitor app-insights query \
+    --app bible-app-insights --resource-group bible-app-rg \
+    --analytics-query "traces | where customDimensions.request_id == '<request-id>' | order by timestamp asc"
+  ```
+
+- **PostgreSQL** — every query issued during the request is tagged with a
+  `/* request_id=<id> */` SQL comment (a `before_cursor_execute` listener in
+  `scripture/database.py`), so a slow or stuck query can be matched back to the request via
+  `pg_stat_activity` or the server log:
+
+  ```sql
+  SELECT pid, state, query_start, query FROM pg_stat_activity
+  WHERE query LIKE '%request_id=<request-id>%';
+  ```
+
+**Where to get the ID:** it's returned in the response `X-Request-ID` header for every request
+(including error responses), so client-side logging/error reporting should capture it alongside any
+user-facing error message.
+
+---
+
 ## Getting Help
 
 If issues persist:


### PR DESCRIPTION
## Summary

BITB-008 ("Add Request Tracing with Correlation IDs") was already ~90% shipped — the
`CorrelationIDMiddleware`, `X-Request-ID` response header (including on error responses), and
per-log-entry request ID injection all already existed on `main`. This PR closes the two remaining
acceptance criteria:

- Propagate the request ID into every DB query as a `/* request_id=... */` SQL comment, via a
  `before_cursor_execute` SQLAlchemy event listener in `api/scripture/database.py` that reads the
  same `REQUEST_ID_CTX_VAR` contextvar the middleware already sets. This lets a slow/stuck query be
  matched back to the request that issued it via `pg_stat_activity` or the Postgres server log. The
  id is sanitized (`*/` and newlines stripped) since a client-supplied `X-Request-ID` is untrusted.
- Document how to trace a single request across logs, Application Insights, and Postgres in
  `docs/TROUBLESHOOTING.md` (new "Tracing a single request by its correlation ID" section under
  Production Incidents).

Also flips `docs/BACKLOG.md` BITB-008 and `docs/TASKS.md` #5.1 to Done — both were stale, showing
"Todo"/"Open" for work that was already merged.

**Known tradeoff (documented inline):** making every query string unique defeats asyncpg's
prepared-statement cache (keyed on SQL text), trading a per-query re-parse for traceability. Given
this app's read-mostly, low-QPS load this is expected to be negligible; flagged in code as something
to revisit if profiling shows a regression.

## Test plan

- [x] New unit tests (`api/tests/test_db_request_id_comment.py`) covering: comment added when a
      request ID is active, no comment when absent/empty, and sanitization of `*/`/newline
      breakout attempts.
- [x] Full backend test suite: `3657 passed, 18 skipped` (skips require a live Postgres/Ollama not
      available in this sandbox), no regressions.
- [x] `ruff`, `black --check`, `mypy`, and `pre-commit run --all-files` all pass on the changed
      files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmS3BcTjWjLFumdDSewbgB)_