### PR TITLE
fix(api): raise chat message limit to 500 and publish via /config (BITB-075)

### DIFF
--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/api/BibleApiService.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/api/BibleApiService.kt
@@ -4,6 +4,7 @@ import org.voxquieta.app.data.remote.models.ChapterResponseDto
 import org.voxquieta.app.data.remote.models.ChatRequestDto
 import org.voxquieta.app.data.remote.models.ChurchSearchRequestDto
 import org.voxquieta.app.data.remote.models.ChurchSearchResponseDto
+import org.voxquieta.app.data.remote.models.ConfigResponseDto
 import org.voxquieta.app.data.remote.models.ContactRequestDto
 import org.voxquieta.app.data.remote.models.ContactResponseDto
 import org.voxquieta.app.data.remote.models.FeedbackRequestDto
@@ -54,6 +55,14 @@ interface BibleApiService {
         @Query("translation") translation: String? = null,
         @Query("lang") lang: String? = null,
     ): ChapterResponseDto
+
+    /**
+     * Fetches non-sensitive runtime configuration published by the backend
+     * (BITB-075), currently just the effective chat message-length limit
+     * (`chat.max_message_length`). Root path — NOT prefixed with `api/v1/`.
+     */
+    @GET("config")
+    suspend fun getConfig(): ConfigResponseDto
 
     /**
      * Submits thumbs-up / thumbs-down feedback for a finished assistant message.

--- a/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ConfigResponseDto.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/data/remote/models/ConfigResponseDto.kt
@@ -1,0 +1,18 @@
+package org.voxquieta.app.data.remote.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// BITB-075: mirrors the `chat` block of the backend's GET /config response.
+// Nullable + defaulted fields so an older/different backend payload still
+// deserializes fine (the shared Json config already has
+// ignoreUnknownKeys = true).
+@Serializable
+data class ConfigResponseDto(
+    val chat: ConfigChatDto? = null,
+)
+
+@Serializable
+data class ConfigChatDto(
+    @SerialName("max_message_length") val maxMessageLength: Int? = null,
+)

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatInputField.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/components/ChatInputField.kt
@@ -34,7 +34,7 @@ fun ChatInputField(
     isLoading: Boolean = false,
     isTurnstileReady: Boolean = true,
     isSessionLimitReached: Boolean = false,
-    maxLength: Int = 300,
+    maxLength: Int,
     onStop: () -> Unit = {},
 ) {
     val canSend = !isLoading && isTurnstileReady && !isSessionLimitReached

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/screens/ChatScreen.kt
@@ -542,7 +542,7 @@ fun ChatScreen(
                 isLoading = uiState.isLoading,
                 isTurnstileReady = uiState.isTurnstileReady,
                 isSessionLimitReached = uiState.isSessionLimitReached,
-                maxLength = ChatViewModel.MAX_MESSAGE_LENGTH,
+                maxLength = uiState.maxMessageLength,
             )
         }
     }

--- a/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
+++ b/android/app/src/main/kotlin/org/voxquieta/app/presentation/viewmodels/ChatViewModel.kt
@@ -136,6 +136,12 @@ data class ChatUiState(
      * language-switch suggestion banner. Null means no banner.
      */
     val languageSuggestion: String? = null,
+    /**
+     * Effective max characters allowed in a single chat message. Seeded from
+     * the compiled-in [ChatViewModel.MAX_MESSAGE_LENGTH] fallback and updated
+     * once GET /config resolves (BITB-075) — see [ChatViewModel.fetchConfigWithRetry].
+     */
+    val maxMessageLength: Int = ChatViewModel.MAX_MESSAGE_LENGTH,
 )
 
 @HiltViewModel
@@ -166,11 +172,14 @@ class ChatViewModel @Inject constructor(
         const val CHAPTER_LOAD_TIMEOUT_MS = 10_000L
 
         /**
-         * Max characters allowed in a single chat message. Must match the
-         * backend's max_message_length setting (api/config.py); the server
-         * rejects anything longer with HTTP 422.
+         * Pre-config fallback only (BITB-075). The effective max characters
+         * allowed in a single chat message comes from the backend at runtime
+         * via GET /config -> chat.max_message_length (see
+         * [ChatUiState.maxMessageLength], seeded from this constant and
+         * updated by [fetchConfigWithRetry]). The server always enforces its
+         * own configured limit regardless of this value.
          */
-        const val MAX_MESSAGE_LENGTH = 300
+        const val MAX_MESSAGE_LENGTH = 500
     }
 
     // Read the persisted theme synchronously so the very first composition (and every
