### PR TITLE
docs(backlog): product review batch (BITB-075…081) — message limit, About page, UX fixes

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1874,11 +1874,19 @@ Chatbot"](https://ai4you.sh/posts/Building-Something-That-Matters-How-Claude-Cod
 is the foundation and canonical reference for the page. New static localized route at
 `/{locale}/about`, built like the existing `/app` page.
 
+The post's motivation is the mental-health one — "something simple, accessible, and deeply rooted in
+Scripture that could offer encouragement when someone needed it most. Not a replacement for therapy
+or pastoral care, but a gentle companion for moments of struggle." Note that the post describes
+**v1.0** and is now stale on the name, the stack and the language list (see the story's *Source
+Material* section): it is the origin story to adapt, not text to transcribe.
+
 **Acceptance Criteria (summary):**
 
 - [ ] `/{locale}/about` renders for all 11 locales, server-rendered and statically generated
 - [ ] Copy adapted from the ai4you.sh post, which is linked as the full story
 - [ ] States plainly what Vox Quieta is *not* (not pastoral care, not counseling)
+- [ ] Reflects the project as it is today; one sentence of continuity for the rename from
+      "Get Inspired by the Bible" to "Vox Quieta"
 - [ ] `About` namespace complete in all 11 `frontend/messages/*.json`; Arabic RTL correct
 - [ ] Linked from the footer **and** from the chat screen; added to `sitemap.ts` `PATHS`
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Prioritized list of user stories and features for Vox Quieta.
 
-**Last Updated:** 2026-07-21
+**Last Updated:** 2026-07-25
 
 **Verification Note (2026-04-20):** PR status reconciliation pass completed against GitHub.
 Confirmed merged PRs: #68, #171, #182, #191, #193, #194, #195, #196, #197, #208, #225, #226,
@@ -1217,6 +1217,94 @@ asset, `ChangelogEntry` model, and `MarkdownText` dependency (no new library).
 
 ---
 
