### PR TITLE
ci(frontend): update Node test matrix from 20.x/22.x to 22.x/26.x

### DIFF
--- a/.github/workflows/test_update.yml
+++ b/.github/workflows/test_update.yml
@@ -136,7 +136,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 26.x]
 
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ Format commands: `make format` (auto-fix Python + frontend)
 | Job | What it does |
 | ----- | ------------- |
 | `backend-tests` | Ruff, Black, MyPy, pytest (PostgreSQL 16 + pgvector service) |
-| `frontend-tests` | npm lint, tsc, vitest, build (Node 20.x + 22.x matrix) |
+| `frontend-tests` | npm lint, tsc, vitest, build (Node 22.x + 26.x matrix) |
 | `integration-tests` | Docker Compose: health check, scripture search, chat, streaming, frontend |
 | `security-check` | Python + npm dependency vulnerability scans |
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -37,7 +37,7 @@ The CI/CD pipeline includes comprehensive testing across multiple layers:
 - ✅ ESLint code quality checks
 - ✅ TypeScript compilation (type checking)
 - ✅ Production build creation
-- ✅ Multi-version Node.js compatibility (18.x, 20.x)
+- ✅ Multi-version Node.js compatibility (22.x, 26.x)
 
 **Runs on:** Every push and PR
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     globals: true,
     setupFiles: "./src/test/setup.ts",
     exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
+    // Node >=25 enables a native `localStorage` global by default, which
+    // throws without --localstorage-file and shadows jsdom's own
+    // window.localStorage before the jsdom environment can install it.
+    // Disable Node's built-in implementation so jsdom's wins.
+    execArgv: ["--no-experimental-webstorage"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Swaps the `frontend-tests` Node matrix in `.github/workflows/test_update.yml` from `[20.x, 22.x]` to `[22.x, 26.x]`.
- Node 20 reached end-of-life for LTS maintenance, so testing against it no longer catches anything actionable.
- `26.x` matches the Node version `frontend/Dockerfile` actually ships to production (`node:26-alpine`), closing the gap between what CI validates and what runs in prod.
- `22.x` is kept since the rest of the repo's workflows (pre-commit, commitlint, release-please) already standardize on it.
- Updates the two living docs that documented the old matrix: `docs/TESTING.md` and `AGENTS.md`.
- Fixes a real Node 26-specific test failure this matrix bump surfaced (see below).

## Analysis performed before changing anything
- **Branch protection / rulesets**: main has no classic branch protection, but 3 active rulesets do exist. Checked all of them — none reference `Frontend Tests (20.x)`/`(22.x)` by name (only `Lint Commit Messages`, `Lint PR Title`, `Pre-Commit Hooks` are required checks), so renaming the matrix legs won't break merging.
- **Other Node-version references**: grepped the whole repo. Found and updated the two living docs above. Left references in `docs/WIP/`, `docs/DONE/`, and `docs/BACKLOG_STORIES/BITB-028-*` untouched since those are point-in-time historical/session records, not living documentation.
- **npm-version drift** (the exact failure mode that broke PR #936, where npm 10.x and 11.x resolved an optional peer dependency differently and produced a lockfile `EUSAGE` mismatch): looked up the npm version bundled with the latest Node 26.x release (`v26.5.0` → npm `11.17.0`, via `nodejs/node`'s `deps/npm/package.json`), then installed that exact npm version locally and ran `npm ci` against `frontend/package-lock.json`. It installs cleanly with no drift under both npm 10.9.2 (Node 22.x) and npm 11.17.0 (Node 26.x).
- **No version-conditional logic**: the `frontend-tests` job steps are identical across matrix legs, so there's nothing else to adjust for the 20.x → 26.x swap.
- **Native deps**: confirmed `sharp` (bundled via `next`'s optional deps) declares `engines.node: "^18.17.0 || ^20.3.0 || >=21.0.0"`, so 26.x is covered.

## Bug found and fixed: Node 26 vs. jsdom's `localStorage`
The first CI run on this branch failed `Frontend Tests (26.x)` — `WhatsNewModal.test.tsx` (all 6 tests) and one case in `page.test.tsx` threw `TypeError: Cannot read properties of undefined (reading 'clear'/'getItem'/'setItem')`. `Frontend Tests (22.x)` was `cancelled`, not failed, due to the matrix's default fail-fast — so at first glance it looked like it might be flakiness. It wasn't: the exact same commit had already passed both legs on `main`'s own push-triggered run minutes earlier, and the error only reproduced on the 26.x leg.

Root cause, confirmed via Node's own changelog (`doc/api/globals.md` in `nodejs/node` at `v26.5.0`): Node >=25 enables a native `localStorage` global **by default** (no flag needed since v25.0.0), and as of v26.0.0 accessing it without `--localstorage-file` throws. This collides with `vitest-environment-jsdom`, which needs to install jsdom's own `window.localStorage` onto the same global — the collision left `localStorage` `undefined` in every test file that touched it, only on the 26.x leg (22.x predates the default-on behavior).

Fix: added `execArgv: ["--no-experimental-webstorage"]` to `frontend/vitest.config.ts` (Node's documented way to disable its native implementation) so jsdom's own `localStorage` wins. Note Vitest 4 flattened the old `test.poolOptions.threads/forks.execArgv` config shape into a single top-level `test.execArgv` — used the current shape.

## Test plan
- [x] `npm ci` clean install with npm 10.9.2 (Node 22.x's bundled npm) — passes
- [x] `npm ci` clean install with npm 11.17.0 (Node 26.x's bundled npm) — passes, no EUSAGE
- [x] `npm run lint` — 0 errors (5 pre-existing warnings, unrelated)
- [x] `npm run test:unit` — 773/773 tests passing locally
- [x] `npm run type-check` — passes
- [x] Real CI run on this PR: `Frontend Tests (22.x)` ✅ and `Frontend Tests (26.x)` ✅ both pass, `Pre-Commit Hooks` ✅

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NQfpC1H5MQRgQWuTfyWSMp