@@ -304,6 +313,9 @@ class ChatViewModel @Inject constructor(
         viewModelScope.launch { fetchTranslationsWithRetry() }
         // Fetch book name mappings from the backend with retry.
         viewModelScope.launch { fetchBookNamesWithRetry() }
+        // Fetch server-published config (currently just the effective chat
+        // message-length limit) from the backend with retry (BITB-075).
+        viewModelScope.launch { fetchConfigWithRetry() }
         // Mirror the connectivity state into uiState so the UI can react.
         viewModelScope.launch {
             networkMonitor.isOffline.collect { offline ->
@@ -369,6 +381,41 @@ class ChatViewModel @Inject constructor(
                     Timber.w(e, "Failed to fetch book names after $maxAttempts attempts; falling back to default regex")
                 } else {
                     Timber.w(e, "Failed to fetch book names (attempt ${attempt + 1}/$maxAttempts); retrying in ${delayMs}ms")
+                    delay(delayMs)
+                    delayMs *= 2
+                }
+            }
+        }
+    }
+
+    /**
+     * Fetches server-published config from the backend with exponential backoff
+     * (BITB-075). Attempts up to [maxAttempts] times, starting with a
+     * [initialDelayMs] ms delay that doubles on each retry. Falls back to
+     * leaving [ChatUiState.maxMessageLength] at its compiled-in default when
+     * all attempts fail, or when the response doesn't include a valid
+     * positive value.
+     */
+    private suspend fun fetchConfigWithRetry(
+        maxAttempts: Int = 3,
+        initialDelayMs: Long = 1_000L,
+    ) {
+        var delayMs = initialDelayMs
+        repeat(maxAttempts) { attempt ->
+            try {
+                val response = bibleApiService.getConfig()
+                val maxLength = response.chat?.maxMessageLength
+                if (maxLength != null && maxLength > 0) {
+                    _uiState.update { it.copy(maxMessageLength = maxLength) }
+                }
+                return
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                val isLastAttempt = attempt == maxAttempts - 1
+                if (isLastAttempt) {
+                    Timber.w(e, "Failed to fetch config after $maxAttempts attempts; keeping fallback maxMessageLength")
+                } else {
+                    Timber.w(e, "Failed to fetch config (attempt ${attempt + 1}/$maxAttempts); retrying in ${delayMs}ms")
                     delay(delayMs)
                     delayMs *= 2
                 }
@@ -1210,7 +1257,7 @@ class ChatViewModel @Inject constructor(
         // over-long message. Tell the user to shorten it rather than showing a
         // generic server error.
         e is HttpException && e.code() == 422 ->
-            context.getString(R.string.error_message_too_long, MAX_MESSAGE_LENGTH)
+            context.getString(R.string.error_message_too_long, _uiState.value.maxMessageLength)
         e is HttpException ->
             context.getString(R.string.error_server)
         e is IOException ->

--- a/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/ChatInputFieldComposeTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/ChatInputFieldComposeTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onNodeWithContentDescription

--- a/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/ChatInputFieldComposeTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/presentation/components/ChatInputFieldComposeTest.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertExists
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import org.junit.Assert.assertEquals
@@ -35,6 +37,7 @@ class ChatInputFieldComposeTest : ComposeTestHarness() {
                 value = text,
                 onValueChange = { text = it },
                 onSend = { sent = it },
+                maxLength = 500,
             )
         }
 
@@ -54,10 +57,31 @@ class ChatInputFieldComposeTest : ComposeTestHarness() {
                 onSend = {},
                 isLoading = true,
                 isSessionLimitReached = false,
+                maxLength = 500,
             )
         }
 
         // Field must remain editable during streaming (enabled = !isSessionLimitReached)
         composeRule.onNode(hasSetTextAction()).assertIsEnabled()
+    }
+
+    @Test
+    fun `counter reflects the passed maxLength rather than a hardcoded default`() {
+        // BITB-075: maxLength is now a required, server-derived value (no
+        // compiled-in default) — this guards against silent drift back to a
+        // stale constant if a call site ever forgets to pass it explicitly.
+        setContentThemed {
+            var text by remember { mutableStateOf("a".repeat(9)) }
+            ChatInputField(
+                value = text,
+                onValueChange = { text = it },
+                onSend = {},
+                maxLength = 10,
+            )
+        }
+
+        // At 9/10 chars (>= 80% of maxLength=10) the counter must be visible
+        // and show the maxLength we passed in, not some other default.
+        composeRule.onNodeWithText("9/10").assertExists()
     }
 }

--- a/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
+++ b/android/app/src/test/kotlin/org/voxquieta/app/viewmodels/ChatViewModelTest.kt
@@ -11,6 +11,8 @@ import org.voxquieta.app.data.remote.api.BibleApiService
 import org.voxquieta.app.data.remote.models.BookNamesResponseDto
 import org.voxquieta.app.data.remote.models.ChapterResponseDto
 import org.voxquieta.app.data.remote.models.ChapterVerseDto
