### PR TITLE
feat(api): ask one clarifying question on a vague first message (BITB-078)

### DIFF
--- a/api/chat/prompts.py
+++ b/api/chat/prompts.py
@@ -709,15 +709,42 @@ Categories:
 - GUIDANCE: seeking wisdom for a decision or life situation
 - CURIOSITY: asking a question about the Bible, theology, or faith
 - VERSE_LOOKUP: asking about a specific Bible verse or passage
+- NEEDS_CLARIFICATION: too short or vague to know what the person actually needs -- no \
+situation and no need named (e.g. "help", "I'm lost", "pray for me", "verse please"), or \
+genuinely ambiguous between materially different readings (e.g. "should I leave?" could mean \
+a job, a marriage, or a church). Do NOT choose this when the message already names a situation \
+AND a need (e.g. "my mother died last week, I can't pray"), or when it is a specific verse/\
+passage lookup.
 - OFF_TOPIC: clearly unrelated to faith, the Bible, or spiritual life \
 (e.g., travel, sports, cooking, games, programming, politics)
 - GENERAL: general conversation or unclear intent within a spiritual context
 
+When in doubt between NEEDS_CLARIFICATION and another category, choose the other category.
 When in doubt between OFF_TOPIC and another category, choose the other category.
 
 User message: "{user_message}"
 
 Respond with ONLY the category name, nothing else."""
+
+
+# BITB-078: appended to the base system prompt when intent routing short-circuits a
+# first-turn, under-determined message into a single clarifying question instead of a
+# full answer. Layered onto the normal persona voice (like OFF_TOPIC_PROMPT) rather than
+# replacing it, so the ask still sounds like the same companion, not a form.
+CLARIFICATION_PROMPT = """The user's opening message is too short or vague to know what they \
+actually need (for example "help", "I'm lost", "pray for me", or a bare emotion/event with no \
+indication of what kind of help is wanted).
+
+Do NOT offer scripture, guidance, or a full response yet. Instead:
+1. Acknowledge what they said, in one warm sentence
+2. Ask exactly ONE gentle, open question that would help you understand what they're facing \
+(for example what happened, or what kind of support they're looking for)
+3. Keep the whole reply under 40 words
+4. Do NOT quote or cite any Bible verse, and do NOT include a "<!-- VERSES: -->" comment
+5. Ask in the user's language (see the LANGUAGE RULE above)
+
+This is the first turn of a two-turn exchange -- once they answer, you will have enough to \
+respond fully, with scripture and guidance."""
 
 
 # ---------------------------------------------------------------------------

--- a/api/chat/service.py
+++ b/api/chat/service.py
@@ -30,6 +30,7 @@ from utils.language import (
 )
 from utils.logging_config import get_logger
 from utils.metrics import (
+    chat_clarification_requested_counter,
     chat_scripture_unavailable_counter,
     chat_verseless_responses_counter,
     scripture_pipeline_errors_counter,
@@ -48,6 +49,7 @@ from utils.verse_parser import (
 )
 
 from .prompts import (
+    CLARIFICATION_PROMPT,
     OFF_TOPIC_PROMPT,
     build_search_context_prompt,
     detect_intent_prompt,
@@ -170,8 +172,8 @@ class ChatService:
         """
         Classify user intent with a fast LLM call.
 
-        Returns one of: COMFORT, GUIDANCE, CURIOSITY, VERSE_LOOKUP, OFF_TOPIC, GENERAL.
-        On any error, returns "GENERAL" (fail-open).
+        Returns one of: COMFORT, GUIDANCE, CURIOSITY, VERSE_LOOKUP, NEEDS_CLARIFICATION,
+        OFF_TOPIC, GENERAL. On any error, returns "GENERAL" (fail-open).
         """
         try:
             messages = [
@@ -185,7 +187,15 @@ class ChatService:
                 model_override=model_override,
             )
             intent = response.content.strip().upper().split()[0]
-            valid = {"COMFORT", "GUIDANCE", "CURIOSITY", "VERSE_LOOKUP", "OFF_TOPIC", "GENERAL"}
+            valid = {
+                "COMFORT",
+                "GUIDANCE",
+                "CURIOSITY",
+                "VERSE_LOOKUP",
+                "NEEDS_CLARIFICATION",
+                "OFF_TOPIC",
+                "GENERAL",
+            }
             if intent not in valid:
                 logger.warning("Unexpected intent classification: %s", intent)
                 return "GENERAL"
@@ -497,6 +507,24 @@ Keep it under 120 words."""
                 },
             )
 