+> **Product feature batch (maintainer, 2026-07-25) → BITB-075…081.**
+> Seven stories from a single product review: raise the message limit, an About page and
+> intro modal explaining why Vox Quieta exists, clarify-before-answering, the off-screen
+> web bottom bar, follow-up suggestion chips, and the Android example-tap fix.
+
+### 🎯 BITB-075: Raise the Chat Message Limit to 500 Characters (Single Source of Truth)
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hrs)
+**Created:** 2026-07-25
+
+**As a** user describing a real, complicated situation, **I want** to write up to 500 characters in
+one message, **so that** I can give enough context to get a useful answer instead of amputating my
+question to fit a 300-character box.
+
+**Why P1:** Raising the number also fixes a live production defect. The limit is hard-coded in five
+places that disagree: the deployed value is **200** (`deployment/terraform.tfvars:91`), the backend
+default is **300** (`api/config.py:180`), and both clients cap at **300**
+(`frontend/src/lib/api.ts:121`, `ChatViewModel.kt:173`). Today a 250-character message passes the
+input box, is rejected with a 422, and the error tells the user the limit is 300. Raising the number
+without fixing the drift just moves the bug.
+
+**Acceptance Criteria (summary):**
+
+- [ ] 500 accepted end-to-end (web + Android); 501 blocked client-side and rejected server-side
+- [ ] Every layer agrees — code default, Terraform, tfvars, env manifest, deployment README
+- [ ] `GET /config` publishes `chat.max_message_length`; clients use it, constant is fallback only
+- [ ] "Message too long" error and the character counter show the *effective* limit
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-075-raise-message-limit-to-500.md`
+
+---
+
+### 🎯 BITB-079: Web — the Bottom Bar Is Permanently Off Screen on the Chat Page
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hrs)
+**Created:** 2026-07-25
+
+**As a** web visitor, **I want** the bottom bar (Get the app / Privacy / Terms / Changelog) to be
+reachable from the chat page, **so that** I can get to the legal pages and the app link.
+
+**Why P1:** `layout.tsx:107-111` renders `<Footer />` *after* a `flex-1` slot, while
+`ChatIsland.tsx:938` gives the chat `h-dvh` — the full dynamic viewport. The footer therefore sits
+exactly one footer-height below the fold, and the chat's own `overflow-y-auto` scroller
+(`ChatIsland.tsx:1035`) swallows the gestures that would reach it. On mobile `100dvh` tracks the
+browser chrome, so it keeps sliding away. Privacy and Terms are legally required disclosures; a nav
+surface that never appears on screen is the same as not having one. Chat-page-only — short pages are
+unaffected.
+
+**Acceptance Criteria (summary):**
+
+- [ ] Footer links reachable without a document scroll at 360×640, 390×844, 768×1024, 1440×900
+- [ ] Composer stays visible with the mobile keyboard open; no horizontal scroll; RTL correct
+- [ ] Bottom region decrowded (collapsed contact form, one promo element at a time)
+- [ ] Playwright viewport regression test — a unit test cannot catch this
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-079-web-bottom-bar-always-offscreen.md`
+
+---
+
+### 🎯 BITB-081: Android — Tapping an Example Question Must Send on the First Tap
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hrs)
+**Created:** 2026-07-25
+
+**As an** Android user tapping an example question on the welcome screen, **I want** it sent
+immediately, **so that** I get an answer from one tap instead of finding the text silently pasted
+into the composer.
+
+**Why P1:** This is the app's first interaction. `ChatScreen.kt:370-382` only sends when
+`isTurnstileReady` is true — which on a cold start it usually is not while the welcome screen is
+showing — so the tap becomes a silent paste with no feedback. The guard is unnecessary:
+`TurnstileInterceptor` already waits for a token, proceeds without one, and retries once on 403
+(`TurnstileInterceptor.kt:28-79`). Web already sends on tap.
+
+**Acceptance Criteria (summary):**
+
+- [ ] Tapping an example on a cold start (no token yet) sends and starts streaming
+- [ ] Tapped text never remains in the input field; no second tap ever needed
+- [ ] Failures surface the normal error state — never silence
+- [ ] Compose UI test with `isTurnstileReady = false` asserts `sendMessage` is invoked
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-081-android-example-prompt-sends-on-tap.md`
+
+---
+
 ## P2 - Medium Priority (Backlog)
 
 > **Beta-tester feedback batch (Oliver Osthoever, 2026-06-11/12) → BITB-045…050.**
@@ -1767,6 +1855,119 @@ Developer Program Policy before shipping).
       gated behind the donation
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-074-support-us-funding.md`
+
+---
+
+### 🎯 BITB-076: "About" Page — Why Vox Quieta Exists
+
+**Status:** 🎯 Todo
+**Size:** M (1–2 days, mostly copywriting + 11 locales)
+**Created:** 2026-07-25
+
+**As a** visitor who has just found Vox Quieta, **I want** to read who built this and why, **so
+that** I can decide whether to trust a chatbot with something as personal as my faith and my grief.
+
+The site answers "what are you doing with my data" (privacy, terms) but never "why does this exist
+and who made it" — the question that actually earns the first message. The motivation is already
+written: **["Building Something That Matters: How Claude Code Helped Me Create a Bible Inspiration
+Chatbot"](https://ai4you.sh/posts/Building-Something-That-Matters-How-Claude-Code-Helped-Me-Create-a-Bible-Inspiration-Chatbot/)**
+is the foundation and canonical reference for the page. New static localized route at
+`/{locale}/about`, built like the existing `/app` page.
+
+**Acceptance Criteria (summary):**
+
+- [ ] `/{locale}/about` renders for all 11 locales, server-rendered and statically generated
+- [ ] Copy adapted from the ai4you.sh post, which is linked as the full story
+- [ ] States plainly what Vox Quieta is *not* (not pastoral care, not counseling)
+- [ ] `About` namespace complete in all 11 `frontend/messages/*.json`; Arabic RTL correct
+- [ ] Linked from the footer **and** from the chat screen; added to `sitemap.ts` `PATHS`
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-076-about-page-motivation.md`
+
+---
+
+### 🎯 BITB-077: "Why Vox Quieta" Intro Modal — Once for Everyone Now, New Visitors Afterwards
+
+**Status:** 🎯 Todo
+**Size:** S (< 4 hrs, after BITB-076)
+**Created:** 2026-07-25
+**Blocked by:** BITB-076
+
+**As a** person opening Vox Quieta, **I want** a short, dismissible introduction explaining who made
+this and why, **so that** I know what I am talking to before typing something personal into it.
+
+A page nobody clicks changes nothing, so the new message warrants one deliberate interruption — then
+it belongs in the onboarding path only. Both halves of the mechanism already exist in the repo: the
+one-time splash cookie (`providers.tsx:13-24`) and the show-once-per-version localStorage gate with
+silent first-visit seeding (`WhatsNewModal.tsx:33-40`). A single versioned
+`vq:aboutIntroSeen` key gives "everyone now, new visitors later" for free.
+
+**Acceptance Criteria (summary):**
+
+- [ ] Every visitor sees it exactly once after deploy; dismissal persists forever
+- [ ] Never stacked on `SplashScreen` or `WhatsNewModal`; appears after the splash completes
+- [ ] Copy from the `About` namespace in all 11 locales; primary action opens `/about`
+- [ ] No SSR/CSR hydration mismatch (see BITB-069); keyboard accessible
+- [ ] Bumping the version constant re-shows it — proven by a test
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-077-about-intro-modal.md`
+
+---
+
+### 🎯 BITB-078: Ask Before Answering — Clarify a Vague Request Instead of Guessing
+
+**Status:** 🎯 Todo
+**Size:** M (1–2 days, prompt work + eval)
+**Created:** 2026-07-25
+
+**As a** user who types something short and raw like "I'm lost", **I want** the companion to ask one
+gentle question about what I'm facing, **so that** the answer speaks to my actual situation instead
+of whatever the model guessed.
+
+The worst failure mode for this product is sounding caring while addressing someone else's problem.
+The instruction exists (`SYSTEM_PROMPT_TEMPLATE`, "## When the Request Is Unclear") but is
+outweighed: "## Your Role" step 2 reads as an unconditional order to bring in a verse, the per-intent
+addenda reinforce it, and scripture context is already retrieved and injected before the model is
+asked whether it understood the question. This makes clarification a first-class intent
+(`NEEDS_CLARIFICATION`) that skips retrieval, capped at one question per conversation.
+
+**Acceptance Criteria (summary):**
+
+- [ ] Vague openings get a warm one-question reply with no verse citation; search is skipped
+- [ ] At most one clarifying question per conversation; specific messages never trigger one
+- [ ] Never asked for verse lookups or `compassionate_response_needed` (crisis) turns
+- [ ] Works across en/it/de/es; clarification rate logged so rollout can be judged
+- [ ] Vague-opening cases added to the retrieval-eval harness (BITB-051)
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md`
+
+---
+
+### 🎯 BITB-080: Suggested Follow-Up Questions as One-Tap Buttons Under Each Answer
+
+**Status:** 🎯 Todo
+**Size:** M (1–2 days, backend + web + Android)
+**Created:** 2026-07-25
+
+**As a** user who has just read an answer, **I want** two or three suggested next questions offered
+as buttons, **so that** I can keep exploring without working out what to ask — or typing it on a
+phone.
+
+The welcome screen already proves the pattern works (tap a starter prompt, it sends), and it
+disappears exactly when the user has the most to explore. The streaming `completion` event is the
+natural carrier: it already grew `resolved_verses` and `corrections` as optional fields that older
+clients ignore (`service.py:1375-1386`). v1 generates follow-ups in-prompt via a machine-readable
+trailer, mirroring the existing `<!-- VERSES: -->` mechanism — no extra call, no extra latency.
+
+**Acceptance Criteria (summary):**
+
+- [ ] 2–3 chips under the **latest** assistant message only, in the user's language; tap sends
+- [ ] Suppressed for off-topic, crisis-flagged and error turns; trailer never leaks into the answer
+- [ ] Clients on an older backend are unaffected (absent field renders nothing)
+- [ ] Shares one chip component with BITB-078; accessible on web and Android
+- [ ] Interaction with the 10-message session limit (BITB-024) checked before rollout
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-080-suggested-followup-questions.md`
 
 ---
 

--- a/docs/BACKLOG_STORIES/BITB-075-raise-message-limit-to-500.md
+++ b/docs/BACKLOG_STORIES/BITB-075-raise-message-limit-to-500.md
@@ -1,0 +1,135 @@
+# BITB-075: Raise the Chat Message Limit to 500 Characters (and Make It a Single Source of Truth)
+
+**Status:** 🎯 Todo
+**Priority:** P1
+**Size:** S (< 4 hrs)
+**Created:** 2026-07-25
+
+## User Story
+
+**As a** user describing a real, complicated situation,
+**I want** to write up to 500 characters in one message,
+**so that** I can give enough context to get a useful answer instead of having to amputate my
+question to fit an arbitrary 300-character box.
+
+## Why
+
+300 characters is roughly three sentences. The people this app is for — someone in grief, someone
+facing a hard decision — routinely need more than three sentences to say what is actually going on.
+Truncating them costs exactly the context the retrieval and the LLM need to answer well (which is
+also what **BITB-078** is about: better context in, better answer out).
+
+**A second problem surfaces while doing this.** The limit is currently hard-coded in *five* places
+that already disagree with each other:
+
+| Layer | Value | Location |
+|---|---|---|
+| Backend default | **300** | `api/config.py:180` |
+| **Deployed production value** | **200** | `deployment/terraform.tfvars:91` (→ `MAX_MESSAGE_LENGTH` env var via `deployment/main.tf:107-108`) |
+| Terraform variable default | **200** | `deployment/variables.tf:404-408` |
+| Env manifest default | **200** | `scripts/env-manifest.yaml:154-157` |
+| Web client | **300** | `frontend/src/lib/api.ts:121` |
+| Android client | **300** | `android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt:173` |
+
+So in production today the server rejects at **200** while both clients happily let the user type
+**300** and display "max 300 characters" in the error. A 250-character message is accepted by the
+input box, sent, rejected with HTTP 422, and reported back to the user with a limit number that is
+wrong. Raising the number without fixing the drift just moves the bug.
+
+## Current Behaviour
+
+- `api/chat/service.py:95` — `message: str = Field(..., min_length=1, max_length=settings.max_message_length)`;
+  over-length messages produce a 422 whose `detail[].msg` reads
+  `String should have at most N characters`.
+- `frontend/src/lib/api.ts:118-121` — `MAX_MESSAGE_LENGTH = 300`, documented as mirroring
+  `api/config.py`, but not actually fetched from the backend.
+- `frontend/src/app/[locale]/ChatIsland.tsx:1180` caps the textarea via `maxLength`; `:1208-1217`
+  renders the counter from 80% of the limit; `:738` shows
+  `Chat.messageTooLong` (`frontend/messages/en.json:131`) with `{max}` interpolated from the
+  client constant.
+- Android: `ChatViewModel.kt:173` (constant, with a comment saying it mirrors the backend),
+  `ChatInputField.kt:37` (`maxLength: Int = 300` default), `ChatScreen.kt:545` (passes the
+  constant), `ChatViewModel.kt:1213` (error string `error_message_too_long`,
+  `android/app/src/main/res/values/strings.xml:190`).
+- `GET /config` (`api/main.py:368-406`) already returns a `chat` block
+  (`max_context_verses`, `max_conversation_history`) but **not** `max_message_length` — the natural
+  place to publish it.
+
+## Proposed Behaviour
+
+1. **Raise the limit to 500** everywhere the number lives:
+   - `api/config.py:180` → `max_message_length: int = 500`
+   - `deployment/variables.tf:404-408` default → `500`
+   - `deployment/terraform.tfvars:91` and `deployment/terraform.tfvars.example:153` → `500`
+   - `deployment/README.md:804,815` table/example → `500`
+   - `scripts/env-manifest.yaml:154-157` default → `"500"`
+2. **Publish the effective limit** from the backend: add `"max_message_length": settings.max_message_length`
+   to the `chat` block of `GET /config`.
+3. **Make the clients follow the server.** Keep the hard-coded constant only as a *fallback* for
+   before `/config` resolves (and bump it to 500 so the fallback is not itself a lie):
+   - Web: read the value in the existing config path and thread it through `ChatIsland` (textarea
+     `maxLength`, counter threshold, `messageTooLong` interpolation) instead of importing the
+     constant directly.
+   - Android: expose it on `ChatUiState`, seeded from `MAX_MESSAGE_LENGTH` and updated once
+     `/config` is read; `ChatInputField` and the error string use the state value.
+4. Verify the LLM prompt/token budget still holds at 500 characters — the message is embedded in the
+   search query and the chat history summary (`api/chat/prompts.py`, history truncated at 200 chars
+   per turn around `prompts.py:630`), so no prompt-size regression is expected, but it should be
+   checked rather than assumed.
+
+**Deliberately out of scope:** a fully dynamic per-locale limit, and any change to the *contact
+form* message limit (a separate field with its own validation — see BITB-051/BITB-052).
+
+## Acceptance Criteria
+
+- [ ] A 500-character chat message is accepted end-to-end (web and Android) against a backend
+      running the new default.
+- [ ] A 501-character message is prevented client-side (input cap) and, if it somehow reaches the
+      API, rejected with 422.
+- [ ] Production configuration (`terraform.tfvars`) and the code default agree; no layer still says
+      200 or 300.
+- [ ] `GET /config` returns `chat.max_message_length`.
+- [ ] Web and Android use the server-published value when available, and the compiled-in constant
+      only as a pre-config fallback.
+- [ ] The "message too long" error shows the *effective* limit, not a stale constant.
+- [ ] Character counter still appears at 80% of the effective limit and turns red at the limit.
+
+## Tests to Add / Update
+
+- `api/tests/test_security.py:55,63` — already derives from `settings.max_message_length`; confirm
+  it still passes and add an explicit 500-boundary case.
+- New API test: `GET /config` includes `chat.max_message_length`.
+- `frontend/src/lib/api.test.ts:1075` — the 422 fixture asserts the literal string
+  `"String should have at most 300 characters"`; update, and prefer asserting on the error *type*
+  rather than the copy.
+- `frontend/src/app/[locale]/page.test.tsx:36` — mock currently pins `MAX_MESSAGE_LENGTH: 300`.
+- Android: `ChatViewModel` test for the 500 boundary and for the error message rendering the
+  effective limit.
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `api/config.py` | Default 300 → 500 |
+| `api/main.py` | Publish `chat.max_message_length` on `/config` |
+| `deployment/variables.tf`, `deployment/terraform.tfvars{,.example}`, `deployment/README.md` | 200 → 500 |
+| `scripts/env-manifest.yaml` | Default "200" → "500" |
+| `frontend/src/lib/api.ts` | Fallback constant → 500; read limit from `/config` |
+| `frontend/src/app/[locale]/ChatIsland.tsx` | Use the effective limit for cap, counter, error |
+| `android/.../ChatViewModel.kt`, `ChatInputField.kt`, `ChatScreen.kt` | Effective limit via UI state |
+| tests as listed above | Boundary + config tests |
+
+## Risks
+
+- **Cost/latency:** longer messages mean slightly larger embeddings and prompts. 500 chars is still
+  small relative to the scripture context block; impact should be negligible but is worth a glance
+  at the chat stage timings after rollout (`docs/HOW-TO-READ-CHAT-STAGE-TIMINGS.md`).
+- **Abuse surface:** the limit is one of the abuse controls (BITB-061). 500 is still a tight bound;
+  rate limiting and the session lifetime limit remain the primary defenses.
+
+## Related
+
+- **BITB-078** — clarifying questions; both stories are about getting enough context to answer well.
+- **BITB-061** — fail-closed abuse controls (message length is one of them).
+- **BITB-051 / BITB-052** — contact-form length/email errors (different field, same class of bug:
+  client and server disagreeing about a limit).

--- a/docs/BACKLOG_STORIES/BITB-076-about-page-motivation.md
+++ b/docs/BACKLOG_STORIES/BITB-076-about-page-motivation.md
@@ -1,0 +1,114 @@
+# BITB-076: "About" Page — Why Vox Quieta Exists
+
+**Status:** 🎯 Todo
+**Priority:** P2
+**Size:** M (1–2 days, mostly copywriting + 11 locales)
+**Created:** 2026-07-25
+
+## User Story
+
+**As a** visitor who has just found Vox Quieta,
+**I want** to read who built this and why,
+**so that** I can decide whether to trust a chatbot with something as personal as my faith and my
+grief.
+
+## Why
+
+Vox Quieta asks people to type the hardest thing in their life into a text box. Right now the site
+gives them no reason to believe anyone is behind it. There is a privacy policy, terms, a changelog
+and a Play Store link — all of which answer *"what are you doing with my data"* — and nothing that
+answers *"why does this exist and who made it"*. For a spiritual-support product that second
+question is the one that actually earns the message.
+
+The motivation is already written down. The author published it as:
+
+> **"Building Something That Matters: How Claude Code Helped Me Create a Bible Inspiration Chatbot"**
+> <https://ai4you.sh/posts/Building-Something-That-Matters-How-Claude-Code-Helped-Me-Create-a-Bible-Inspiration-Chatbot/>
+
+That post is the **foundation and the canonical reference** for this page: the About page adapts it
+for a first-time visitor (short, personal, non-technical) and links out to the full post for anyone
+who wants the whole story, including how it was built.
+
+> **Note for whoever implements this:** the post could not be fetched from the CI/agent sandbox
+> (the egress proxy returns 403 for `ai4you.sh`), so the copy below is a *structure* to fill, not a
+> transcription. Open the post, take the author's own words, and adapt them — do not let an LLM
+> invent a founder story. Anything personal (the origin moment, the "why this matters" passage)
+> must come from the post or from the author directly.
+
+## Proposed Behaviour
+
+A new static, server-rendered, localized page at `/{locale}/about`, built exactly like the existing
+`/app` page (`frontend/src/app/[locale]/app/page.tsx`): `generateStaticParams` over
+`routing.locales`, `generateMetadata` via `pageMetadata` from `@/lib/seo`, copy from a new `About`
+translation namespace.
+
+**Suggested section outline** (each a key group in the `About` namespace):
+
+1. **Hero** — one sentence on what Vox Quieta is, in plain language.
+2. **Why this exists** — the personal motivation, adapted from the post. First person, short
+   paragraphs.
+3. **What it does / what it is not** — grounded in scripture, multilingual, free; explicitly *not*
+   a pastor, not a therapist, not a replacement for a church community. This mirrors the disclaimer
+   the chat already shows (`Chat.disclaimer`) and the boundaries in the system prompt
+   (`api/chat/prompts.py`, "## Boundaries").
+4. **How it was built** — brief, honest note that it is an open-source side project built with AI
+   assistance, linking the repo and the original post.
+5. **Read the full story** — prominent outbound link to the ai4you.sh post.
+6. **Get in touch / support** — link to the existing contact form and, once **BITB-074** lands, the
+   support link.
+
+**Entry points:**
+
+- `Footer.tsx` gets an "About" link (alongside Get app / Privacy / Terms / Changelog).
+- The main-menu / welcome area on the chat screen links to it — this is the surface most visitors
+  actually see.
+- `frontend/src/app/sitemap.ts` — add `/about` to `PATHS` (line 8) so all 11 locales are indexed.
+
+**Localization:** the `About` namespace must exist in all 11 locale files
+(`frontend/messages/{en,it,de,es,fr,pt,ar,ru,zh,hi,ko}.json`, per `frontend/src/i18n/routing.ts`).
+Arabic must read correctly RTL — the layout already sets `dir` at the `<html>` level
+(`frontend/src/app/[locale]/layout.tsx`).
+
+## Acceptance Criteria
+
+- [ ] `/{locale}/about` renders for all 11 locales, server-rendered and statically generated.
+- [ ] Page copy is adapted from the ai4you.sh post and links to it explicitly as the full story.
+- [ ] Page states plainly what Vox Quieta is *not* (not pastoral care, not counseling, not a
+      substitute for a faith community).
+- [ ] `About` namespace present and complete in all 11 `frontend/messages/*.json` files.
+- [ ] Reachable from the footer **and** from the chat screen (menu or welcome area).
+- [ ] `/about` added to `frontend/src/app/sitemap.ts` `PATHS`, with hreflang alternates (handled
+      automatically by the existing mapping).
+- [ ] Unique `metaTitle` / `metaDescription` per locale via `pageMetadata` — no duplicate-title
+      warning from the SEO audit (`/seo-audit`).
+- [ ] Arabic renders RTL without layout breakage.
+
+## Tests to Add
+
+- `frontend/src/app/[locale]/about/page.test.tsx` — renders headings and the outbound post link
+  (mirror the existing `/app` page tests).
+- Sitemap test asserting `/about` appears once per locale.
+- The repo's message-completeness check (all locales carry the same key set) must cover the new
+  namespace.
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `frontend/src/app/[locale]/about/page.tsx` | **New** — the page |
+| `frontend/messages/*.json` (11) | **New** `About` namespace |
+| `frontend/src/components/Footer.tsx` | "About" link |
+| `frontend/src/app/[locale]/ChatIsland.tsx` / `MainMenu.tsx` | In-app entry point |
+| `frontend/src/app/sitemap.ts` | Add `/about` to `PATHS` |
+
+## Out of Scope
+
+- Android. The Android app should eventually link to the same page from Settings → About; file as a
+  follow-up rather than widening this story.
+- Any re-hosting of the blog post's full text. Link to it; do not copy it wholesale.
+
+## Related
+
+- **BITB-077** — the first-run modal that surfaces this page's message to existing users.
+- **BITB-074** — "Support us" entry points; the About page is the natural home for that ask.
+- **BITB-037** — SEO follow-ups (server-rendered pages, metadata, OG image).

--- a/docs/BACKLOG_STORIES/BITB-076-about-page-motivation.md
+++ b/docs/BACKLOG_STORIES/BITB-076-about-page-motivation.md
@@ -23,17 +23,66 @@ question is the one that actually earns the message.
 The motivation is already written down. The author published it as:
 
 > **"Building Something That Matters: How Claude Code Helped Me Create a Bible Inspiration Chatbot"**
+> — ai4you.sh, 7 February 2026
 > <https://ai4you.sh/posts/Building-Something-That-Matters-How-Claude-Code-Helped-Me-Create-a-Bible-Inspiration-Chatbot/>
 
 That post is the **foundation and the canonical reference** for this page: the About page adapts it
 for a first-time visitor (short, personal, non-technical) and links out to the full post for anyone
 who wants the whole story, including how it was built.
 
-> **Note for whoever implements this:** the post could not be fetched from the CI/agent sandbox
-> (the egress proxy returns 403 for `ai4you.sh`), so the copy below is a *structure* to fill, not a
-> transcription. Open the post, take the author's own words, and adapt them — do not let an LLM
-> invent a founder story. Anything personal (the origin moment, the "why this matters" passage)
-> must come from the post or from the author directly.
+## Source Material (from the post)
+
+The parts that belong on an About page — the *why*, not the build log:
+
+**The origin.** "Have you ever had an idea that just wouldn't leave you alone?" The motivation is
+stated plainly:
+
+> "Depression and mental health struggles affect so many people — young and old alike. I wanted to
+> create something simple, accessible, and deeply rooted in Scripture that could offer
+> encouragement when someone needed it most. Not a replacement for therapy or pastoral care, but a
+> gentle companion for moments of struggle."
+
+**The scope, deliberately narrow.**
+
+> "It's not trying to be everything. It's trying to be one thing done well: a place to find hope and
+> inspiration when you need it."
+
+**Why a human still matters** (from "The Human Element (Still Essential)" — vision, quality
+control, purpose):
+
+> "Technology is just a tool. The 'why' behind this project — the empathy for people struggling
+> with mental health, the desire to offer hope — that's entirely human."
+
+**What the author actually wanted out of it.**
+
+> "But honestly? I'm just happy it exists. It's out there. Someone having a rough day can visit
+> that URL and find encouragement. That's what matters."
+
+**Also usable:** the project is open source (repo linked from the post), it was built with AI
+assistance by someone who is "not a professional frontend developer", and the author explicitly
+invites feedback ("What worked? What could be better? What would make it more helpful?") — which
+pairs naturally with the existing contact form.
+
+### ⚠️ The post is a year old — adapt, do not transcribe
+
+The post describes **v1.0** and several of its specifics are now wrong. The About page must not
+repeat them:
+
+| The post says | Reality today |
+|---|---|
+| Named "Get Inspired by the Bible", at `getinspiredbythebible.ai4you.sh` | **Vox Quieta**, at `voxquieta.org` (repo name unchanged) |
+| "Clean HTML/CSS/JavaScript interface", "simple API" | Next.js App Router frontend, FastAPI backend, PostgreSQL + pgvector semantic search |
+| Web only | Web **and** a published Android app |
+| Bible in English, German, Italian; "more to come" (listed under *What's Next*) | 11 UI locales; multiple translations per language |
+| — | Content-safety pipeline, Turnstile, verse-citation grounding, church finder |
+
+Treat the post as the **origin story**, and let the About page say plainly that the project has
+grown since — the rename in particular needs one sentence of continuity, since a reader arriving
+from the post will be looking for a name that no longer appears on the site. The "What's Next" list
+in the post is largely *done*; do not restate it as a roadmap.
+
+Everything personal on the page must trace back to the post above or to the author directly — do
+not let an LLM extend the founder story with invented detail.
 
 ## Proposed Behaviour
 
@@ -44,18 +93,25 @@ translation namespace.
 
 **Suggested section outline** (each a key group in the `About` namespace):
 
-1. **Hero** — one sentence on what Vox Quieta is, in plain language.
-2. **Why this exists** — the personal motivation, adapted from the post. First person, short
-   paragraphs.
-3. **What it does / what it is not** — grounded in scripture, multilingual, free; explicitly *not*
-   a pastor, not a therapist, not a replacement for a church community. This mirrors the disclaimer
-   the chat already shows (`Chat.disclaimer`) and the boundaries in the system prompt
-   (`api/chat/prompts.py`, "## Boundaries").
-4. **How it was built** — brief, honest note that it is an open-source side project built with AI
-   assistance, linking the repo and the original post.
-5. **Read the full story** — prominent outbound link to the ai4you.sh post.
-6. **Get in touch / support** — link to the existing contact form and, once **BITB-074** lands, the
-   support link.
+1. **Hero** — one sentence on what Vox Quieta is, in plain language. The post's own framing is the
+   strongest candidate: *a place to find hope and inspiration when you need it*.
+2. **Why this exists** — the mental-health motivation, first person, two or three short paragraphs
+   adapted from the origin passage above. This is the section that earns the first message; it
+   should read like a person, not a mission statement.
+3. **What it is not** — "not a replacement for therapy or pastoral care, but a gentle companion for
+   moments of struggle" is the author's own line and already the right one. Reinforce with: not a
+   pastor, not a therapist, not a substitute for a faith community. Consistent with the disclaimer
+   the chat already shows (`Chat.disclaimer`) and the "## Boundaries" section of the system prompt
+   (`api/chat/prompts.py`).
+4. **What it does now** — grounded in scripture with visible verse references, 11 languages, on the
+   web and Android, free. This is the section that carries the "it has grown since the post" note,
+   including the rename from *Get Inspired by the Bible* to *Vox Quieta*.
+5. **Built by one person, with AI help** — short and honest: an open-source side project, built
+   with Claude Code by someone who is not a frontend developer, because the idea "wouldn't leave
+   me alone". Link the GitHub repo. Keep the build details to a sentence — the post covers them.
+6. **Read the full story** — prominent outbound link to the ai4you.sh post.
+7. **Get in touch / support** — the author explicitly asks for feedback in the post; link the
+   existing contact form and, once **BITB-074** lands, the support link.
 
 **Entry points:**
 
@@ -74,7 +130,10 @@ Arabic must read correctly RTL — the layout already sets `dir` at the `<html>`
 - [ ] `/{locale}/about` renders for all 11 locales, server-rendered and statically generated.
 - [ ] Page copy is adapted from the ai4you.sh post and links to it explicitly as the full story.
 - [ ] Page states plainly what Vox Quieta is *not* (not pastoral care, not counseling, not a
-      substitute for a faith community).
+      substitute for a faith community) — the post's own framing.
+- [ ] The page reflects the project **as it is today**, not the post's v1.0 description: no stale
+      stack, no stale language list, and one sentence of continuity covering the rename from
+      "Get Inspired by the Bible" to "Vox Quieta" for readers arriving from the post.
 - [ ] `About` namespace present and complete in all 11 `frontend/messages/*.json` files.
 - [ ] Reachable from the footer **and** from the chat screen (menu or welcome area).
 - [ ] `/about` added to `frontend/src/app/sitemap.ts` `PATHS`, with hreflang alternates (handled

--- a/docs/BACKLOG_STORIES/BITB-077-about-intro-modal.md
+++ b/docs/BACKLOG_STORIES/BITB-077-about-intro-modal.md
@@ -1,0 +1,118 @@
+# BITB-077: "Why Vox Quieta" Intro Modal — Once for Everyone Now, New Visitors Afterwards
+
+**Status:** 🎯 Todo
+**Priority:** P2
+**Size:** S (< 4 hrs, after BITB-076)
+**Created:** 2026-07-25
+
+## User Story
+
+**As a** person opening Vox Quieta,
+**I want** a short, dismissible introduction explaining who made this and why,
+**so that** I know what I am talking to before I type something personal into it.
+
+**As the** maintainer,
+**I want** every current user to see it once when it ships, and only first-time visitors to see it
+after that,
+**so that** the announcement reaches the existing audience without nagging them forever.
+
+## Why
+
+**BITB-076** puts the motivation on an `/about` page — but a page nobody clicks changes nothing.
+The message is new, so it warrants one deliberate interruption; after that it belongs in the
+onboarding path only.
+
+The repo already contains both halves of the mechanism, and one of them is currently dead code:
+
+- **A "show once ever" gate**: the splash cookie in `frontend/src/app/[locale]/providers.tsx:13-24`
+  (`splash_seen=1`, 1-year max-age) gating `SplashScreen` at `:88-98`. Note the deliberate
+  hydration-safe pattern documented there (seed `false` on both server and client, read the cookie
+  in an effect) — see **BITB-069** for what happens if that is done naively.
+- **A "show once per version" gate**: `frontend/src/components/WhatsNewModal.tsx` — `localStorage`
+  key `vq:lastSeenVersion`, and at `:33-40` it *silently records* the version on a first-ever visit
+  so newcomers are not shown a changelog they have no context for. That component is rendered in
+  `frontend/src/app/[locale]/layout.tsx:111`, but the codebase contains no other reference to it —
+  it is effectively the pattern to copy, and worth confirming it is actually reachable in
+  production while working here.
+
+This story needs the *union* of those two behaviours, which is neither one exactly.
+
+## Proposed Behaviour
+
+A dismissible modal — `AboutIntroModal` — showing a condensed version of the About copy
+(2–3 short paragraphs from the `About` namespace), with:
+
+- a primary action → `/{locale}/about` (the full page),
+- a secondary "Continue" / close action,
+- an accessible dialog shell (`role="dialog"`, `aria-modal`, focus trap, Esc to close), modelled on
+  `WhatsNewModal.tsx:62-90`.
+
+**Display rule** — a single `localStorage` key, e.g. `vq:aboutIntroSeen`, holding a **version
+string** (`"1"` for this rollout):
+
+| Visitor | Key state on load | Behaviour |
+|---|---|---|
+| Existing user (has `splash_seen` cookie or any prior local state) | key absent | **Show once**, then write `"1"` |
+| Brand-new visitor, first ever load | key absent, no prior state | Show once, then write `"1"` |
+| Anyone who has already dismissed it | key `= "1"` | Never show again |
+| Future rollout with materially new content | key `< "2"` | Show again (bump the constant deliberately, not on every release) |
+
+In other words: *"all users now, new users later"* falls out of a one-time key that is written on
+dismissal. The distinction the user asked for — everyone now, new visitors afterwards — is
+satisfied because after the rollout window the only people without the key are new visitors.
+
+**Sequencing with the existing splash.** The animated `SplashScreen` runs first on a cold visit.
+The intro modal must appear **after** the splash completes (i.e. gate it on `splashDone` in
+`providers.tsx`), never stacked on top of it. It should also not collide with `WhatsNewModal`: if
+both would fire on the same load, show the intro modal and defer "what's new" to the next visit.
+
+**Hydration safety is a hard requirement.** Read `localStorage` in a `useEffect` after mount and
+seed the visible state to `false` on both server and client. See BITB-069 (`docs/DONE/`) for the
+exact failure this avoids.
+
+## Acceptance Criteria
+
+- [ ] On first load after deploy, every visitor sees the intro modal exactly once.
+- [ ] Dismissing it (button, Esc, or backdrop) persists — it never reappears for that browser.
+- [ ] A returning visitor who already dismissed it never sees it again, including across sessions.
+- [ ] A brand-new visitor sees it once, after the splash animation completes.
+- [ ] The modal never renders simultaneously with `SplashScreen` or `WhatsNewModal`.
+- [ ] Primary action navigates to the localized `/about` page.
+- [ ] Copy comes from the `About` namespace — all 11 locales, no English fallback in a non-English
+      UI.
+- [ ] No SSR/CSR hydration mismatch (no console warning; verified in a production build).
+- [ ] Keyboard accessible: focus moves into the dialog, Esc closes, focus returns to the page.
+- [ ] Bumping the version constant re-shows it — proven by a test, not by hand.
+
+## Tests to Add
+
+- `frontend/src/components/AboutIntroModal.test.tsx` — shows when the key is absent; hidden when it
+  matches the current version; shows again when the stored version is older; writes the key on
+  dismiss.
+- `frontend/src/app/[locale]/providers.test.tsx` — extend the existing splash test to assert the
+  modal only renders after `onComplete` fires.
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `frontend/src/components/AboutIntroModal.tsx` | **New** |
+| `frontend/src/app/[locale]/providers.tsx` | Render after `splashDone`; own the display gate |
+| `frontend/messages/*.json` (11) | `About.intro*` keys (condensed copy + CTA labels) |
+| `frontend/src/components/WhatsNewModal.tsx` | Defer when the intro modal is showing |
+
+## Out of Scope
+
+- **Android.** The equivalent there is a first-run sheet; the app already has a splash
+  (`android/.../presentation/screens/SplashScreen.kt`), a what's-new sheet (**BITB-058**) and a
+  first-run spotlight story (**BITB-054**). Fold the About content into those rather than adding a
+  fourth first-run interruption — track separately.
+- Server-side per-user tracking. This is a `localStorage` gate; clearing site data re-shows it, and
+  that is an acceptable trade for storing nothing about the visitor.
+
+## Related
+
+- **BITB-076** — the About page this modal points at (**blocks this story**).
+- **BITB-069** — splash-screen hydration mismatch; the trap to avoid.
+- **BITB-058** — Android "What's New" on launch; the same show-once-per-version idea.
+- **BITB-054** — Android first-run feature spotlight.

--- a/docs/BACKLOG_STORIES/BITB-077-about-intro-modal.md
+++ b/docs/BACKLOG_STORIES/BITB-077-about-intro-modal.md
@@ -42,6 +42,13 @@ This story needs the *union* of those two behaviours, which is neither one exact
 A dismissible modal — `AboutIntroModal` — showing a condensed version of the About copy
 (2–3 short paragraphs from the `About` namespace), with:
 
+> **Copy guidance.** The modal is not a summary of the About page; it is the *one thing* a person
+> needs before typing something personal. The source post gives it almost verbatim — "something
+> simple, accessible, and deeply rooted in Scripture that could offer encouragement when someone
+> needed it most. Not a replacement for therapy or pastoral care, but a gentle companion for
+> moments of struggle" — and that second sentence is the one that must survive the edit down.
+> Target ~60 words total. See BITB-076's *Source Material* section.
+
 - a primary action → `/{locale}/about` (the full page),
 - a secondary "Continue" / close action,
 - an accessible dialog shell (`role="dialog"`, `aria-modal`, focus trap, Esc to close), modelled on

--- a/docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md
+++ b/docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md
@@ -1,0 +1,146 @@
+# BITB-078: Ask Before Answering — Clarify a Vague Request Instead of Guessing
+
+**Status:** 🎯 Todo
+**Priority:** P2
+**Size:** M (1–2 days, prompt work + eval)
+**Created:** 2026-07-25
+
+## User Story
+
+**As a** user who types something short and raw like "I'm lost" or "pray for me",
+**I want** the companion to ask me one gentle question about what I'm facing,
+**so that** the answer I get speaks to my actual situation instead of being a generic verse dump
+aimed at whatever the model guessed.
+
+## Why
+
+The current flow always produces a full answer on the first turn, whatever it was given. For a
+three-word message the pipeline still runs semantic search, picks verses, and generates a
+confident, complete pastoral response — built on an assumption the user never made. That is the
+single worst failure mode for this product: it *sounds* caring while addressing someone else's
+problem, and the user usually just leaves rather than correcting it.
+
+A companion sitting next to you would ask. This story makes the app do that.
+
+The instruction technically already exists and is not working hard enough. `api/chat/prompts.py`
+(`SYSTEM_PROMPT_TEMPLATE`, section **"## When the Request Is Unclear"**) says:
+
+> If the user's message is too short or vague to understand what they are facing or asking, do not
+> guess. Respond with warmth and ask one gentle clarifying question (in their language) so you can
+> understand them before offering scripture.
+
+It is buried between the scripture-weaving rules and "## Your Role", whose step 2 —
+*"Ground them in scripture: bring in a fitting verse"* — reads as unconditional and pulls the model
+straight back to answering. The per-intent addenda reinforce that: `COMFORT_SEEKING_PROMPT` and
+`CURIOSITY_PROMPT` (`prompts.py:649-678`) both instruct the model to share scripture immediately.
+And structurally, by the time the LLM is called, the scripture context block has *already* been
+retrieved and injected (`api/chat/service.py:514`, `:1255`), so the model is looking at a pile of
+verses while being asked to consider not using them.
+
+## Current Behaviour
+
+- `_detect_intent` (`api/chat/service.py:168-193`) classifies each message into
+  `COMFORT | GUIDANCE | CURIOSITY | VERSE_LOOKUP | OFF_TOPIC | GENERAL`
+  (`detect_intent_prompt`, `prompts.py`). There is **no "needs clarification" outcome** —
+  a vague message falls into `GENERAL` or `COMFORT` and proceeds to a full answer.
+- Scripture search runs before generation; the context block is prepended to the system prompt
+  (`service.py:1453-1455`).
+- Conversation history is carried (`request.conversation_history`, summarized by
+  `build_conversation_context`, `prompts.py:608-634`, last 6 messages, 200 chars each), so a
+  multi-turn clarify → answer exchange is already supported by the transport — nothing new is
+  needed there.
+
+## Proposed Behaviour
+
+**1. Make "ask first" a first-class outcome of intent detection.**
+Add a `NEEDS_CLARIFICATION` category to `detect_intent_prompt`, with explicit criteria so it stays
+rare and predictable. Ask only when the message genuinely under-determines the answer:
+
+- very short and non-specific ("help", "I'm lost", "pray for me", "verse please"), **or**
+- names an emotion or event with no indication of what kind of help is wanted, **or**
+- is ambiguous between materially different readings (e.g. "should I leave?" — a job? a marriage?
+  a church?).
+
+Do **not** ask when:
+
+- the message already names a situation *and* a need ("my mother died last week, I can't pray"),
+- it is a verse or passage lookup (`VERSE_LOOKUP`) — that is unambiguous by construction,
+- it is a follow-up in an existing conversation where the context is already on the table,
+- the safety pipeline flagged `compassionate_response_needed` — someone in crisis gets support
+  first, never an interrogation. This exclusion is **non-negotiable**; see
+  `COMPASSIONATE_RESPONSE_ADDENDUM` in `prompts.py`.
+
+**2. Cap it at one clarifying turn.** If the user's reply is still vague, answer with the best
+reading available and say what was assumed ("I'll speak to X — tell me if you meant something
+else"). Never two questions in a row; never a question in the second turn if one was already asked.
+Enforce this from `conversation_history`, not from model goodwill.
+
+**3. Make the clarifying turn cheap and coherent.** When the intent is `NEEDS_CLARIFICATION`,
+skip semantic scripture search entirely and use a dedicated short prompt
+(`CLARIFICATION_PROMPT`). This is both correct — no verse should be picked for a question that
+hasn't been understood — and faster and cheaper than a full turn. The clarifying reply should:
+acknowledge the feeling in one sentence, ask exactly **one** open question, in the user's language,
+under ~40 words, with no verse citation and therefore no `<!-- VERSES: -->` comment.
+
+**4. Offer the clarification as tappable options where possible.** The question lands much better
+with 2–3 one-tap choices ("about grief" / "about a decision" / "something else") than as an open
+prompt on a phone keyboard. This shares its delivery mechanism with **BITB-080** (follow-up
+buttons) — build one chip mechanism, use it for both.
+
+**5. Strengthen the prompt itself.** Move the clarify rule out of the middle of the template into
+the ordered "## Your Role" list as an explicit step 0 ("understand before you answer"), and
+condition step 2 ("ground them in scripture") on having understood the request.
+
+## Acceptance Criteria
+
+- [ ] A vague opening message ("I'm lost", "help me", "pray for me") produces a warm, one-question
+      reply with no verse citation.
+- [ ] The clarifying turn skips semantic search — verifiable in the stage timings
+      (`docs/HOW-TO-READ-CHAT-STAGE-TIMINGS.md`) and measurably faster than a normal turn.
+- [ ] The user's answer to the clarifying question produces a full, grounded response that visibly
+      uses both turns.
+- [ ] At most one clarifying question per conversation.
+- [ ] A specific opening message is **never** met with a clarifying question — no regression to
+      "what do you mean?" for a well-formed request.
+- [ ] A message flagged `compassionate_response_needed` is never met with a clarifying question.
+- [ ] `VERSE_LOOKUP` and prayer lookups are never met with a clarifying question.
+- [ ] Behaviour holds across languages — verified at minimum in en, it, de, es (the clarifying
+      question must be in the user's language).
+- [ ] Clarification rate measured and logged (new `intent` value in the existing intent logging,
+      `service.py:192`), so the rollout can be judged rather than guessed at.
+
+## Tests to Add
+
+- `api/tests/` — intent classification: a table of vague vs. specific messages asserting the
+  `NEEDS_CLARIFICATION` boundary, including the exclusions (verse lookup, crisis flag, follow-up
+  turn).
+- Service test: `NEEDS_CLARIFICATION` short-circuits scripture search (search provider not called)
+  and emits no `verses_cited`.
+- Service test: a second vague message in the same conversation answers rather than asking again.
+- **Golden-set / eval:** add vague-opening cases to the retrieval-eval harness
+  (`docs/SEARCH_EVAL_HOWTO.md`, **BITB-051**) so this is measured across model changes, not
+  spot-checked once.
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `api/chat/prompts.py` | `NEEDS_CLARIFICATION` category; new `CLARIFICATION_PROMPT`; restructure "Your Role" |
+| `api/chat/service.py` | Route the new intent: skip search, use the clarification prompt, one-question cap from history |
+| `api/tests/` | Intent boundary + routing tests |
+| `frontend` / `android` | Render clarification options as chips (shared with BITB-080) |
+
+## Risks
+
+- **Over-asking is worse than the current behaviour.** A user who wrote a clear message and gets
+  "can you tell me more?" will leave. The eval set and the logged clarification rate exist to catch
+  this; consider shipping behind a config flag and watching the rate before making it the default.
+- **Extra latency on the path to a real answer** — mitigated by making the clarifying turn skip
+  retrieval, and by offering tappable options rather than requiring typing.
+
+## Related
+
+- **BITB-075** — a 500-character limit gives users room to be specific in the first place.
+- **BITB-080** — follow-up chips; same UI mechanism, opposite end of the turn.
+- **BITB-045** — typo-tolerant queries with clarification fallback (adjacent trigger, same UX).
+- **BITB-018 / BITB-050** — query understanding and response depth.

--- a/docs/BACKLOG_STORIES/BITB-079-web-bottom-bar-always-offscreen.md
+++ b/docs/BACKLOG_STORIES/BITB-079-web-bottom-bar-always-offscreen.md
@@ -1,0 +1,121 @@
+# BITB-079: Web — the Bottom Bar Is Permanently Off Screen on the Chat Page
+
+**Status:** 🎯 Todo
+**Priority:** P1
+**Size:** S (< 4 hrs)
+**Created:** 2026-07-25
+
+## User Story
+
+**As a** web visitor,
+**I want** the bottom bar (About / Get the app / Privacy / Terms / Changelog) to be reachable from
+the chat page,
+**so that** I can actually get to the legal pages and the app link instead of scrolling into a
+footer that never arrives.
+
+## Why
+
+On the chat page the footer is rendered but is not reachable in practice. It is not a styling
+nitpick: `/privacy` and `/terms` are legally required disclosures, `/app` is the Play Store funnel,
+and the About page from **BITB-076** is about to be added to the same bar. A navigation surface
+that exists in the DOM and never appears on screen is the same as not having one.
+
+## Current Behaviour — Root Cause
+
+The layout gives the chat page the entire viewport and then places the footer *after* it:
+
+- `frontend/src/app/[locale]/layout.tsx:107-111`
+
+  ```tsx
+  <div className="min-h-screen bg-gradient-to-b ... flex flex-col [overflow-x:clip]">
+    <div className="flex-1">{children}</div>
+    <Footer />
+  </div>
+  ```
+
+- `frontend/src/app/[locale]/ChatIsland.tsx:938` — `<main className="flex h-dvh">`, i.e. the chat
+  occupies a **full dynamic viewport height** on its own.
+
+So the document is `100dvh` of chat **plus** the footer's height. The footer sits exactly one
+footer-height below the fold, and the only way to reach it is a document-level scroll that the user
+essentially never gets: the chat page's own scrolling happens inside
+`ChatIsland.tsx:1033-1035` (`flex-1 overflow-y-auto`), which swallows wheel and touch gestures,
+and the input area below it (`:1149`, `sticky bottom-0`) pins the visual bottom of the screen. On
+mobile the mismatch is worse — `100dvh` tracks the browser chrome as it hides and shows, so the
+footer keeps sliding back out of reach as the user scrolls.
+
+Short pages (`/app`, `/privacy`, `/terms`, `/changelog`) are unaffected — they are not `h-dvh`, so
+their footer shows normally. **This is a chat-page-only defect.**
+
+A related crowding problem lives in the same region: the sticky input container at
+`ChatIsland.tsx:1149-1231` stacks the session-limit button, the language-switch suggestion, the
+textarea, the character counter, the disclaimer, `ChurchFinderBanner` and the whole `ContactForm`
+into one block. When several of those are visible at once (and when `ContactForm` is expanded), the
+bottom region eats an unreasonable share of a phone screen and pushes the conversation out of view.
+Worth fixing in the same pass.
+
+## Proposed Behaviour
+
+The chat page must be self-contained within the viewport **and** expose the footer links. Pick one
+of these — recommended first:
+
+1. **Recommended — a compact footer row inside the chat shell.** Stop relying on the page-level
+   `<Footer />` for the chat route and render a slim link row inside the sticky bottom container
+   (next to, or merged with, the `Chat.disclaimer` line at `ChatIsland.tsx:1220-1222`). Always
+   visible, no scrolling required, costs one line of height. The page-level `<Footer />` continues
+   to serve every other route unchanged.
+2. **Alternative — make the chat page shorter than the viewport.** Replace `h-dvh` on `main` with a
+   height that subtracts the footer (`h-[calc(100dvh-var(--footer-h))]` with the footer height
+   published as a CSS variable) so the footer is permanently on screen beneath the chat. Costs
+   vertical space on every screen and needs care with the mobile keyboard.
+
+Whichever is chosen, it must survive the mobile keyboard: when the on-screen keyboard opens, the
+input must stay visible and the bottom chrome must not be pushed under it. `dvh` units plus the
+existing `sticky bottom-0` handle most of this; verify on real iOS Safari and Android Chrome, not
+only in a desktop responsive emulator.
+
+**Also in scope — decrowd the bottom region:**
+
+- Collapse `ContactForm` to a single-line trigger by default on small screens (it already has an
+  `isExpanded` state, `ContactForm.tsx:34`) and consider moving it out of the sticky container so
+  it does not compete with the composer.
+- Ensure at most one promotional/suggestion element (`ChurchFinderBanner`, language-switch
+  suggestion, session-limit button) is shown at a time.
+
+## Acceptance Criteria
+
+- [ ] On the chat page, the footer links (About, Get the app, Privacy, Terms, Changelog) are
+      reachable without a document-level scroll, at 360×640, 390×844, 768×1024 and 1440×900.
+- [ ] With the mobile keyboard open, the composer remains fully visible and is not overlapped.
+- [ ] The conversation area still gets the majority of the vertical space on a 360×640 screen with
+      the church-finder banner visible.
+- [ ] No horizontal scrolling is introduced at any of the above widths.
+- [ ] `/app`, `/privacy`, `/terms`, `/changelog` are visually unchanged.
+- [ ] RTL (Arabic) renders correctly.
+- [ ] No duplicate footer rendered on the chat page.
+
+## Tests to Add
+
+- Playwright (`frontend/e2e/`): on `/en`, assert a footer link is within the viewport bounding box
+  without scrolling, at mobile and desktop viewports — this is the regression that matters and it
+  cannot be caught by a unit test.
+- Playwright: with the church-finder banner shown, the last message and the composer are both
+  within the viewport.
+- Component test for whatever new bottom-bar component is introduced.
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `frontend/src/app/[locale]/ChatIsland.tsx` | Chat-shell height; bottom link row; decrowd sticky region |
+| `frontend/src/app/[locale]/layout.tsx` | Do not double-render the footer on the chat route |
+| `frontend/src/components/Footer.tsx` | Extract a compact variant for in-chat use |
+| `frontend/src/components/ContactForm.tsx` | Collapsed-by-default trigger on small screens |
+| `frontend/e2e/` | Viewport regression tests |
+
+## Related
+
+- **BITB-076** — adds an About link to this bar; the link is worthless until this is fixed.
+- **BITB-074** — adds a "Support us" link to the same bar.
+- **BITB-028** — Church Finder banner/bottom-sheet cleanup (same crowded region).
+- `docs/BACKLOG_STORIES/mobile-fab-reposition.md` — prior art on mobile bottom-region layout.

--- a/docs/BACKLOG_STORIES/BITB-080-suggested-followup-questions.md
+++ b/docs/BACKLOG_STORIES/BITB-080-suggested-followup-questions.md
@@ -1,0 +1,130 @@
+# BITB-080: Suggested Follow-Up Questions as One-Tap Buttons Under Each Answer
+
+**Status:** 🎯 Todo
+**Priority:** P2
+**Size:** M (1–2 days, backend + web + Android)
+**Created:** 2026-07-25
+
+## User Story
+
+**As a** user who has just read an answer,
+**I want** two or three suggested next questions offered as buttons under it,
+**so that** I can keep exploring without having to work out what to ask next — or type it on a
+phone.
+
+## Why
+
+The welcome screen already does this and it works: four randomized starter prompts, and tapping one
+submits it immediately (`ChatIsland.tsx:1061-1070` → `submitMessage(prompt)`; Android
+`WelcomeBanner.kt` → `ChatScreen.kt:370-382`). That scaffolding disappears the moment the first
+answer arrives, exactly when the user has the most to explore and the least idea how to phrase it.
+
+Conversations here end after one turn far more often than they should. Someone who asked about
+anxiety may want the passage in context, or a prayer, or what to do when the feeling comes back
+tonight — but they have to invent the question themselves, in their own words, into a small
+keyboard, while emotionally spent. A concrete, tappable next step removes all of that friction, and
+each suggestion also teaches what this companion can do.
+
+There is a design pairing with **BITB-078**: that story asks a clarifying question *before*
+answering; this one offers next questions *after*. Both need the same thing on the client — a row
+of tappable, send-on-tap chips. **Build the chip component once and use it for both.**
+
+## Current Behaviour
+
+- No follow-up affordance exists after an assistant message. `ChatMessage.tsx` renders content,
+  verse chips and feedback controls; nothing else.
+- The streaming contract already has a clean place to carry this. The `completion` event
+  (`api/chat/service.py:1375-1386`) is a dict that grew `resolved_verses`, `corrected_message` and
+  `corrections` over time, with the explicit note that *"older clients ignore unknown fields, so
+  this is backward compatible"*. `StreamChunk` on the web side
+  (`frontend/src/lib/api.ts:563-589`) mirrors it with optional fields.
+- Conversation history is already sent back on the next turn
+  (`ChatRequest.conversation_history`, `service.py:96`), so a tapped follow-up behaves like any
+  other user message with full context — no new plumbing needed.
+
+## Proposed Behaviour
+
+**Backend — generate the follow-ups.** Add an optional `follow_ups: list[str]` to the `completion`
+event (and to `ChatResponse` for the non-streaming path). Two viable approaches:
+
+1. **In-prompt (recommended for v1).** Extend the system prompt so the model appends its suggested
+   follow-ups in a machine-readable trailer, exactly like the existing verse-citation mechanism
+   (`<!-- VERSES: ... -->` in `SYSTEM_PROMPT_TEMPLATE`), e.g. `<!-- FOLLOWUPS: ...|...|... -->`.
+   Strip it from the visible text in the same place the verse comment is stripped, and emit it in
+   `completion`. Zero extra latency, zero extra cost, and the suggestions are grounded in what was
+   actually said.
+2. **Separate fast call.** A second cheap LLM call after generation. Cleaner separation, but adds
+   latency to the end of every turn and a second failure mode.
+
+Constraints on the generated suggestions:
+
+- **2–3** suggestions, never more (a wall of buttons is its own kind of pressure).
+- Written **in the user's language**, in the user's voice — they are things the *user* would say
+  ("What does Psalm 34 say in context?"), not menu labels.
+- Short enough to render on one or two lines on a phone (~60 characters).
+- Genuinely different from each other and from what was just asked.
+- **Suppressed entirely** when the turn was off-topic, when the safety pipeline flagged
+  `compassionate_response_needed` (someone in crisis is not offered a menu), and on any error turn.
+- Never fabricate scripture references in a suggestion.
+
+**Clients — render as send-on-tap chips.**
+
+- **Web:** a chip row under the last assistant message only (not under every message in the
+  scrollback), wired to the existing `submitMessage` path so a tap sends immediately. Chips clear as
+  soon as a new turn starts. Reuse the visual language of the welcome-screen prompt buttons.
+- **Android:** the same, under the last assistant item in the chat `LazyColumn`
+  (`ChatScreen.kt`), calling `viewModel.sendMessage(...)` — and it must send on the first tap
+  (see **BITB-081**).
+
+**Degrade silently.** If `follow_ups` is absent (older backend, or suppressed), the client renders
+nothing. No spinner, no empty row.
+
+## Acceptance Criteria
+
+- [ ] After a normal answer, 2–3 follow-up buttons appear under the last assistant message on web
+      and Android.
+- [ ] Tapping one sends it immediately as a user message — no second tap, no manual send.
+- [ ] Suggestions are in the conversation's language.
+- [ ] Chips appear only under the **latest** assistant message and disappear when the next turn
+      starts.
+- [ ] No follow-ups on off-topic replies, crisis-flagged turns, or errors.
+- [ ] A client on an older backend (no `follow_ups` field) is unaffected.
+- [ ] The follow-up trailer never leaks into the visible answer text.
+- [ ] Perceived end-of-turn latency does not regress measurably (check the stage timings).
+- [ ] The suggestion row is keyboard accessible on web and screen-reader labelled on both platforms.
+
+## Tests to Add
+
+- API: the trailer is parsed into `follow_ups` and stripped from the message body; malformed or
+  missing trailer yields an empty list without erroring.
+- API: follow-ups suppressed for off-topic and crisis-flagged turns.
+- `frontend/src/lib/api.test.ts` — `completion` chunk carrying `follow_ups` is surfaced; absent
+  field is handled.
+- Web component test: chips render under the last message only; tap submits.
+- Android: Compose UI test (the `testDebugCompose` tier, **BITB-034**) — chips render and a tap
+  triggers `sendMessage`.
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `api/chat/prompts.py` | Follow-up trailer instruction + constraints |
+| `api/chat/service.py` | Parse/strip trailer; add `follow_ups` to `completion` and `ChatResponse` |
+| `frontend/src/lib/api.ts` | `follow_ups?: string[]` on `StreamChunk` / `ChatResponse` |
+| `frontend/src/app/[locale]/ChatIsland.tsx`, `ChatMessage.tsx` | Chip row under the last answer |
+| `android/.../ChatViewModel.kt`, `ChatScreen.kt`, `ChatMessageItem.kt` | Parse + render + send on tap |
+| `frontend/messages/*.json`, `android/.../strings.xml` | Accessibility label for the row |
+
+## Risks
+
+- **Generic suggestions are worse than none.** "Tell me more" adds nothing. Review real output
+  before enabling by default; consider a config flag and a manual read of a sample of turns.
+- **Steering people away from what they actually wanted to say.** Chips should sit *under* the
+  answer as an option, never replace or crowd the composer.
+
+## Related
+
+- **BITB-078** — clarifying questions; shares the chip component.
+- **BITB-081** — Android send-on-tap; the same first-tap requirement.
+- **BITB-024** — 10-interaction session limit: more follow-ups means hitting that ceiling sooner.
+  Check the interaction between the two before rollout.

--- a/docs/BACKLOG_STORIES/BITB-081-android-example-prompt-sends-on-tap.md
+++ b/docs/BACKLOG_STORIES/BITB-081-android-example-prompt-sends-on-tap.md
@@ -1,0 +1,121 @@
+# BITB-081: Android — Tapping an Example Question Must Always Send It on the First Tap
+
+**Status:** 🎯 Todo
+**Priority:** P1
+**Size:** S (< 4 hrs)
+**Created:** 2026-07-25
+
+## User Story
+
+**As an** Android user tapping one of the example questions on the welcome screen,
+**I want** it to be sent immediately,
+**so that** I get an answer from one tap instead of having the text silently dropped into the input
+box and having to find the send arrow.
+
+## Why
+
+This is the app's very first interaction. A new user taps "I feel anxious and can't stop worrying"
+expecting an answer; instead the text appears in the composer and nothing happens. Some users tap
+the same suggestion again (still nothing sends), some assume the app is broken and leave. The web
+version does not have this problem — tapping a starter prompt there calls `submitMessage(prompt)`
+directly (`frontend/src/app/[locale]/ChatIsland.tsx:1061-1070`) and sends.
+
+The Android code *intends* to send, but guards the send behind a Turnstile-readiness check that is
+frequently false exactly when the welcome screen is on display — cold start, before the Turnstile
+WebView has produced its first token.
+
+## Current Behaviour
+
+`android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt:370-382`:
+
+```kotlin
+WelcomeBanner(
+    onPromptSelected = { prompt ->
+        // Tapping a sample question submits it directly.
+        // If Turnstile isn't ready yet, fall back to
+        // filling the input so the Send button still works.
+        if (uiState.isTurnstileReady) {
+            viewModel.sendMessage(prompt)
+            inputText = ""
+        } else {
+            inputText = prompt
+        }
+    },
+    ...
+)
+```
+
+`isTurnstileReady` becomes true only once the WebView delivers a token **or** Turnstile has errored
+(fail-open) — `ChatViewModel.kt:262-274`. On a cold start the welcome screen is visible well before
+either happens, so the `else` branch runs and the tap becomes a silent paste with no feedback.
+
+**The guard is unnecessary.** `TurnstileInterceptor` already handles a missing token for POSTs: it
+waits for one with a bounded timeout (`awaitTokenOrNull()`), attaches it when it arrives, proceeds
+without it if it does not, and on a 403 kicks the widget to refresh and retries the request exactly
+once (`android/app/src/main/kotlin/org/voxquieta/app/data/remote/interceptors/TurnstileInterceptor.kt:28-79`).
+`ChatViewModel.sendMessage` itself (`:379`) has no token precondition — it only refuses when the
+text is blank or a send is already in flight. So sending unconditionally is already safe; the
+screen-level guard duplicates, and defeats, the transport-level handling.
+
+## Proposed Behaviour
+
+Send on every tap:
+
+```kotlin
+onPromptSelected = { prompt ->
+    inputText = ""
+    viewModel.sendMessage(prompt)
+}
+```
+
+The message is appended to the conversation immediately with the usual streaming placeholder, so
+the user gets instant visual confirmation; the interceptor absorbs the token wait. If the request
+ultimately fails, the existing error handling surfaces it — a visible error is a far better outcome
+than a silent paste.
+
+Two details to get right:
+
+- **Do not gate on `isSessionLimitReached` here either** — that path already produces its own
+  user-visible message.
+- **Keep the composer's own send button gated as it is** (`ChatInputField.kt:35,40`,
+  `canSend = !isLoading && isTurnstileReady && !isSessionLimitReached`) or reconsider it
+  separately. This story is about the example tap; widening it to the composer is a separate
+  judgement call about whether the composer should also stop disabling itself during the Turnstile
+  warm-up. Note the inconsistency in the story's follow-up if it is left as is.
+
+The same send-on-tap behaviour must apply to the follow-up chips from **BITB-080** when they land.
+
+## Acceptance Criteria
+
+- [ ] Tapping an example question on a **cold start**, before Turnstile has produced a token, sends
+      the message and starts streaming a response.
+- [ ] The tapped text never remains in the input field.
+- [ ] Tapping an example question never requires a second tap or a press of the send arrow.
+- [ ] If the backend rejects the request, the user sees the normal error state — never silence.
+- [ ] Behaviour is identical whether Turnstile is enabled, disabled, or in its error/fail-open
+      state.
+- [ ] Web parity: one tap → one sent message on both platforms.
+
+## Tests to Add
+
+- Compose UI test (`./gradlew testDebugCompose`, the **BITB-034** tier): with
+  `isTurnstileReady = false`, tapping a `WelcomeBanner` suggestion invokes `sendMessage` and leaves
+  the input field empty.
+- `ChatViewModel` test: `sendMessage` called with no Turnstile token still appends the user message
+  and starts a stream (interceptor behaviour mocked).
+- Regression: tapping a suggestion twice in quick succession does not create two conversations
+  (guarded by the existing `isLoading` check in `sendMessage`).
+
+## Files Likely to Change
+
+| File | Change |
+|---|---|
+| `android/.../presentation/screens/ChatScreen.kt` | Remove the `isTurnstileReady` branch in `onPromptSelected` |
+| `android/app/src/test/.../` | Compose UI + ViewModel tests |
+
+## Related
+
+- **BITB-080** — follow-up chips must send on first tap for the same reason.
+- **BITB-003** — Turnstile on Android (origin of the readiness flag).
+- `docs/DONE/PR171-turnstile-ready-fix.md`, `docs/DONE/PR-turnstile-ready-fix.md` — prior fixes in
+  this area; worth reading before changing the flag's semantics.


### PR DESCRIPTION
## Summary

This PR documents a product review batch of seven user stories addressing message limits, onboarding clarity, and platform-specific UX issues. All stories are newly created backlog entries with detailed acceptance criteria and implementation guidance.

## Changes

- **Updated backlog timestamp** (`docs/BACKLOG.md`) from 2026-07-21 to 2026-07-25
- **Added seven new story documents** in `docs/BACKLOG_STORIES/`:
  - **BITB-075** (P1, S): Raise chat message limit to 500 characters and establish a single source of truth across five currently-disagreeing configuration layers (Terraform, backend config, web client, Android client)
  - **BITB-076** (P2, M): Create an "About" page explaining why Vox Quieta exists, adapted from the canonical ai4you.sh blog post, localized to all 11 UI languages
  - **BITB-077** (P2, S): Add a dismissible intro modal showing once to all current users, then only to new visitors, using a versioned localStorage gate
  - **BITB-078** (P2, M): Implement "ask before answering" — detect vague requests and ask one clarifying question instead of guessing, with optional tappable response chips
  - **BITB-079** (P1, S): Fix web footer permanently off-screen on chat page by either rendering a compact footer row inside the chat shell or adjusting viewport height
  - **BITB-080** (P2, M): Add 2–3 suggested follow-up questions as one-tap buttons under each answer, generated in-prompt or via fast LLM call
  - **BITB-081** (P1, S): Fix Android example question tap to send immediately on first tap instead of silently pasting into composer, removing unnecessary Turnstile-readiness guard

## Notable Details

- **BITB-075** identifies a live production defect: the message limit is hard-coded in five places with conflicting values (200 deployed, 300 in code, 300 in clients). The story proposes publishing the limit via `GET /config` so clients follow the server.
- **BITB-076** emphasizes adapting rather than transcribing the source blog post, which describes v1.0 and is now stale on product name, stack, and language support.
- **BITB-077** reuses existing patterns (`splash_seen` cookie, `WhatsNewModal` localStorage gate) to achieve "show once to everyone now, new visitors later" with a single versioned key.
- **BITB-078** and **BITB-080** share a client-side chip component for both clarifying questions and follow-up suggestions.
- **BITB-079** is chat-page-only; short pages (`/app`, `/privacy`, `/terms`) are unaffected.
- **BITB-081** notes that `TurnstileInterceptor` already handles token waits and retries, making the screen-level guard redundant and harmful to UX.

All stories include detailed acceptance criteria, test guidance, and file-change predictions.

https://claude.ai/code/session_01RziXKU1zeVMKDmz923Vu1H