+import org.voxquieta.app.data.remote.models.ConfigChatDto
+import org.voxquieta.app.data.remote.models.ConfigResponseDto
 import org.voxquieta.app.data.remote.models.ContactSubject
 import org.voxquieta.app.data.remote.models.TranslationDto
 import org.voxquieta.app.data.remote.models.TranslationsResponseDto
@@ -37,6 +39,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -132,6 +135,12 @@ class ChatViewModelTest {
         coEvery { lastConversationPreferences.getLastConversationId() } returns null
         bibleApiService = mockk(relaxed = true)
         coEvery { bibleApiService.getTranslations() } returns TranslationsResponseDto(emptyList())
+        // BITB-075: the relaxed mock would otherwise return a garbage/default
+        // ConfigResponseDto; stub it explicitly so maxMessageLength updates
+        // are only exercised by tests that mean to exercise them.
+        coEvery { bibleApiService.getConfig() } returns ConfigResponseDto(
+            chat = ConfigChatDto(maxMessageLength = 500),
+        )
         viewModel = ChatViewModel(
             repository,
             churchRepository,
@@ -722,6 +731,168 @@ class ChatViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         coVerify(exactly = 1) { localApiService.getBookNames() }
+    }
+
+    // ── BITB-075: server-published max message length ─────────────────────
+
+    @Test
+    fun `initial state has the compiled-in fallback maxMessageLength before config loads`() {
+        // Before advanceUntilIdle() runs the init{} coroutines, the state must
+        // already carry the fallback constant (500) so the UI never briefly
+        // renders with 0 / an unset limit.
+        assertEquals(ChatViewModel.MAX_MESSAGE_LENGTH, viewModel.uiState.value.maxMessageLength)
+        assertEquals(500, viewModel.uiState.value.maxMessageLength)
+    }
+
+    @Test
+    fun `maxMessageLength reflects the server value once config loads`() = runTest {
+        coEvery { bibleApiService.getConfig() } returns ConfigResponseDto(
+            chat = ConfigChatDto(maxMessageLength = 800),
+        )
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(800, vm.uiState.value.maxMessageLength)
+    }
+
+    @Test
+    fun `maxMessageLength keeps the fallback when getConfig throws`() = runTest {
+        val localApiService = mockk<BibleApiService>(relaxed = true)
+        coEvery { localApiService.getTranslations() } returns TranslationsResponseDto(emptyList())
+        coEvery { localApiService.getConfig() } throws IOException("no network")
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            localApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ChatViewModel.MAX_MESSAGE_LENGTH, vm.uiState.value.maxMessageLength)
+    }
+
+    @Test
+    fun `maxMessageLength keeps the fallback when the server value is not a valid positive int`() = runTest {
+        val localApiService = mockk<BibleApiService>(relaxed = true)
+        coEvery { localApiService.getTranslations() } returns TranslationsResponseDto(emptyList())
+        coEvery { localApiService.getConfig() } returns ConfigResponseDto(
+            chat = ConfigChatDto(maxMessageLength = 0),
+        )
+
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            localApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ChatViewModel.MAX_MESSAGE_LENGTH, vm.uiState.value.maxMessageLength)
+    }
+
+    @Test
+    fun `fetchConfigWithRetry propagates CancellationException without retrying`() = runTest {
+        val localApiService = mockk<BibleApiService>(relaxed = true)
+        coEvery { localApiService.getConfig() } throws CancellationException("scope cancelled")
+
+        ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            localApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { localApiService.getConfig() }
+    }
+
+    @Test
+    fun `HTTP 422 error message uses the effective server-derived limit, not the raw constant`() = runTest {
+        // The context mock in setUp() doesn't stub error_message_too_long by
+        // default (BITB-075) — stub it here, scoped to this test, so a
+        // forgotten stub fails loudly instead of silently passing.
+        every {
+            context.getString(R.string.error_message_too_long, any())
+        } returns "Your message is a little long (max 800 characters)."
+        // Seed a non-default effective limit so this test can tell the
+        // difference between "uses the raw MAX_MESSAGE_LENGTH constant" (bug)
+        // and "uses the state-derived effective limit" (correct).
+        coEvery { bibleApiService.getConfig() } returns ConfigResponseDto(
+            chat = ConfigChatDto(maxMessageLength = 800),
+        )
+        val vm = ChatViewModel(
+            repository,
+            churchRepository,
+            contactRepository,
+            turnstileManager,
+            languagePreferences,
+            context,
+            themePreferences,
+            translationPreferences,
+            sessionPreferences,
+            lastConversationPreferences,
+            bibleApiService,
+            networkMonitor,
+            localeApplier,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(800, vm.uiState.value.maxMessageLength)
+
+        every { repository.chatStream(any()) } returns flow {
+            throw make422Exception("""{"detail": [{"msg": "String should have at most 800 characters"}]}""")
+        }
+
+        vm.sendMessage("Hello")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "Your message is a little long (max 800 characters).",
+            vm.uiState.value.error,
+        )
+        verify { context.getString(R.string.error_message_too_long, 800) }
     }
 
     @Test