+        # BITB-078: a first-turn message too vague to answer gets one clarifying
+        # question instead of a guessed full response.
+        if self._wants_clarification(
+            detected_intent,
+            is_verse_lookup,
+            safety.compassionate,
+            len(request.conversation_history),
+        ):
+            return await self._handle_needs_clarification(
+                request,
+                effective_language,
+                translation,
+                translation_info,
+                total_start,
+                model_override,
+                language_suggestion,
+            )
+
         # Step 1: Search for relevant scripture (if enabled; timed via @timed_stage)
         scripture_context, search_context_prompt = await self._search_scripture(
             request,
@@ -692,6 +720,74 @@ Keep it under 120 words."""
             model=response.model,
             detected_translation=translation,
             translation_info=translation_info,
+        )
+
+    def _wants_clarification(
+        self,
+        detected_intent: str,
+        is_verse_lookup: bool,
+        compassionate: bool,
+        history_len: int,
+    ) -> bool:
+        """BITB-078 gate: whether to ask one clarifying question instead of answering.
+
+        Enforced here in code, not left to the classifier's judgement, per the
+        story's non-negotiable exclusions: never for a verse lookup (unambiguous
+        by construction), never when the safety pipeline flagged crisis support,
+        and never past the first turn of a conversation -- by the second turn the
+        prior exchange already supplies context, which also gives "at most one
+        clarifying question per conversation" for free without tracking any
+        extra state.
+        """
+        return (
+            settings.chat_clarification_enabled
+            and detected_intent == "NEEDS_CLARIFICATION"
+            and not is_verse_lookup
+            and not compassionate
+            and history_len == 0
+        )
+
+    async def _handle_needs_clarification(
+        self,
+        request: ChatRequest,
+        detected_language: str,
+        translation: str,
+        translation_info: dict | None,
+        total_start: float,
+        model_override: str | None = None,
+        language_suggestion: str | None = None,
+    ) -> "ChatResponse":
+        """Ask one gentle clarifying question, skipping scripture search entirely."""
+        logger.info("Message needs clarification, skipping scripture search")
+        messages = self._build_messages(
+            user_message=request.message,
+            history=request.conversation_history,
+            search_context="",
+            language_code=detected_language,
+            prompt_type="clarification",
+        )
+        response = await self.llm.chat(
+            messages=messages,
+            temperature=settings.llm_temperature,
+            max_tokens=settings.llm_max_tokens,
+            model_override=model_override,
+        )
+        chat_clarification_requested_counter.add(1, {"language": detected_language})
+        message_id = str(uuid.uuid4())
+        total_duration = time.time() - total_start
+        logger.info(
+            "Clarifying question completed",
+            extra={"total_duration_seconds": f"{total_duration:.2f}"},
+        )
+        return ChatResponse(
+            message_id=message_id,
+            message=response.content,
+            scripture_context=None,
+            provider=response.provider,
+            model=response.model,
+            detected_translation=translation,
+            translation_info=translation_info,
+            language_suggestion=language_suggestion,
         )
 
     def _build_blocked_response(
@@ -1235,6 +1331,43 @@ Keep it under 120 words."""
         is_verse_lookup = is_verse_lookup_request(request.message)
         verse_refs, prayer_ref = extract_references(request.message)
 
