### PR TITLE
fix(frontend): make chat page footer links reachable (BITB-079)

### DIFF
--- a/frontend/e2e/chat-bottom-bar.spec.ts
+++ b/frontend/e2e/chat-bottom-bar.spec.ts
@@ -61,9 +61,7 @@ test.describe("chat page bottom bar", () => {
     expect(textareaBox).not.toBeNull();
     expect(textareaBox!.y + textareaBox!.height).toBeLessThanOrEqual(641);
 
-    const linksBox = await page
-      .getByTestId("chat-footer-links")
-      .boundingBox();
+    const linksBox = await page.getByTestId("chat-footer-links").boundingBox();
     expect(linksBox).not.toBeNull();
     expect(linksBox!.y + linksBox!.height).toBeLessThanOrEqual(641);
   });

--- a/frontend/e2e/chat-bottom-bar.spec.ts
+++ b/frontend/e2e/chat-bottom-bar.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test";
+
+// BITB-079: the chat page's footer links were rendered after a full-viewport
+// (h-dvh) chat shell, so they existed in the DOM but were never reachable
+// without a document-level scroll the chat page's own internal scrolling
+// swallows. These specs assert the compact in-shell link row is on screen
+// without any scrolling, at representative mobile and desktop viewports.
+
+const VIEWPORTS = [
+  { width: 360, height: 640, label: "small mobile" },
+  { width: 390, height: 844, label: "large mobile" },
+  { width: 768, height: 1024, label: "tablet" },
+  { width: 1440, height: 900, label: "desktop" },
+];
+
+test.describe("chat page bottom bar", () => {
+  for (const vp of VIEWPORTS) {
+    test(`footer links are on screen at ${vp.label} (${vp.width}x${vp.height}) without scrolling`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/en");
+      await page.waitForLoadState("networkidle");
+
+      const privacyLink = page
+        .getByTestId("chat-footer-links")
+        .getByRole("link", { name: "Privacy" });
+      await expect(privacyLink).toBeVisible();
+
+      const box = await privacyLink.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.y).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(vp.width + 1);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(vp.height + 1);
+    });
+
+    test(`no horizontal overflow at ${vp.label} (${vp.width}x${vp.height})`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/en");
+      await page.waitForLoadState("networkidle");
+
+      const hasOverflow = await page.evaluate(
+        () => document.documentElement.scrollWidth > window.innerWidth + 1,
+      );
+      expect(hasOverflow).toBe(false);
+    });
+  }
+
+  test("composer and footer links are both fully visible on a small phone", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 640 });
+    await page.goto("/en");
+    await page.waitForLoadState("networkidle");
+
+    const textarea = page.getByRole("textbox");
+    const textareaBox = await textarea.boundingBox();
+    expect(textareaBox).not.toBeNull();
+    expect(textareaBox!.y + textareaBox!.height).toBeLessThanOrEqual(641);
+
+    const linksBox = await page
+      .getByTestId("chat-footer-links")
+      .boundingBox();
+    expect(linksBox).not.toBeNull();
+    expect(linksBox!.y + linksBox!.height).toBeLessThanOrEqual(641);
+  });
+
+  test("composer stays visible when the viewport shrinks (mobile keyboard proxy)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 640 });
+    await page.goto("/en");
+    await page.waitForLoadState("networkidle");
+
+    // A real on-screen keyboard shrinks the visual viewport; approximate it
+    // by shrinking the viewport itself. Real iOS Safari / Android Chrome
+    // keyboard behavior still needs manual verification per the story.
+    await page.setViewportSize({ width: 360, height: 360 });
+
+    const textarea = page.getByRole("textbox");
+    await expect(textarea).toBeVisible();
+    const box = await textarea.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(361);
+  });
+
+  test("no duplicate footer is rendered on the chat page, and the page footer still renders elsewhere", async ({
+    page,
+  }) => {
+    await page.goto("/en");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("footer")).toHaveCount(0);
+
+    await page.goto("/en/privacy");
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("footer")).toHaveCount(1);
+  });
+
+  test("footer links render correctly in RTL (Arabic)", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/ar");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+    await expect(page.getByTestId("chat-footer-links")).toBeVisible();
+
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1,
+    );
+    expect(hasOverflow).toBe(false);
+  });
+});

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -194,7 +194,9 @@ export default function ChatIsland({
   // Only one promo/suggestion element in the sticky bottom region at a time,
   // so it never crowds the composer off a small screen (BITB-079).
   const showLanguageSuggestion =
-    !!languageSuggestion && !languageSuggestionDismissed && !showSessionLimitButton;
+    !!languageSuggestion &&
+    !languageSuggestionDismissed &&
+    !showSessionLimitButton;
 
   // Show church finder banner after 3+ messages and not dismissed
   const showChurchFinderBanner =

--- a/frontend/src/app/[locale]/ChatIsland.tsx
+++ b/frontend/src/app/[locale]/ChatIsland.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useTranslations, useLocale } from "next-intl";
 import { Link } from "@/i18n/navigation";
+import ChatFooterLinks from "@/components/ChatFooterLinks";
 import ChatMessage from "@/components/ChatMessage";
 import VerseCard from "@/components/VerseCard";
 import ChapterModal from "@/components/ChapterModal";
@@ -190,9 +191,18 @@ export default function ChatIsland({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyRefresh, setHistoryRefresh] = useState(0);
 
+  // Only one promo/suggestion element in the sticky bottom region at a time,
+  // so it never crowds the composer off a small screen (BITB-079).
+  const showLanguageSuggestion =
+    !!languageSuggestion && !languageSuggestionDismissed && !showSessionLimitButton;
+
   // Show church finder banner after 3+ messages and not dismissed
   const showChurchFinderBanner =
-    interactionCount >= 3 && !churchFinderDismissed && messages.length > 0;
+    interactionCount >= 3 &&
+    !churchFinderDismissed &&
+    messages.length > 0 &&
+    !showSessionLimitButton &&
+    !showLanguageSuggestion;
 
   // Translation preference
   const [translations, setTranslations] = useState<TranslationInfo[]>([]);
@@ -1161,7 +1171,7 @@ export default function ChatIsland({
           )}
 
           {/* Language-mismatch suggestion */}
-          {languageSuggestion && !languageSuggestionDismissed && (
+          {showLanguageSuggestion && (
             <LanguageSwitchSuggestion
               suggestedLocale={languageSuggestion}
               onSwitch={handleLanguageSwitch}
@@ -1220,6 +1230,10 @@ export default function ChatIsland({
           <p className="text-xs text-gray-400 mt-2 text-center">
             {tChat("disclaimer")}
           </p>
+
+          {/* Compact link row — the page-level Footer is unreachable on this
+              h-dvh chat page, so these links live in the shell instead. */}
+          <ChatFooterLinks />
 
           {/* Church Finder Banner */}
           {showChurchFinderBanner && (

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -11,7 +11,7 @@ import { routing } from "@/i18n/routing";
 import { pageMetadata, buildJsonLd, SITE_NAME } from "@/lib/seo";
 import { Providers } from "./providers";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import Footer from "@/components/Footer";
+import FooterGate from "@/components/FooterGate";
 import WhatsNewModal from "@/components/WhatsNewModal";
 
 export async function generateMetadata({
@@ -107,7 +107,7 @@ export default async function LocaleLayout({
             <ErrorBoundary>
               <div className="min-h-screen bg-gradient-to-b from-primary-50 to-white flex flex-col [overflow-x:clip]">
                 <div className="flex-1">{children}</div>
-                <Footer />
+                <FooterGate />
               </div>
               <WhatsNewModal />
             </ErrorBoundary>

--- a/frontend/src/app/[locale]/page.test.tsx
+++ b/frontend/src/app/[locale]/page.test.tsx
@@ -616,9 +616,18 @@ describe("Home page responsive layout", () => {
     it("renders an emphasized header pill link to /app", () => {
       renderWithIntl(<Home />);
 
-      const label = screen.getByText(enMessages.Header.appCta);
-      const headerLink = label.closest('a[href="/app"]');
-      expect(headerLink).not.toBeNull();
+      // The chat page's compact footer link row (BITB-079) also links to
+      // /app with the same label, so disambiguate by finding the pill —
+      // the emphasized filled link, not any /app link.
+      const labels = screen.getAllByText(enMessages.Header.appCta);
+      const headerLink = labels
+        .map((label) => label.closest('a[href="/app"]'))
+        .find(
+          (link) =>
+            link?.className.includes("rounded-full") &&
+            link?.className.includes("bg-teal-600"),
+        );
+      expect(headerLink).not.toBeUndefined();
       // Guard the *emphasis*, not just presence: the regression downgraded the
       // pill to a muted text link. The filled pill is what makes it a primary
       // call to action.

--- a/frontend/src/components/ChatFooterLinks.test.tsx
+++ b/frontend/src/components/ChatFooterLinks.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ChatFooterLinks from "./ChatFooterLinks";
+import { renderWithIntl } from "@/test/i18n-helpers";
+import enMessages from "../../messages/en.json";
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: ({
+    children,
+    href,
+  }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("ChatFooterLinks", () => {
+  it("renders the same five links as the page-level Footer", () => {
+    renderWithIntl(<ChatFooterLinks />);
+
+    const nav = screen.getByTestId("chat-footer-links");
+    const hrefs = Array.from(nav.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs).toEqual(["/app", "/about", "/privacy", "/terms", "/changelog"]);
+  });
+
+  it("labels each link with the translated Footer/Legal copy", () => {
+    renderWithIntl(<ChatFooterLinks />);
+
+    expect(screen.getByText(enMessages.Footer.getApp)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.Footer.about)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.Legal.navPrivacy)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.Legal.navTerms)).toBeInTheDocument();
+    expect(screen.getByText(enMessages.Footer.changelog)).toBeInTheDocument();
+  });
+
+  it("renders as a nav, not a second <footer>", () => {
+    renderWithIntl(<ChatFooterLinks />);
+    expect(document.querySelector("footer")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ChatFooterLinks.test.tsx
+++ b/frontend/src/components/ChatFooterLinks.test.tsx
@@ -5,10 +5,7 @@ import { renderWithIntl } from "@/test/i18n-helpers";
 import enMessages from "../../messages/en.json";
 
 vi.mock("@/i18n/navigation", () => ({
-  Link: ({
-    children,
-    href,
-  }: React.PropsWithChildren<{ href: string }>) => (
+  Link: ({ children, href }: React.PropsWithChildren<{ href: string }>) => (
     <a href={href}>{children}</a>
   ),
 }));
@@ -21,7 +18,13 @@ describe("ChatFooterLinks", () => {
     const hrefs = Array.from(nav.querySelectorAll("a")).map((a) =>
       a.getAttribute("href"),
     );
-    expect(hrefs).toEqual(["/app", "/about", "/privacy", "/terms", "/changelog"]);
+    expect(hrefs).toEqual([
+      "/app",
+      "/about",
+      "/privacy",
+      "/terms",
+      "/changelog",
+    ]);
   });
 
   it("labels each link with the translated Footer/Legal copy", () => {

--- a/frontend/src/components/ChatFooterLinks.tsx
+++ b/frontend/src/components/ChatFooterLinks.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Link } from "@/i18n/navigation";
+import { useFooterLinks } from "./Footer";
+
+// The chat page gives its <main> the full viewport height (h-dvh), so the
+// page-level <Footer> rendered after it is always one screen below the fold
+// and effectively unreachable (BITB-079). This compact row renders the same
+// links inside the chat shell's own sticky bottom container instead.
+export default function ChatFooterLinks() {
+  const links = useFooterLinks();
+
+  return (
+    <nav
+      data-testid="chat-footer-links"
+      className="mt-1 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-[11px] text-gray-400"
+    >
+      {links.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="hover:text-primary-700 transition-colors"
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/ContactForm.tsx
+++ b/frontend/src/components/ContactForm.tsx
@@ -95,7 +95,7 @@ export default function ContactForm() {
   };
 
   return (
-    <div className="mt-6 border-t border-gray-200 pt-4">
+    <div className="mt-3 pt-3 sm:mt-6 sm:pt-4 border-t border-gray-200">
       {/* Header - always visible */}
       <button
         onClick={() => setIsExpanded(!isExpanded)}
@@ -114,7 +114,7 @@ export default function ContactForm() {
 
       {/* Collapsible content */}
       {isExpanded && (
-        <div className="mt-4 space-y-4">
+        <div className="mt-4 space-y-4 max-h-[50dvh] overflow-y-auto">
           {/* Contact email */}
           <div className="flex items-center gap-2 text-sm">
             <Mail className="w-4 h-4 text-gray-400" />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,40 +1,37 @@
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 
-export default function Footer() {
+// Shared with ChatFooterLinks (a compact variant rendered inside the chat
+// page's own scroll area, since the page-level Footer below is never
+// reachable there — see BITB-079).
+export function useFooterLinks() {
   const tLegal = useTranslations("Legal");
   const tFooter = useTranslations("Footer");
+
+  return [
+    { href: "/app", label: tFooter("getApp") },
+    { href: "/about", label: tFooter("about") },
+    { href: "/privacy", label: tLegal("navPrivacy") },
+    { href: "/terms", label: tLegal("navTerms") },
+    { href: "/changelog", label: tFooter("changelog") },
+  ] as const;
+}
+
+export default function Footer() {
+  const links = useFooterLinks();
 
   return (
     <footer className="border-t border-gray-200 bg-white py-6 mt-8">
       <div className="max-w-3xl mx-auto px-4 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-500">
-        <Link href="/app" className="hover:text-primary-700 transition-colors">
-          {tFooter("getApp")}
-        </Link>
-        <Link
-          href="/about"
-          className="hover:text-primary-700 transition-colors"
-        >
-          {tFooter("about")}
-        </Link>
-        <Link
-          href="/privacy"
-          className="hover:text-primary-700 transition-colors"
-        >
-          {tLegal("navPrivacy")}
-        </Link>
-        <Link
-          href="/terms"
-          className="hover:text-primary-700 transition-colors"
-        >
-          {tLegal("navTerms")}
-        </Link>
-        <Link
-          href="/changelog"
-          className="hover:text-primary-700 transition-colors"
-        >
-          {tFooter("changelog")}
-        </Link>
+        {links.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className="hover:text-primary-700 transition-colors"
+          >
+            {link.label}
+          </Link>
+        ))}
       </div>
     </footer>
   );

--- a/frontend/src/components/FooterGate.test.tsx
+++ b/frontend/src/components/FooterGate.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import FooterGate from "./FooterGate";
+import { renderWithIntl } from "@/test/i18n-helpers";
+
+const mockPathname = vi.fn();
+
+vi.mock("@/i18n/navigation", () => ({
+  usePathname: () => mockPathname(),
+  Link: ({
+    children,
+    href,
+  }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe("FooterGate", () => {
+  it("renders nothing on the chat page (root path)", () => {
+    mockPathname.mockReturnValue("/");
+    const { container } = renderWithIntl(<FooterGate />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the page-level Footer on every other route", () => {
+    mockPathname.mockReturnValue("/privacy");
+    const { container } = renderWithIntl(<FooterGate />);
+    expect(container.querySelector("footer")).not.toBeNull();
+  });
+});

--- a/frontend/src/components/FooterGate.test.tsx
+++ b/frontend/src/components/FooterGate.test.tsx
@@ -6,10 +6,7 @@ const mockPathname = vi.fn();
 
 vi.mock("@/i18n/navigation", () => ({
   usePathname: () => mockPathname(),
-  Link: ({
-    children,
-    href,
-  }: React.PropsWithChildren<{ href: string }>) => (
+  Link: ({ children, href }: React.PropsWithChildren<{ href: string }>) => (
     <a href={href}>{children}</a>
   ),
 }));

--- a/frontend/src/components/FooterGate.tsx
+++ b/frontend/src/components/FooterGate.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { usePathname } from "@/i18n/navigation";
+import Footer from "./Footer";
+
+// The chat page (the site root) renders its own in-shell link row
+// (ChatFooterLinks) because the page-level Footer is unreachable there
+// (BITB-079, h-dvh chat + footer-after-content). Every other route keeps
+// the normal page-level footer.
+export default function FooterGate() {
+  const pathname = usePathname();
+  if (pathname === "/") return null;
+  return <Footer />;
+}


### PR DESCRIPTION
## What

Fixes P1 story `docs/BACKLOG_STORIES/BITB-079-web-bottom-bar-always-offscreen.md`: on the chat page the footer (About / Get the app / Privacy / Terms / Changelog) is rendered but never reachable in practice, since the page-level `<Footer>` sits one full footer-height below a chat shell that occupies `100dvh` on its own. `/privacy` and `/terms` are legally required disclosures and `/app` is the Play Store funnel, so a navigation surface that exists in the DOM and never appears on screen is the same as not having one.

- **New `ChatFooterLinks`** — a compact link row rendered inside the chat page's own sticky bottom container (right after the disclaimer, before `ChurchFinderBanner`/`ContactForm`), reusing the same links/translations as the page-level footer via a new `useFooterLinks()` hook extracted from `Footer.tsx`. No new translation keys — all five labels already exist in every locale.
- **New `FooterGate`** — a thin client wrapper around `layout.tsx`'s `<Footer />` that renders `null` on the chat route (site root) and the normal `<Footer />` everywhere else (`/app`, `/privacy`, `/terms`, `/changelog`, `/about` are all pixel-unchanged).
- **Decrowd the sticky bottom region** (in scope per the story): `ContactForm` gets tighter default spacing (`mt-3 pt-3` vs `mt-6 pt-4` on mobile) and a `max-h-[50dvh] overflow-y-auto` cap on its expanded panel so it can never push the composer or the new link row off screen. Only one promo/suggestion element (session-limit button, language-switch suggestion, church-finder banner) is now shown at a time — the language suggestion takes priority over the church-finder banner when both would otherwise fire.

## Test plan

- [x] `cd frontend && npm run lint && npm run type-check && npx vitest run` — clean, 805/805 passed (one existing test, `page.test.tsx`'s "header pill link to /app" assertion, was updated to disambiguate against the new footer row's identical "Get the app" label)
- [x] New unit tests: `ChatFooterLinks.test.tsx` (links/labels render correctly, renders as `<nav>` not a second `<footer>`), `FooterGate.test.tsx` (hides Footer on `/`, renders it elsewhere)
- [x] New `frontend/e2e/chat-bottom-bar.spec.ts` — ran locally against `npm run dev`: footer links fully in-viewport with no scrolling at 360×640/390×844/768×1024/1440×900, no horizontal overflow at any of those, composer + link row both visible on a small phone, composer stays visible when the viewport shrinks (mobile-keyboard proxy), no duplicate `<footer>` on the chat page (and the page footer still renders on `/privacy`), and RTL (`/ar`) renders correctly. **12/12 passed.** (Not wired into CI — matches the existing `turnstile-ready.spec.ts`, which also isn't referenced by any workflow; only `prod-chat-smoke.spec.ts` runs in `prod-browser-smoke.yml`.)
- [ ] `make pre-commit` — not run as a single pass (frontend-only change; lint/type-check/vitest/e2e verified individually as above)

## Notes

- Approach chosen per the story's own recommendation (a compact in-shell link row) over shrinking `main`'s `h-dvh` to subtract a footer-height CSS variable, which would have needed care around the mobile keyboard and would have broken an existing `h-dvh` assertion in `page.test.tsx`.
- Known residual, not fixed here: `layout.tsx`'s outer wrapper is `min-h-screen` (`100vh`) while the chat main is `100dvh`; on mobile browsers with retracting chrome this can leave a few px of document-level scroll. Harmless now that the footer links live inside the viewport-bound shell, and invisible under Playwright's fixed viewport (`vh === dvh` there).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01529goP9wY4MzBCBwwgcz6t

---
_Generated by [Claude Code](https://claude.ai/code/session_01529goP9wY4MzBCBwwgcz6t)_