--- a/api/config.py
+++ b/api/config.py
@@ -177,7 +177,7 @@ class Settings(BaseSettings):
     memory_warning_threshold_mb: int = 512  # Memory usage warning threshold
 
     # Security Settings
-    max_message_length: int = 300  # Max characters per chat message
+    max_message_length: int = 500  # Max characters per chat message
     rate_limit_enabled: bool = True
     # BITB-061: "postgres" shares counters across replicas and survives
     # restarts/deploys (the whole point of this setting); "memory" is the

--- a/api/main.py
+++ b/api/main.py
@@ -397,6 +397,7 @@ async def get_config():
         "chat": {
             "max_context_verses": settings.max_context_verses,
             "max_conversation_history": settings.max_conversation_history,
+            "max_message_length": settings.max_message_length,
         },
         "security": {
             "turnstile_enabled": settings.turnstile_enabled,

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from config import settings
 from providers import EmbeddingResponse, ProviderError
 
 # ==================== Health Route Tests ====================
@@ -422,6 +423,10 @@ class TestMainApp:
             assert "chat" in data
             assert "provider" in data["llm"]
             assert "model" in data["llm"]
+            # BITB-075: the effective chat message-length limit must be
+            # published so clients don't rely on a hard-coded, possibly
+            # out-of-sync, constant.
+            assert data["chat"]["max_message_length"] == settings.max_message_length
 
     def test_provider_error_handler(self):
         with (

--- a/api/tests/test_security.py
+++ b/api/tests/test_security.py
@@ -65,6 +65,34 @@ class TestInputValidation:
         request = ChatRequest(message=exact_message)
         assert len(request.message) == limit
 
+    def test_max_message_length_is_500(self):
+        """BITB-075: the configured default limit must be 500, not the old
+        300 (web/Android) or 200 (production terraform) values that used to
+        disagree with each other."""
+        assert settings.max_message_length == 500
+
+    def test_500_char_message_accepted(self):
+        """BITB-075: a 500-character message must be accepted end-to-end."""
+        message_500 = "a" * 500
+        request = ChatRequest(message=message_500)
+        assert len(request.message) == 500
+
+    def test_501_char_message_rejected_with_422(self):
+        """BITB-075: a message one character over the 500 limit must be
+        rejected by the API with HTTP 422 (not just at the Pydantic-model
+        level). Uses varied, realistic text (not a repeated character) so the
+        content filter's spam check doesn't mask the length rejection."""
+        client = TestClient(app)
+        sentence = "This is a realistic sentence about finding peace and hope. "
+        long_message = (sentence * ((501 // len(sentence)) + 1))[:501]
+        assert len(long_message) == 501
+
+        response = client.post(
+            "/api/v1/chat",
+            json={"message": long_message},
+        )
+        assert response.status_code == 422
+
     def test_valid_session_id(self):
         """Accept valid session ID format."""
         request = ChatRequest(message="Hello", session_id="abc123-xyz_456")
@@ -373,8 +401,13 @@ class TestSecurityIntegration:
     def test_message_too_long_returns_422(self):
         """API should return 422 for messages over limit."""
         client = TestClient(app)
-        # Use realistic text to avoid content filter triggering on repeated chars
-        long_message = "This is a test message that is too long " * 10  # Over 200 limit
+        # Use realistic text to avoid content filter triggering on repeated chars.
+        # Repeat enough times to exceed the configured limit (BITB-075: 500),
+        # rather than a fixed repeat count that would stop exceeding the limit
+        # whenever the limit is raised.
+        phrase = "This is a test message that is too long "
+        repeats = (settings.max_message_length // len(phrase)) + 2
+        long_message = phrase * repeats
 
         response = client.post("/api/v1/chat", json={"message": long_message})
         assert response.status_code == 422

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -801,7 +801,7 @@ The application includes several security features that are enabled by default i
 | Rate Limiting | `rate_limit_enabled` | `true` | Limits requests per IP/session |
 | Content Filtering | `content_filter_enabled` | `true` | Blocks profanity, spam, URLs |
 | Debug Mode | `debug_mode` | `false` | Prevents verbose error messages |
-| Message Length | `max_message_length` | `200` | Prevents oversized messages |
+| Message Length | `max_message_length` | `500` | Prevents oversized messages |
 
 ### Configuration in Terraform
 
@@ -812,7 +812,7 @@ log_level                      = "INFO"
 rate_limit_enabled             = true
 rate_limit_requests_per_minute = 20
 content_filter_enabled         = true
-max_message_length             = 200
+max_message_length             = 500
 ```
 
 ### Additional Best Practices

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -88,7 +88,7 @@ rate_limit_enabled             = true
 rate_limit_requests_per_minute = 10
 
 content_filter_enabled = true
-max_message_length     = 200
+max_message_length     = 500
 
 # -----------------------------------------------------------------------------
 # Azure OpenAI for Embeddings

--- a/deployment/terraform.tfvars.example
+++ b/deployment/terraform.tfvars.example
@@ -150,7 +150,7 @@ rate_limit_requests_per_minute = 10
 
 # Content filtering (blocks profanity, spam, URLs)
 content_filter_enabled = true
-max_message_length     = 200
+max_message_length     = 500
 
 # -----------------------------------------------------------------------------
 # Azure OpenAI for Embeddings (RECOMMENDED - very cheap!)

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -404,7 +404,7 @@ variable "content_filter_enabled" {
 variable "max_message_length" {
   description = "Maximum length of chat messages"
   type        = number
-  default     = 200
+  default     = 500
 }
 
 variable "content_safety_enabled" {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -170,7 +170,7 @@ All inputs are validated before processing.
 
 | Constraint | Value | Configuration |
 |------------|-------|---------------|
-| Max length | 200 chars | `MAX_MESSAGE_LENGTH` |
+| Max length | 500 chars | `MAX_MESSAGE_LENGTH` |
 | Min length | 1 char | Hardcoded |
 | Session ID format | Alphanumeric + `-_` | Regex pattern |
 | Session ID max length | 64 chars | Hardcoded |
@@ -224,7 +224,7 @@ CONTENT_FILTER_MAX_REPEATED_CHARS=5
 CONTENT_FILTER_MAX_URLS=0
 
 # Input Limits
-MAX_MESSAGE_LENGTH=200
+MAX_MESSAGE_LENGTH=500
 
 # CORS
 CORS_ORIGINS=https://custom-domain.com

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -45,7 +45,6 @@ import {
   StreamTimeoutError,
   MessageTooLongError,
   VerificationError,
-  MAX_MESSAGE_LENGTH,
   checkBackendReady,
   warmupBackend,
   StreamChunk,
@@ -60,6 +59,7 @@ import {
 import { updateMultiWordNames } from "@/lib/versePatterns";
 import { mergeVerses } from "@/lib/mergeVerses";
 import { useTurnstile } from "@/lib/turnstile";
+import { useServerConfig } from "@/lib/serverConfig";
 import { isSmokeMode } from "@/lib/smoke";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import ConversationSidebar from "@/components/ConversationSidebar";
@@ -97,6 +97,7 @@ export default function ChatIsland({
     isEnabled: turnstileEnabled,
     configLoaded: turnstileConfigLoaded,
   } = useTurnstile();
+  const { maxMessageLength } = useServerConfig();
   // Block submissions until /config has resolved: until then we don't yet
   // know whether Turnstile is enabled, and a fast click could fire a POST
   // without an X-Turnstile-Token header and get bounced as 403.
@@ -735,7 +736,7 @@ export default function ChatIsland({
       // Backend rejected an over-long message (422) — tell the user to shorten
       // it instead of showing a misleading connection error.
       if (error instanceof MessageTooLongError) {
-        showError(tChat("messageTooLong", { max: MAX_MESSAGE_LENGTH }));
+        showError(tChat("messageTooLong", { max: maxMessageLength }));
         setIsLoading(false);
         return;
       }
@@ -1177,7 +1178,7 @@ export default function ChatIsland({
               onKeyDown={handleInputKeyDown}
               placeholder={tChat("inputPlaceholder")}
               rows={1}
-              maxLength={MAX_MESSAGE_LENGTH}
+              maxLength={maxMessageLength}
               className="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none overflow-y-auto leading-6"
               disabled={showSessionLimitButton}
             />
@@ -1205,16 +1206,16 @@ export default function ChatIsland({
           </form>
           {/* Character counter — surfaces only as the user nears the limit so
               they understand why a long message can't grow further. */}
-          {input.length >= MAX_MESSAGE_LENGTH * 0.8 && (
+          {input.length >= maxMessageLength * 0.8 && (
             <p
               className={`text-xs mt-1 text-right ${
-                input.length >= MAX_MESSAGE_LENGTH
+                input.length >= maxMessageLength
                   ? "text-red-500"
                   : "text-gray-400"
               }`}
               aria-live="polite"
             >
-              {input.length}/{MAX_MESSAGE_LENGTH}
+              {input.length}/{maxMessageLength}
             </p>
           )}
           <p className="text-xs text-gray-400 mt-2 text-center">

--- a/frontend/src/app/[locale]/page.server.test.tsx
+++ b/frontend/src/app/[locale]/page.server.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/lib/api", () => ({
   ColdStartError: class ColdStartError extends Error {},
   ContentBlockedError: class ContentBlockedError extends Error {},
   SessionLimitError: class SessionLimitError extends Error {},
+  MAX_MESSAGE_LENGTH: 500,
   checkBackendReady: vi.fn().mockResolvedValue(true),
   warmupBackend: vi.fn(),
   searchChurches: vi.fn(),

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -33,7 +33,7 @@ vi.mock("@/lib/api", () => ({
   generateSessionId: vi.fn().mockReturnValue("test-session-id"),
   getOrCreateSessionId: vi.fn().mockReturnValue("test-session-id"),
   ColdStartError: class ColdStartError extends Error {},
-  MAX_MESSAGE_LENGTH: 300,
+  MAX_MESSAGE_LENGTH: 500,
   checkBackendReady: vi.fn().mockResolvedValue(true),
   warmupBackend: vi.fn((onReady: () => void) => {
     onReady();

--- a/frontend/src/app/[locale]/providers.test.tsx
+++ b/frontend/src/app/[locale]/providers.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/lib/api", () => ({
   setTurnstileToken: () => {},
   setOnTokenConsumed: () => {},
   setTurnstileAwaiter: () => {},
+  MAX_MESSAGE_LENGTH: 500,
 }));
 vi.mock("@/lib/clientErrorReporter", () => ({ reportClientError: () => {} }));
 

--- a/frontend/src/app/[locale]/providers.tsx
+++ b/frontend/src/app/[locale]/providers.tsx
@@ -8,6 +8,7 @@ import {
   setTurnstileAwaiter,
 } from "@/lib/api";
 import { useTurnstile } from "@/lib/turnstile";
+import { ServerConfigProvider } from "@/lib/serverConfig";
 import { reportClientError } from "@/lib/clientErrorReporter";
 import { SplashScreen } from "@/components/SplashScreen";
 import AboutIntroModal from "@/components/AboutIntroModal";
@@ -123,23 +124,25 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <TurnstileProvider>
-      <TurnstileTokenSync>
-        {!splashDone && (
-          <SplashScreen
-            onComplete={() => {
-              setSplashCookie();
-              setSplashDone(true);
-            }}
-          />
-        )}
-        <AboutIntroGateProvider value={introGate}>
-          {children}
-        </AboutIntroGateProvider>
-        {splashDone && showAboutIntro && (
-          <AboutIntroModal onDismiss={dismissAboutIntro} />
-        )}
-      </TurnstileTokenSync>
-    </TurnstileProvider>
+    <ServerConfigProvider>
+      <TurnstileProvider>
+        <TurnstileTokenSync>
+          {!splashDone && (
+            <SplashScreen
+              onComplete={() => {
+                setSplashCookie();
+                setSplashDone(true);
+              }}
+            />
+          )}
+          <AboutIntroGateProvider value={introGate}>
+            {children}
+          </AboutIntroGateProvider>
+          {splashDone && showAboutIntro && (
+            <AboutIntroModal onDismiss={dismissAboutIntro} />
+          )}
+        </TurnstileTokenSync>
+      </TurnstileProvider>
+    </ServerConfigProvider>
   );
 }

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1072,13 +1072,13 @@ describe("streamMessage", () => {
           {
             type: "string_too_long",
             loc: ["body", "message"],
-            msg: "String should have at most 300 characters",
+            msg: "String should have at most 500 characters",
           },
         ],
       }),
     });
 
-    const gen = streamMessage("a".repeat(301));
+    const gen = streamMessage("a".repeat(501));
     await expect(gen.next()).rejects.toBeInstanceOf(MessageTooLongError);
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -114,11 +114,13 @@ export class VerificationError extends Error {
 }
 
 /**
- * Max characters allowed in a single chat message. MUST stay in sync with the
- * backend's `max_message_length` setting (api/config.py); the server rejects
- * anything longer with HTTP 422.
+ * Pre-config fallback only. The effective max characters allowed in a single
+ * chat message comes from the backend at runtime via `GET /config` ->
+ * `chat.max_message_length` (see `useServerConfig()` in `@/lib/serverConfig`);
+ * this constant is used only until that fetch resolves (or if it fails). The
+ * server always enforces its own configured limit regardless of this value.
  */
-export const MAX_MESSAGE_LENGTH = 300;
+export const MAX_MESSAGE_LENGTH = 500;
 
 /**
  * Max time to wait for the next chunk from the streaming endpoint before

--- a/frontend/src/lib/serverConfig.test.tsx
+++ b/frontend/src/lib/serverConfig.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { ServerConfigProvider, useServerConfig } from "./serverConfig";
+
+// BITB-075: the effective chat message limit is published by the backend via
+// GET /config -> chat.max_message_length, with the compiled-in
+// MAX_MESSAGE_LENGTH constant (currently 500) used only as a pre-fetch /
+// fail-open fallback.
+
+function wrapper(apiUrl = "http://test.example") {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <ServerConfigProvider apiUrl={apiUrl}>{children}</ServerConfigProvider>
+    );
+  };
+}
+
+describe("ServerConfigProvider", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("starts with the compiled-in fallback before /config resolves", () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { result } = renderHook(() => useServerConfig(), {
+      wrapper: wrapper(),
+    });
+
+    expect(result.current.maxMessageLength).toBe(500);
+  });
+
+  it("adopts the server value when /config succeeds", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ chat: { max_message_length: 500 } }),
+    });
+
+    const { result } = renderHook(() => useServerConfig(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.maxMessageLength).toBe(500);
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://test.example/config");
+  });
+
+  it("adopts a different server value when the backend disagrees with the fallback", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ chat: { max_message_length: 800 } }),
+    });
+
+    const { result } = renderHook(() => useServerConfig(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.maxMessageLength).toBe(800);
+    });
+  });
+
+  it("keeps the fallback when the fetch rejects (network error)", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useServerConfig(), {
+      wrapper: wrapper(),
+    });
+
+    // Give the failed fetch a tick to settle.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(result.current.maxMessageLength).toBe(500);
+  });
+
+  it("keeps the fallback when the response is not ok", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useServerConfig(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(result.current.maxMessageLength).toBe(500);
+  });
+
+  it("keeps the fallback when chat is missing from the response", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const { result } = renderHook(() => useServerConfig(), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(result.current.maxMessageLength).toBe(500);
+  });
+
+  it.each([0, -5, 12.5, "500", null, undefined])(
+    "keeps the fallback when max_message_length is invalid (%p)",
+    async (invalidValue) => {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ chat: { max_message_length: invalidValue } }),
+      });
+
+      const { result } = renderHook(() => useServerConfig(), {
+        wrapper: wrapper(),
+      });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalled();
+      });
+      expect(result.current.maxMessageLength).toBe(500);
+    },
+  );
+
+  it("fetches /config unconditionally, regardless of Turnstile build-time site-key state", async () => {
+    // Regression test for the prod-skip trap: TurnstileProvider skips its own
+    // /config fetch whenever NEXT_PUBLIC_TURNSTILE_SITE_KEY is set at build
+    // time (always true in production, see frontend/Dockerfile). This
+    // provider must NOT inherit that behaviour — it has no build-time
+    // shortcut and always fetches, so the message-limit config is never
+    // silently dead in prod.
+    const originalSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+    process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = "prod-build-time-site-key";
+
+    try {
+      const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ chat: { max_message_length: 500 } }),
+      });
+
+      renderHook(() => useServerConfig(), { wrapper: wrapper() });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith("http://test.example/config");
+      });
+    } finally {
+      if (originalSiteKey === undefined) {
+        delete process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+      } else {
+        process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = originalSiteKey;
+      }
+    }
+  });
+
+  it("uses the NEXT_PUBLIC_API_URL default when no apiUrl prop is supplied", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ chat: { max_message_length: 500 } }),
+    });
+
+    renderHook(() => useServerConfig(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ServerConfigProvider>{children}</ServerConfigProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/config"),
+      );
+    });
+  });
+});

--- a/frontend/src/lib/serverConfig.tsx
+++ b/frontend/src/lib/serverConfig.tsx
@@ -44,11 +44,7 @@ export function ServerConfigProvider({
         if (!response.ok) return;
         const config = await response.json();
         const value = config?.chat?.max_message_length;
-        if (
-          !cancelled &&
-          Number.isInteger(value) &&
-          value > 0
-        ) {
+        if (!cancelled && Number.isInteger(value) && value > 0) {
           setMaxMessageLength(value);
         }
       } catch {

--- a/frontend/src/lib/serverConfig.tsx
+++ b/frontend/src/lib/serverConfig.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { MAX_MESSAGE_LENGTH } from "@/lib/api";
+
+// BITB-075: publishes server-controlled chat configuration (currently just
+// the effective message-length limit) to the client tree. Deliberately does
+// its OWN unconditional /config fetch rather than reusing/extending
+// TurnstileProvider: that provider skips its /config round-trip whenever a
+// build-time Turnstile site key is present, which is always true in
+// production (baked in via frontend/Dockerfile), so piggybacking on it would
+// make this feature silently dead in prod. Fails open on any error and keeps
+// the compiled-in fallback, matching the rest of the app's config-fetch style.
+interface ServerConfigValue {
+  maxMessageLength: number;
+}
+
+const ServerConfigContext = createContext<ServerConfigValue>({
+  maxMessageLength: MAX_MESSAGE_LENGTH,
+});
+
+export function useServerConfig(): ServerConfigValue {
+  return useContext(ServerConfigContext);
+}
+
+interface ServerConfigProviderProps {
+  children: React.ReactNode;
+  apiUrl?: string;
+}
+
+export function ServerConfigProvider({
+  children,
+  apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+}: ServerConfigProviderProps) {
+  const [maxMessageLength, setMaxMessageLength] =
+    useState<number>(MAX_MESSAGE_LENGTH);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchConfig = async () => {
+      try {
+        const response = await fetch(`${apiUrl}/config`);
+        if (!response.ok) return;
+        const config = await response.json();
+        const value = config?.chat?.max_message_length;
+        if (
+          !cancelled &&
+          Number.isInteger(value) &&
+          value > 0
+        ) {
+          setMaxMessageLength(value);
+        }
+      } catch {
+        // Fail open: keep the compiled-in fallback.
+      }
+    };
+
+    fetchConfig();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl]);
+
+  return (
+    <ServerConfigContext.Provider value={{ maxMessageLength }}>
+      {children}
+    </ServerConfigContext.Provider>
+  );
+}

--- a/scripts/env-manifest.yaml
+++ b/scripts/env-manifest.yaml
@@ -154,7 +154,7 @@ variables:
   MAX_MESSAGE_LENGTH:
     required_in: remote
     description: Maximum chat message length
-    default: "200"
+    default: "500"
 
   ENVIRONMENT:
     required_in: remote


### PR DESCRIPTION
## What

Fixes a live production bug: the chat message length limit was hard-coded in six disagreeing places. The deployed backend rejected messages over **200** characters while both the web and Android clients advertised and allowed up to **300** — so a 250-character message would type fine, send, and come back rejected with an error showing the wrong limit.

- **Raise the limit to 500** everywhere it lived: `api/config.py`, `deployment/variables.tf`, `deployment/terraform.tfvars(.example)`, `deployment/README.md`, `scripts/env-manifest.yaml`, `docs/SECURITY.md`.
- **Publish the effective limit from the backend** — `GET /config` now returns `chat.max_message_length`.
- **Clients follow the server, not a hard-coded number.** Compiled-in constants (bumped to 500) now serve only as pre-fetch fallbacks:
  - Web: new `ServerConfigProvider`/`useServerConfig()` (`frontend/src/lib/serverConfig.tsx`) does its own **unconditional** `/config` fetch. It's deliberately *not* built on the existing `TurnstileProvider`, which skips its own `/config` round-trip whenever a build-time Turnstile site key is present — which is always true in production (baked in via `frontend/Dockerfile`). Reusing it would have made this feature silently dead in prod.
  - Android: new `getConfig()` endpoint + `ConfigResponseDto`, fetched with retry/backoff in `ChatViewModel.init{}` (same shape as the existing `fetchBookNamesWithRetry`), feeding `ChatUiState.maxMessageLength`.
- `ChatInputField.kt`'s `maxLength` parameter lost its `= 300` default so a stale value can no longer silently creep back in — call sites must be explicit.

Full story: `docs/BACKLOG_STORIES/BITB-075-raise-message-limit-to-500.md`

## Deploy-order note

Merging this PR alone does **not** fix production. `deployment/terraform.tfvars` unconditionally injects `MAX_MESSAGE_LENGTH` into the backend container, overriding the code default — a `terraform apply` is required alongside the code deploy for the live 200-char limit to actually become 500.

## Test plan

- [x] `python -m pytest api/tests/test_security.py api/tests/test_routes_main_coverage.py -v` — 138 passed, incl. new 500/501-char boundary tests and a `GET /config` assertion on `chat.max_message_length`
- [x] `cd frontend && npm run lint && npm run type-check && npx vitest run` — clean, 814/814 passed, incl. a new `serverConfig.test.tsx` regression test that the `/config` fetch fires even when a Turnstile build-time site key is present
- [ ] Android — could not build/test locally (no Android SDK in this environment, and `com.android.application` plugin resolution failed against Google's Maven repo from the sandbox). Edits were made by hand mirroring existing conventions (`ChatViewModelTest.kt` updated with new coverage for the config fetch and the 422-error-message path). **CI must confirm the Android build/tests are green.**
- [ ] `make pre-commit` — not run as a single pass; component pieces (backend pytest, frontend lint/type-check/vitest) verified individually as above

## Notes

- Out of scope (per the story): fully dynamic per-locale limits, and the separate contact-form message limit (a different field, tracked under BITB-051/052).
- `deployment/README.md:802`'s unrelated `rate_limit_requests_per_minute` drift (20 vs 10) was left untouched — different bug, not part of this story.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FZ4cxwztxCuBMPd3E9Dffs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZ4cxwztxCuBMPd3E9Dffs)_