### PR TITLE
docs(backlog): close out BITB-073 (PR #928 merged, move to DONE)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1793,11 +1793,12 @@ with zero behavioural risk.
 
 ---
 
-### 🎯 BITB-073: Split Dev/Prod Python Requirements (Stop Shipping pytest in the Prod Image)
+### ✅ BITB-073: Split Dev/Prod Python Requirements (Stop Shipping pytest in the Prod Image)
 
-**Status:** ✅ Done
+**Status:** ✅ Done (PR #928 merged 2026-07-23)
 **Size:** S (< 4 hrs)
 **Created:** 2026-07-20
+**Completed:** 2026-07-23
 
 **As a** maintainer, **I want** test-only deps out of `api/requirements.txt`
 (into a new `requirements-dev.txt`), **so that** the production image doesn't carry the
@@ -1810,7 +1811,7 @@ because it touches 2 workflows + Makefile + docs.
 - [x] Backend CI (unit + integration) green with updated install lines and cache keys
 - [x] Docker image builds unchanged; dependabot still covers both files
 
-**Full Story:** `docs/BACKLOG_STORIES/BITB-073-split-dev-prod-python-requirements.md`
+**Full Story:** `docs/DONE/BITB-073-split-dev-prod-python-requirements.md`
 
 ---
 

--- a/docs/DONE/BITB-073-split-dev-prod-python-requirements.md
+++ b/docs/DONE/BITB-073-split-dev-prod-python-requirements.md
@@ -1,9 +1,10 @@
 # BITB-073: Split Dev/Prod Python Requirements (Stop Shipping pytest in the Prod Image)
 
-**Status:** ✅ Done
+**Status:** ✅ Done (PR #928 merged 2026-07-23)
 **Priority:** P3
 **Size:** S (< 4 hrs)
 **Created:** 2026-07-20
+**Completed:** 2026-07-23
 
 **As a** maintainer, **I want** test-only Python dependencies out of
 `api/requirements.txt`, **so that** the production image doesn't carry the test


### PR DESCRIPTION
## Summary

Small backlog-hygiene follow-up to #928 (BITB-073). Per this repo's `AGENTS.md` → Backlog Hygiene, a completed story should have its PR number/completion date recorded and be moved to `docs/DONE/`. That was deliberately deferred until the PR was confirmed merged (the PR number wasn't knowable at build/verify time).

- `docs/BACKLOG_STORIES/BITB-073-split-dev-prod-python-requirements.md` → moved to `docs/DONE/`, with `**Status:** ✅ Done (PR #928 merged 2026-07-23)` and a `**Completed:**` date added.
- `docs/BACKLOG.md` — BITB-073 entry heading emoji flipped to ✅ (matching other Done entries), status line updated with PR number/date, and the "Full Story" link updated to point at `docs/DONE/`.

Docs-only change, no code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSLR9TK5hpWsCVStPVuNc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSLR9TK5hpWsCVStPVuNc6)_