+        # BITB-078: a first-turn message too vague to answer gets one clarifying
+        # question instead of a guessed full response, skipping scripture search.
+        if self._wants_clarification(
+            detected_intent,
+            is_verse_lookup,
+            safety.compassionate,
+            len(request.conversation_history),
+        ):
+            logger.info("Message needs clarification in stream, skipping scripture search")
+            yield {
+                "type": "metadata",
+                "message_id": message_id,
+                "scripture_context": None,
+                "provider": settings.llm_provider,
+                "model": settings.llm_model,
+                "detected_translation": translation,
+                "translation_info": translation_info,
+                "language_suggestion": language_suggestion,
+            }
+            messages = self._build_messages(
+                user_message=request.message,
+                history=request.conversation_history,
+                search_context="",
+                language_code=effective_language,
+                prompt_type="clarification",
+            )
+            async for token in self.llm.chat_stream(
+                messages=messages,
+                temperature=settings.llm_temperature,
+                max_tokens=settings.llm_max_tokens,
+                model_override=model_override,
+            ):
+                yield {"type": "content", "content": token}
+            chat_clarification_requested_counter.add(1, {"language": effective_language})
+            yield {"type": "completion", "verses_cited": []}
+            return
+
         # Step 1: Search for relevant scripture (timed via @timed_stage)
         scripture_context, search_context_prompt = await self._search_scripture(
             request,
@@ -1429,7 +1562,8 @@ Keep it under 120 words."""
             history: Previous conversation messages
             search_context: Optional scripture context from search
             language_code: Detected language code for response language
-            prompt_type: Type of prompt ("default", "verse_lookup", "prayer_lookup", "off_topic")
+            prompt_type: Type of prompt ("default", "verse_lookup", "prayer_lookup", "off_topic",
+                "clarification")
             compassionate_mode: When True, appends COMPASSIONATE_RESPONSE_ADDENDUM to system prompt
 
         Returns:
@@ -1450,6 +1584,8 @@ Keep it under 120 words."""
         # Select appropriate system prompt based on request type
         if prompt_type == "off_topic":
             system_prompt = get_system_prompt(language_code) + "\n\n" + OFF_TOPIC_PROMPT
+        elif prompt_type == "clarification":
+            system_prompt = get_system_prompt(language_code) + "\n\n" + CLARIFICATION_PROMPT
         elif prompt_type == "verse_lookup":
             system_prompt = get_verse_lookup_prompt(language_code)
         elif prompt_type == "prayer_lookup":

--- a/api/config.py
+++ b/api/config.py
@@ -198,6 +198,14 @@ class Settings(BaseSettings):
     content_filter_intent_detection: bool = True  # Pre-LLM intent classification
     security_log_violations: bool = True  # Log security violations
 
+    # BITB-078: on a first-turn message too short/vague to know what the person
+    # needs, ask one clarifying question instead of generating a full answer on a
+    # guess. Off by default — ship dark, watch the chat.clarification.requested
+    # metric and the "NEEDS_CLARIFICATION" intent rate in logs, then enable once
+    # over-asking risk is confirmed low (a clarifying question on an already-clear
+    # message reads as the app not listening, which is worse than the status quo).
+    chat_clarification_enabled: bool = False
+
     # Verse grounding (post-generation scripture fidelity)
     verse_grounding_enabled: bool = True  # Correct fabricated/mismatched inline verse quotes
     # BITB-054: how to handle an inline-quoted citation that cannot be resolved to any

--- a/api/tests/test_intent_detection.py
+++ b/api/tests/test_intent_detection.py
@@ -11,7 +11,7 @@ import pytest
 # Add parent directory to path to import modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from chat.prompts import OFF_TOPIC_PROMPT, detect_intent_prompt
+from chat.prompts import CLARIFICATION_PROMPT, OFF_TOPIC_PROMPT, detect_intent_prompt
 from chat.service import ChatRequest, ChatService
 from providers.base import LLMResponse
 
@@ -61,12 +61,25 @@ class TestDetectIntentPrompt:
 
     def test_contains_all_categories(self):
         result = detect_intent_prompt("hello")
-        for cat in ["COMFORT", "GUIDANCE", "CURIOSITY", "VERSE_LOOKUP", "OFF_TOPIC", "GENERAL"]:
+        for cat in [
+            "COMFORT",
+            "GUIDANCE",
+            "CURIOSITY",
+            "VERSE_LOOKUP",
+            "NEEDS_CLARIFICATION",
+            "OFF_TOPIC",
+            "GENERAL",
+        ]:
             assert cat in result
 
     def test_contains_fail_open_instruction(self):
         result = detect_intent_prompt("hello")
         assert "When in doubt" in result
+
+    def test_contains_clarification_exclusions(self):
+        result = detect_intent_prompt("hello")
+        assert "Do NOT choose this when the message already names a situation" in result
+        assert "When in doubt between NEEDS_CLARIFICATION" in result
 
     def test_contains_only_instruction(self):
         result = detect_intent_prompt("hello")
@@ -90,6 +103,14 @@ class TestDetectIntent:
         mock_llm.chat.return_value = LLMResponse(content="  comfort  \n", model="m", provider="p")
         result = await chat_service._detect_intent("I'm sad")
         assert result == "COMFORT"
+
+    @pytest.mark.asyncio
+    async def test_returns_needs_clarification(self, chat_service, mock_llm):
+        mock_llm.chat.return_value = LLMResponse(
+            content="NEEDS_CLARIFICATION", model="m", provider="p"
+        )
+        result = await chat_service._detect_intent("help")
+        assert result == "NEEDS_CLARIFICATION"
 
     @pytest.mark.asyncio
     async def test_takes_first_word(self, chat_service, mock_llm):
@@ -336,3 +357,257 @@ class TestChatStreamOffTopic:
         content = "".join(c["content"] for c in chunks if c["type"] == "content")
         assert content == "God loves you."
         assert chunks[-1]["type"] == "completion"
+
+
+# ---------------------------------------------------------------------------
+# _wants_clarification() gate tests (BITB-078)
+# ---------------------------------------------------------------------------
+
+
+class TestWantsClarificationGate:
+    """The gate is enforced in code, not left to the classifier's judgement --
+    these exercise each non-negotiable exclusion in isolation."""
+
+    @patch("chat.service.settings")
+    def test_asks_when_all_conditions_met(self, mock_settings, chat_service):
+        mock_settings.chat_clarification_enabled = True
+        assert chat_service._wants_clarification(
+            "NEEDS_CLARIFICATION", is_verse_lookup=False, compassionate=False, history_len=0
+        )
+
+    @patch("chat.service.settings")
+    def test_flag_disabled_never_asks(self, mock_settings, chat_service):
+        mock_settings.chat_clarification_enabled = False
+        assert not chat_service._wants_clarification(
+            "NEEDS_CLARIFICATION", is_verse_lookup=False, compassionate=False, history_len=0
+        )
+
+    @patch("chat.service.settings")
+    def test_wrong_intent_never_asks(self, mock_settings, chat_service):
+        mock_settings.chat_clarification_enabled = True
+        assert not chat_service._wants_clarification(
+            "GENERAL", is_verse_lookup=False, compassionate=False, history_len=0
+        )
+
+    @patch("chat.service.settings")
+    def test_verse_lookup_never_asks(self, mock_settings, chat_service):
+        mock_settings.chat_clarification_enabled = True
+        assert not chat_service._wants_clarification(
+            "NEEDS_CLARIFICATION", is_verse_lookup=True, compassionate=False, history_len=0
+        )
+
+    @patch("chat.service.settings")
+    def test_compassionate_never_asks(self, mock_settings, chat_service):
+        mock_settings.chat_clarification_enabled = True
+        assert not chat_service._wants_clarification(
+            "NEEDS_CLARIFICATION", is_verse_lookup=False, compassionate=True, history_len=0
+        )
+
+    @patch("chat.service.settings")
+    def test_follow_up_turn_never_asks(self, mock_settings, chat_service):
+        """At most one clarifying question per conversation: once there's any
+        history, the request already has context on the table."""
+        mock_settings.chat_clarification_enabled = True
+        assert not chat_service._wants_clarification(
+            "NEEDS_CLARIFICATION", is_verse_lookup=False, compassionate=False, history_len=1
+        )
+
+
+# ---------------------------------------------------------------------------
+# chat() clarification flow tests (BITB-078)
+# ---------------------------------------------------------------------------
+
+
+class TestChatNeedsClarificationFlow:
+    @pytest.mark.asyncio
+    @patch("chat.service.settings")
+    async def test_clarification_skips_scripture_search(
+        self, mock_settings, chat_service, mock_llm
+    ):
+        mock_settings.content_filter_intent_detection = True
+        mock_settings.chat_clarification_enabled = True
+        mock_settings.llm_temperature = 0.7
+        mock_settings.llm_max_tokens = 1024
+        mock_settings.max_conversation_history = 10
+
+        chat_service.search_service = AsyncMock()
+        chat_service.search_service.search = AsyncMock(
+            side_effect=AssertionError("search should have been skipped")
+        )
+
+        mock_llm.chat.side_effect = [
+            LLMResponse(content="NEEDS_CLARIFICATION", model="m", provider="p"),
+            LLMResponse(
+                content="That sounds hard. What's been weighing on you?",
+                model="m",
+                provider="p",
+            ),
+        ]
+
+        request = ChatRequest(message="I'm lost")
+        response = await chat_service.chat(request)
+
+        assert response.scripture_context is None
+        assert response.message == "That sounds hard. What's been weighing on you?"
+        assert mock_llm.chat.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("chat.service.settings")
+    async def test_second_turn_answers_instead_of_asking_again(
+        self, mock_settings, chat_service, mock_llm
+    ):
+        """A second vague message in an existing conversation gets a full answer,
+        not another clarifying question -- the one-question-per-conversation cap."""
+        mock_settings.content_filter_intent_detection = True
+        mock_settings.chat_clarification_enabled = True
+        mock_settings.llm_temperature = 0.7
+        mock_settings.llm_max_tokens = 1024
+        mock_settings.max_context_verses = 10
+        mock_settings.max_conversation_history = 10
+        mock_settings.query_expansion_enabled = False
+        mock_settings.require_scripture_grounding = False
+
+        chat_service.search_service = AsyncMock()
+        chat_service.search_service.search = AsyncMock(return_value=None)
+        chat_service.search_service.search_hybrid = AsyncMock(return_value=None)
+        chat_service.search_service.search_hybrid_boosted = AsyncMock(return_value=None)
+        chat_service.search_service.get_verse = AsyncMock(return_value=None)
+        chat_service.search_service.get_verse_range = AsyncMock(return_value=[])
+
+        mock_llm.chat.side_effect = [
+            LLMResponse(content="NEEDS_CLARIFICATION", model="m", provider="p"),
+            LLMResponse(content="I hear you, here is a word of comfort.", model="m", provider="p"),
+        ]
+
+        request = ChatRequest(
+            message="still lost",
+            conversation_history=[
+                {"role": "user", "content": "I'm lost"},
+                {"role": "assistant", "content": "What's been weighing on you?"},
+            ],
+        )
+        response = await chat_service.chat(request)
+
+        assert response.message == "I hear you, here is a word of comfort."
+
+
+# ---------------------------------------------------------------------------
+# _build_messages() clarification prompt type tests (BITB-078)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMessagesClarification:
+    def test_clarification_includes_clarification_prompt(self, chat_service):
+        messages = chat_service._build_messages(
+            user_message="I'm lost",
+            history=[],
+            search_context="",
+            language_code="en",
+            prompt_type="clarification",
+        )
+        system_msg = messages[0].content
+        assert CLARIFICATION_PROMPT in system_msg
+
+    def test_clarification_includes_base_system_prompt(self, chat_service):
+        messages = chat_service._build_messages(
+            user_message="I'm lost",
+            history=[],
+            search_context="",
+            language_code="en",
+            prompt_type="clarification",
+        )
+        system_msg = messages[0].content
+        assert "compassionate spiritual companion" in system_msg
+
+    def test_default_does_not_include_clarification_prompt(self, chat_service):
+        messages = chat_service._build_messages(
+            user_message="I feel sad",
+            history=[],
+            search_context="",
+            language_code="en",
+            prompt_type="default",
+        )
+        system_msg = messages[0].content
+        assert CLARIFICATION_PROMPT not in system_msg
+
+
+# ---------------------------------------------------------------------------
+# chat_stream() clarification flow tests (BITB-078)
+# ---------------------------------------------------------------------------
+
+
+class TestChatStreamNeedsClarification:
+    @pytest.mark.asyncio
+    @patch("chat.service.settings")
+    async def test_stream_clarification_short_circuits(self, mock_settings, chat_service, mock_llm):
+        mock_settings.content_filter_intent_detection = True
+        mock_settings.chat_clarification_enabled = True
+        mock_settings.llm_temperature = 0.7
+        mock_settings.llm_max_tokens = 1024
+        mock_settings.max_conversation_history = 10
+
+        chat_service.search_service = AsyncMock()
+        chat_service.search_service.search = AsyncMock(
+            side_effect=AssertionError("search should have been skipped")
+        )
+
+        mock_llm.chat.return_value = LLMResponse(
+            content="NEEDS_CLARIFICATION", model="m", provider="p"
+        )
+
+        async def mock_stream(*args, **kwargs):
+            for chunk in ["What's ", "on ", "your heart?"]:
+                yield chunk
+
+        mock_llm.chat_stream = MagicMock(return_value=mock_stream())
+
+        request = ChatRequest(message="pray for me")
+        chunks = []
+        async for chunk in chat_service.chat_stream(request):
+            chunks.append(chunk)
+
+        assert len(chunks) == 5
+        assert chunks[0]["type"] == "metadata"
+        assert chunks[0]["scripture_context"] is None
+        content = "".join(c["content"] for c in chunks if c["type"] == "content")
+        assert content == "What's on your heart?"
+        assert chunks[-1]["type"] == "completion"
+        assert chunks[-1]["verses_cited"] == []
+
+    @pytest.mark.asyncio
+    @patch("chat.service.settings")
+    async def test_stream_flag_disabled_proceeds_normally(
+        self, mock_settings, chat_service, mock_llm
+    ):
+        mock_settings.content_filter_intent_detection = True
+        mock_settings.chat_clarification_enabled = False
+        mock_settings.llm_temperature = 0.7
+        mock_settings.llm_max_tokens = 1024
+        mock_settings.max_context_verses = 10
+        mock_settings.max_conversation_history = 10
+
+        chat_service.search_service = AsyncMock()
+        chat_service.search_service.search = AsyncMock(return_value=None)
+        chat_service.search_service.get_verse = AsyncMock(return_value=None)
+        chat_service.search_service.get_verse_range = AsyncMock(return_value=[])
+
+        mock_llm.chat.return_value = LLMResponse(
+            content="NEEDS_CLARIFICATION", model="m", provider="p"
+        )
+
+        async def mock_stream(*args, **kwargs):
+            for chunk in ["Here ", "is ", "a verse."]:
+                yield chunk
+
+        mock_llm.chat_stream = MagicMock(return_value=mock_stream())
+
+        request = ChatRequest(message="pray for me")
+        chunks = []
+        async for chunk in chat_service.chat_stream(request):
+            chunks.append(chunk)
+
+        # Flag off: falls through to the normal (non-clarification) path, which
+        # sends real scripture-search metadata rather than short-circuiting.
+        assert chunks[0]["type"] == "metadata"
+        content = "".join(c["content"] for c in chunks if c["type"] == "content")
+        assert content == "Here is a verse."

--- a/api/utils/metrics.py
+++ b/api/utils/metrics.py
@@ -82,6 +82,16 @@ verse_grounding_paraphrase_detections_counter = meter.create_counter(
     unit="1",
 )  # attributes: language, bracketed (bool), applied (bool)
 
+# A first-turn message routed to a single clarifying question instead of a full
+# answer (BITB-078, behind chat_clarification_enabled). Makes the ask rate
+# observable so the rollout can be judged rather than guessed at — see the
+# story's Risks section on over-asking.
+chat_clarification_requested_counter = meter.create_counter(
+    name="chat.clarification.requested",
+    description="First-turn messages short-circuited into a single clarifying question",
+    unit="1",
+)  # attributes: language
+
 # ── Translation data-coverage diagnostics (BITB-054) ──────────────────────
 # A supported UI language whose backing translation has zero verses (never
 # loaded) or zero embeddings (loaded but unsearchable) degrades silently —

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -576,9 +576,10 @@ scope here.
 
 ---
 
-### 🎯 BITB-053: Ground Unquoted / Paraphrased Verse Citations
+### ✅ BITB-053: Ground Unquoted / Paraphrased Verse Citations
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done (code, detect-only mode) — `_apply_paraphrase_grounding`/`_classify_paraphrase`
+shipped in `api/chat/verse_grounding.py`; this entry was stale, see the story file for rollout status
 **Size:** M (1-2 days)
 **Created:** 2026-06-19
 
@@ -601,27 +602,14 @@ fixed.
 
 ---
 
-### 🎯 BITB-054: Per-Translation Data Observability + Honest Handling of Unresolvable Citations
+### ✅ BITB-054: Per-Translation Data Observability + Honest Handling of Unresolvable Citations
 
-**Status:** 🎯 Todo
-**Size:** M (1-2 days)
-**Created:** 2026-06-19
+**Status:** ✅ Done (PR #803) — `get_translation_coverage()` + admin diagnostic route, startup
+coverage check + `scripture.translation_data.missing` metric, and configurable
+`grounding_unresolved_behavior` (`keep`/`strip`/`notice`, default `strip`) all shipped. This entry
+was stale. See `docs/DONE/BITB-054-translation-data-observability.md`.
 
-**As the** maintainer, **I want** to know — and the app to behave honestly — when a cited verse
-can't be resolved in the user's translation, **so that** a missing/incomplete translation never
-shows up as silently hallucinated scripture.
-
-**Why P2:** When a translation isn't loaded (or has no embeddings), search returns no context and
-grounding silently keeps the model's text (`reason=unresolved`). The only diagnostic today is a
-manual SQL snippet, and the unresolved path is invisible.
-
-**Acceptance Criteria (summary — full story has detail):**
-
-- [ ] Per-translation verse + embedding counts via a diagnostic (route or startup log)
-- [ ] Startup/CI warning + metric when a supported language has no usable verse data
-- [ ] Configurable handling of `unresolved` citations (fallback / strip / notify) with tests
-
-**Full Story:** `docs/BACKLOG_STORIES/BITB-054-translation-data-observability.md`
+**Full Story:** `docs/DONE/BITB-054-translation-data-observability.md`
 
 ---
 
@@ -1419,9 +1407,10 @@ log-scraping the bug slipped through twice, no metric distinguished "served with
 
 ---
 
-### 🎯 BITB-045: Typo-Tolerant Queries with Clarification Fallback
+### ✅ BITB-045: Typo-Tolerant Queries with Clarification Fallback
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done — `TYPO_TOLERANCE_GUIDANCE` shipped in all three system prompts in
+`api/chat/prompts.py`; this entry was stale, see the story file
 **Size:** S (< 4 hrs)
 **Created:** 2026-06-12
 
@@ -1841,9 +1830,10 @@ because it's data work gated behind BITB-043's eval set, not a live regression.
 
 ---
 
-### 🎯 BITB-009: Refactor SQLAlchemy Models to 2.0 Syntax
+### ✅ BITB-009: Refactor SQLAlchemy Models to 2.0 Syntax
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done — `api/scripture/models.py` and `api/feedback/models.py` are fully
+`Mapped[]`/`DeclarativeBase`; zero `= Column(...)` usages remain repo-wide. This entry was stale.
 **Size:** L
 
 **As a** developer,
@@ -2036,9 +2026,11 @@ they show the pre-rename v1.0 UI — must be labeled as "then," not presented as
 
 ---
 
-### 🎯 BITB-078: Ask Before Answering — Clarify a Vague Request Instead of Guessing
+### 🚧 BITB-078: Ask Before Answering — Clarify a Vague Request Instead of Guessing
 
-**Status:** 🎯 Todo
+**Status:** 🚧 In Progress — backend intent routing + clarifying-question flow shipped
+(behind `chat_clarification_enabled`, default off); tappable chip UI (shared with BITB-080)
+and golden-set eval integration deferred, see story file
 **Size:** M (1–2 days, prompt work + eval)
 **Created:** 2026-07-25
 

--- a/docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md
+++ b/docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md
@@ -13,6 +13,7 @@ surfaces (frontend, Android, the retrieval-eval harness) that a repo-only agent 
 validate end-to-end in a day.
 
 **Shipped:**
+
 - `NEEDS_CLARIFICATION` intent category (`detect_intent_prompt`, `api/chat/prompts.py`) with the
   ask/don't-ask criteria from "Proposed Behaviour" #1 below, written into the classifier prompt.
 - Dedicated `CLARIFICATION_PROMPT` (acknowledge + one open question, <40 words, no verse
@@ -32,6 +33,7 @@ validate end-to-end in a day.
   `_build_messages` prompt-type dispatch.
 
 **Deferred (separate follow-up story):**
+
 - Tappable chip options (Proposed Behaviour #4) — shared UI mechanism with **BITB-080**; do both
   chip UIs together once BITB-080 is scoped, rather than building the mechanism twice.
 - Golden-set eval additions (`docs/SEARCH_EVAL_HOWTO.md`, BITB-051) for vague-opening cases.

--- a/docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md
+++ b/docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md
@@ -1,9 +1,46 @@
 # BITB-078: Ask Before Answering — Clarify a Vague Request Instead of Guessing
 
-**Status:** 🎯 Todo
+**Status:** 🚧 In Progress — backend slice shipped, see "Delivered / Deferred" below
 **Priority:** P2
 **Size:** M (1–2 days, prompt work + eval)
 **Created:** 2026-07-25
+
+## Delivered / Deferred (this pass)
+
+Scoped down to a backend-only slice completable in one PR, splitting by risk the same way PR
+\#877/\#955 split BITB-062 — the chip UI and eval-harness pieces below touch other
+surfaces (frontend, Android, the retrieval-eval harness) that a repo-only agent pass can't
+validate end-to-end in a day.
+
+**Shipped:**
+- `NEEDS_CLARIFICATION` intent category (`detect_intent_prompt`, `api/chat/prompts.py`) with the
+  ask/don't-ask criteria from "Proposed Behaviour" #1 below, written into the classifier prompt.
+- Dedicated `CLARIFICATION_PROMPT` (acknowledge + one open question, <40 words, no verse
+  citation) wired through `_build_messages(prompt_type="clarification")`.
+- Routing in both `chat()` and `chat_stream()` (`api/chat/service.py`) that skips scripture
+  search entirely for a qualifying message — the `_wants_clarification()` gate.
+- The three non-negotiable exclusions enforced **in code**, not left to the classifier: never for
+  `VERSE_LOOKUP`, never when `compassionate_response_needed` is set, and never past the first
+  turn of a conversation (`len(conversation_history) == 0`) — which also gives "at most one
+  clarifying question per conversation" for free, without tracking any extra state.
+- `chat.clarification.requested` counter (language-tagged) and the existing intent-detection log
+  line now cover `NEEDS_CLARIFICATION` for free (it's just a new value in the same `valid` set).
+- Shipped **behind `chat_clarification_enabled` (default `False`)** per this story's own Risks
+  section — watch the ask rate before defaulting it on.
+- Tests: `api/tests/test_intent_detection.py` — prompt content, the gate's five exclusion paths
+  in isolation, `chat()`/`chat_stream()` flow (search skipped, one-question cap on turn 2),
+  `_build_messages` prompt-type dispatch.
+
+**Deferred (separate follow-up story):**
+- Tappable chip options (Proposed Behaviour #4) — shared UI mechanism with **BITB-080**; do both
+  chip UIs together once BITB-080 is scoped, rather than building the mechanism twice.
+- Golden-set eval additions (`docs/SEARCH_EVAL_HOWTO.md`, BITB-051) for vague-opening cases.
+- Explicit per-language assertions beyond the prompt's built-in "ask in the user's language"
+  instruction (en/it/de/es AC) — the mechanism is language-agnostic by construction (same as
+  `OFF_TOPIC_PROMPT`), but no test exercises a non-English clarifying reply yet.
+- Restructuring `SYSTEM_PROMPT_TEMPLATE`'s "## Your Role" step 2 (Proposed Behaviour #5) — not
+  needed for the new short-circuit path (it uses its own prompt), only for the old buried
+  instruction it doesn't replace; leaving that alone avoids touching the default-path prompt.
 
 ## User Story
 

--- a/docs/DONE/BITB-054-translation-data-observability.md
+++ b/docs/DONE/BITB-054-translation-data-observability.md
@@ -14,7 +14,7 @@ and this file were never updated to match, so the story kept surfacing as unstar
 directly against `main` on 2026-08-02:
 
 - **Diagnostic:** `ScriptureRepository.get_translation_coverage()` (`api/scripture/repository.py:902`)
-  + admin route `GET /api/v1/admin/translation-coverage` (`api/routes/admin.py:66`, probe-secret
+  - admin route `GET /api/v1/admin/translation-coverage` (`api/routes/admin.py:66`, probe-secret
   gated).
 - **Startup/CI guard:** `_check_translation_coverage_at_startup()` (`api/main.py:66`, called from
   the app lifespan) logs per-language warnings and increments the

--- a/docs/DONE/BITB-054-translation-data-observability.md
+++ b/docs/DONE/BITB-054-translation-data-observability.md
@@ -1,10 +1,37 @@
 # BITB-054: Per-Translation Data Observability + Honest Handling of Unresolvable Citations
 
-**Status:** 🎯 Todo
+**Status:** ✅ Done (PR #803)
 **Priority:** P2 (Medium) — correctness/observability; prevents silent ungrounded scripture
 **Size:** M (1-2 days)
 **Created:** 2026-06-19
 **Parent / related:** verse grounding (`api/chat/verse_grounding.py`), `scripts/load_bible.py`
+
+## Delivered
+
+Found already shipped via CHANGELOG.md ("per-translation data observability + honest
+unresolved citations (BITB-054) (#803)") while scoping a follow-up story — `docs/BACKLOG.md`
+and this file were never updated to match, so the story kept surfacing as unstarted. Verified
+directly against `main` on 2026-08-02:
+
+- **Diagnostic:** `ScriptureRepository.get_translation_coverage()` (`api/scripture/repository.py:902`)
+  + admin route `GET /api/v1/admin/translation-coverage` (`api/routes/admin.py:66`, probe-secret
+  gated).
+- **Startup/CI guard:** `_check_translation_coverage_at_startup()` (`api/main.py:66`, called from
+  the app lifespan) logs per-language warnings and increments the
+  `scripture.translation_data.missing` counter (`api/utils/metrics.py`).
+- **Configurable `unresolved` handling:** `grounding_unresolved_behavior: Literal["keep", "strip",
+  "notice"]` (`api/config.py`, default `"strip"`) — the story predicted a boolean
+  `grounding_strip_unresolved` flag; the actual implementation is the strictly more capable
+  three-valued version, implemented in `api/chat/verse_grounding.py` and wired in
+  `api/chat/service.py`. `strip` (not "fall back to another translation's text") was chosen as the
+  default — surfacing another language's canonical text inside a response in a different language
+  is a distinct honesty failure, not a fix for this one.
+- `reason=unresolved` is observable and asserted in `api/tests/test_chat_coverage.py`.
+
+Not separately re-verified in this pass: the AC's "across all 11 languages" clause for the
+`unresolved`-handling tests, and a real-DB (as opposed to mocked) test of
+`get_translation_coverage()`. Worth a small follow-up story if a gap is ever suspected there —
+not reopening this one speculatively.
 
 ## User Story
 


### PR DESCRIPTION
## What

Backend slice of **BITB-078** ("Ask Before Answering — Clarify a Vague Request Instead of Guessing", 2026-07-25 product review batch). The story names this "the single worst failure mode for this product": a three-word message like "I'm lost" or "pray for me" still gets a full, confident, scripture-backed answer — built on an assumption the user never made.

- New `NEEDS_CLARIFICATION` intent category (`api/chat/prompts.py` `detect_intent_prompt`), with explicit ask/don't-ask criteria so it stays rare (no situation+need named vs. already-specific messages, per the story's "Proposed Behaviour" #1).
- Dedicated `CLARIFICATION_PROMPT`: acknowledge in one sentence, ask exactly one open question, under 40 words, no verse citation.
- Routing in both `chat()` and `chat_stream()` (`api/chat/service.py`) that skips scripture search entirely for a qualifying message — new `_wants_clarification()` gate.
- The three non-negotiable exclusions from the story are **enforced in code**, not left to the classifier: never for `VERSE_LOOKUP` (unambiguous by construction), never when `compassionate_response_needed` is set (crisis support first, always), and never past the first turn of a conversation — which also gives "at most one clarifying question per conversation" for free, with no extra state to track.
- New `chat.clarification.requested` counter (language-tagged); the existing intent-detection log line covers `NEEDS_CLARIFICATION` for free.
- Shipped **behind `chat_clarification_enabled` (default `False`)**, per the story's own Risks section ("over-asking is worse than the current behaviour") — watch the ask rate before defaulting it on.

**Deferred to a follow-up** (different surfaces, can't be validated end-to-end in one PR from a repo-only agent pass — split by risk the same way PR #877/#955 split BITB-062):
- Tappable chip options for the clarifying question — shares its UI mechanism with **BITB-080** (follow-up-question chips); build that mechanism once, for both.
- Golden-set eval additions (BITB-051) for vague-opening cases.
- Explicit non-English test assertions (the mechanism is language-agnostic by construction, same pattern as `OFF_TOPIC_PROMPT`, but untested beyond English here).

Full story: `docs/BACKLOG_STORIES/BITB-078-clarify-before-answering.md` (updated with a "Delivered / Deferred" section).

### Bonus: backlog doc cleanup

While scoping this story I found `docs/BACKLOG.md` was stale in four other places — stories marked "🎯 Todo" that are actually fully shipped:

- **BITB-054** (per-translation data observability) — shipped in PR #803; moved its story file to `docs/DONE/`.
- **BITB-053** (paraphrase citation grounding), **BITB-045** (typo tolerance), **BITB-009** (SQLAlchemy 2.0 models) — all verified against current `main` and flipped to Done.

Flagging this because I nearly re-implemented BITB-054 from scratch based on the stale doc before catching it against `CHANGELOG.md`/`main`.

## Test plan

- [x] New tests in `api/tests/test_intent_detection.py`: prompt content (category + exclusion wording), the `_wants_clarification` gate exercised in isolation for all 5 conditions, `chat()`/`chat_stream()` flow (scripture search skipped, one-question-per-conversation cap on a second turn, flag-disabled fallthrough), `_build_messages` prompt-type dispatch. 34/34 pass.
- [x] Full backend suite (`pytest -m "not network and not functional and not e2e and not golden_set"`): 3714 passed, same 6 pre-existing environment-only failures as on unmodified `main` (rate-limiter fails closed with no live Postgres in this sandbox — confirmed identical failure set before/after this change).
- [x] `ruff check . --select E,F,W,C90,I,N --ignore E501` and `black --check .` clean.
- [ ] Not run: a live multi-turn manual chat session (no deployed/local LLM+DB environment available in this sandbox) — the flag ships off by default specifically so this can be watched safely once merged.

## Notes

- Config: `chat_clarification_enabled: bool = False` (`api/config.py`) — flip on after watching `chat.clarification.requested` and the `NEEDS_CLARIFICATION` intent-log rate for a while.
- No new dependencies, no migrations, no infra changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Vs5RGVJX1pvdfuLP9icf3)_