### PR TITLE
feat(deploy): wire Alembic migrations into the deploy pipeline (BITB-089)

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -143,6 +143,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       scripts: ${{ steps.filter.outputs.scripts }}
       migration_scripts: ${{ steps.filter.outputs.migration_scripts }}
+      alembic_migrations: ${{ steps.filter.outputs.alembic_migrations }}
       bible_scripts: ${{ steps.filter.outputs.bible_scripts }}
       deployment: ${{ steps.filter.outputs.deployment }}
     steps:
@@ -166,6 +167,8 @@ jobs:
               - 'scripts/**'
             migration_scripts:
               - 'scripts/migrations/**'
+            alembic_migrations:
+              - 'api/alembic/versions/**'
             bible_scripts:
               - 'scripts/load_bible.py'
               - 'scripts/create_embeddings.py'
@@ -1446,10 +1449,11 @@ jobs:
     # 1. always() - evaluate even if deploy was skipped
     # 2. Not a PR (no DB access from PR branches)
     # 3. Deploy didn't fail (success or skipped is OK)
-    # 4. Migration scripts changed OR manual workflow_dispatch
+    # 4. Migration scripts changed (legacy or Alembic) OR manual workflow_dispatch
     if: >-
       always() && github.event_name != 'pull_request' && (needs.deploy.result == 'success' || needs.deploy.result ==
       'skipped') && (needs.changes.outputs.migration_scripts == 'true' ||
+       needs.changes.outputs.alembic_migrations == 'true' ||
        github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1467,7 +1471,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install asyncpg pydantic pydantic-settings
+        # BITB-089: use the pinned api/requirements.txt (includes alembic) so
+        # `alembic upgrade head` below runs the same version CI validates in
+        # the alembic-migrations job, instead of an unpinned ad-hoc set.
+        run: pip install -r api/requirements.txt
 
       - name: Login to Azure
         uses: azure/login@v3
@@ -1498,6 +1505,65 @@ jobs:
           export DATABASE_URL="postgresql+asyncpg://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}?ssl=require"
           cd scripts/migrations
           python run_migrations.py
+
+      # BITB-089: the three steps below wire the Alembic framework (BITB-004,
+      # PR #948) into deploy. Production has not been cut over to Alembic yet
+      # (no `alembic_version` table) — see docs/MIGRATION_GUIDELINES.md for the
+      # operator runbook (Stages 1-2) that must run once before this activates.
+      # Until then "Check Alembic stamp" reports stamped=false and the upgrade
+      # step is skipped, so this job's behavior is unchanged from today.
+      - name: Check Alembic stamp
+        id: alembic_gate
+        env:
+          DB_USER: ${{ secrets.TF_VAR_DB_ADMIN_USERNAME }}
+          DB_PASS: ${{ secrets.TF_VAR_DB_ADMIN_PASSWORD }}
+          DB_HOST: ${{ steps.db.outputs.db_host }}
+          DB_NAME: ${{ secrets.TF_VAR_DB_NAME }}
+        run: |
+          export DATABASE_URL="postgresql+asyncpg://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}?sslmode=require"
+          cd api
+          CURRENT="$(alembic current 2>/dev/null | tr -d '[:space:]')"
+          if [ -n "$CURRENT" ]; then
+            echo "stamped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stamped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # continue-on-error is deliberately temporary for the first release after
+      # the operator completes the Stage 1-2 cutover — remove it once a prod
+      # `alembic upgrade head` run has succeeded end-to-end, so failures start
+      # failing the job instead of only warning.
+      - name: Apply Alembic migrations
+        id: alembic_upgrade
+        if: steps.alembic_gate.outputs.stamped == 'true'
+        continue-on-error: true
+        env:
+          DB_USER: ${{ secrets.TF_VAR_DB_ADMIN_USERNAME }}
+          DB_PASS: ${{ secrets.TF_VAR_DB_ADMIN_PASSWORD }}
+          DB_HOST: ${{ steps.db.outputs.db_host }}
+          DB_NAME: ${{ secrets.TF_VAR_DB_NAME }}
+        run: |
+          export DATABASE_URL="postgresql+asyncpg://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}?sslmode=require"
+          cd api
+          alembic upgrade head
+          alembic current
+
+      - name: Migration summary
+        if: always()
+        run: |
+          if [ "${{ steps.alembic_gate.outputs.stamped }}" != "true" ]; then
+            echo "### Alembic migrations: skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "Production is not yet stamped at an Alembic revision. Run the BITB-089" >> "$GITHUB_STEP_SUMMARY"
+            echo "Stage 1-2 operator runbook in docs/MIGRATION_GUIDELINES.md before this step" >> "$GITHUB_STEP_SUMMARY"
+            echo "can apply anything." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.alembic_upgrade.outcome }}" == "success" ]; then
+            echo "### Alembic migrations: applied" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Alembic upgrade step failed — see 'Apply Alembic migrations' step log."
+            echo "### Alembic migrations: FAILED" >> "$GITHUB_STEP_SUMMARY"
+            echo "The 'Apply Alembic migrations' step failed. The legacy migrations run" >> "$GITHUB_STEP_SUMMARY"
+            echo "above is unaffected. See docs/MIGRATION_GUIDELINES.md for rollback." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # ---------------------------------------------------------------------------
   # Seed Matrix (derives the translation list from scripts/translations.py)

--- a/api/scripture/database.py
+++ b/api/scripture/database.py
@@ -30,21 +30,26 @@ def get_async_database_url() -> tuple[str, dict]:
     url = settings.database_url
     connect_args: dict = {}
 
-    # Parse the URL to extract and remove sslmode parameter
+    # Parse the URL to extract and remove sslmode/ssl parameters
     parsed = urlparse(url)
     if parsed.query:
         query_params = parse_qs(parsed.query)
         sslmode = query_params.pop("sslmode", [None])[0]
+        # BITB-089: some callers (e.g. the deploy workflow's legacy migration
+        # step) build the URL with `?ssl=require` instead of `sslmode=require`.
+        # asyncpg accepts neither as a URL param, so strip both the same way
+        # scripts/migrations/utils.py:get_migration_connection_params() does.
+        ssl_param = query_params.pop("ssl", [None])[0]
 
-        # Rebuild URL without sslmode
+        # Rebuild URL without SSL parameters
         new_query = urlencode(query_params, doseq=True) if query_params else ""
         url = urlunparse(parsed._replace(query=new_query))
 
-        # Configure SSL for asyncpg based on sslmode
-        if sslmode in ("require", "verify-ca", "verify-full"):
+        # Configure SSL for asyncpg based on sslmode/ssl
+        if sslmode in ("require", "verify-ca", "verify-full") or ssl_param == "require":
             # Create SSL context for secure connection
             ssl_context = ssl.create_default_context()
-            if sslmode == "require":
+            if sslmode == "require" or ssl_param == "require":
                 # Don't verify certificate (like psycopg2's sslmode=require)
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE

--- a/api/tests/test_alembic_migrations.py
+++ b/api/tests/test_alembic_migrations.py
@@ -274,6 +274,57 @@ def test_alembic_check_reports_no_drift(throwaway_database_url):
     _run_alembic("check", database_url=throwaway_database_url)
 
 
+def test_stamp_cutover_matches_the_deploy_gate(throwaway_database_url):
+    """Rehearses the BITB-089 production cutover, and doubles as the model
+    for the deploy workflow's "Check Alembic stamp" preflight.
+
+    Production today has the schema (built by scripts/migrations/) but no
+    `alembic_version` bookkeeping -- exactly what dropping that table on an
+    already-upgraded throwaway database simulates. The operator's Stage 2
+    (`alembic stamp r0001`) must then make `upgrade head` a no-op and
+    `current` report `r0001`, which is also precisely the condition the
+    deploy job's "Check Alembic stamp" step checks before it will run
+    `alembic upgrade head` against production.
+    """
+    # 1. Schema exists (as it does on prod today), but simulate "no Alembic
+    #    bookkeeping yet" by dropping alembic_version after creating it.
+    _run_alembic("upgrade", "head", database_url=throwaway_database_url)
+    parsed = urlparse(throwaway_database_url)
+    conn = psycopg2.connect(
+        host=parsed.hostname,
+        port=parsed.port or 5432,
+        user=parsed.username,
+        password=parsed.password,
+        dbname=parsed.path.lstrip("/"),
+    )
+    try:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("DROP TABLE alembic_version")
+    finally:
+        conn.close()
+
+    # `alembic current` against an unstamped database prints nothing and
+    # exits 0 -- this is exactly what the deploy job's preflight step reads
+    # to decide stamped=false and skip the upgrade step.
+    result = _run_alembic("current", database_url=throwaway_database_url)
+    assert result.stdout.strip() == ""
+
+    # 2. Stage 2: stamp (writes one row, executes zero DDL).
+    _run_alembic("stamp", "r0001", database_url=throwaway_database_url)
+
+    # 3. Post-stamp, `current` reports r0001 (deploy gate now says stamped=true)...
+    result = _run_alembic("current", database_url=throwaway_database_url)
+    assert "r0001" in result.stdout
+
+    # ...and `upgrade head` is a no-op: no DDL, table set unchanged.
+    tables_before = _table_names(throwaway_database_url)
+    _run_alembic("upgrade", "head", database_url=throwaway_database_url)
+    tables_after = _table_names(throwaway_database_url)
+    assert tables_before == tables_after
+    assert _alembic_version_rows(throwaway_database_url) == ["r0001"]
+
+
 class TestHostSafetyGuard:
     """Tests for the guard itself -- the thing standing between
     `alembic downgrade base` and a database nobody meant to touch.

--- a/api/tests/test_database_church_coverage.py
+++ b/api/tests/test_database_church_coverage.py
@@ -102,6 +102,61 @@ class TestGetAsyncDatabaseUrl:
         assert "connect_timeout" in url
         assert "ssl" in args
 
+    @patch("scripture.database.settings")
+    def test_url_with_ssl_require_param(self, mock_settings):
+        # BITB-089: the deploy workflow's legacy migration step builds the URL
+        # with `?ssl=require` (not `sslmode=require`). Regression test for the
+        # helper stripping that form too, instead of leaking it to asyncpg.
+        mock_settings.database_url = (
+            "postgresql://user:pass@host/db?ssl=require"  # pragma: allowlist secret
+        )
+        from scripture.database import get_async_database_url
+
+        with patch("scripture.database.settings", mock_settings):
+            url, args = get_async_database_url()
+
+        assert "ssl=" not in url
+        assert "ssl" in args
+
+    @patch("scripture.database.settings")
+    def test_url_with_ssl_and_other_params(self, mock_settings):
+        mock_settings.database_url = "postgresql://user:pass@host/db?ssl=require&connect_timeout=10"  # pragma: allowlist secret
+        from scripture.database import get_async_database_url
+
+        with patch("scripture.database.settings", mock_settings):
+            url, args = get_async_database_url()
+
+        assert "ssl=" not in url
+        assert "connect_timeout" in url
+        assert "ssl" in args
+
+    @patch("scripture.database.settings")
+    def test_url_with_both_ssl_and_sslmode(self, mock_settings):
+        mock_settings.database_url = (
+            "postgresql://user:pass@host/db?ssl=require&sslmode=require"  # pragma: allowlist secret
+        )
+        from scripture.database import get_async_database_url
+
+        with patch("scripture.database.settings", mock_settings):
+            url, args = get_async_database_url()
+
+        assert "ssl=" not in url
+        assert "sslmode" not in url
+        assert "ssl" in args
+
+    @patch("scripture.database.settings")
+    def test_url_with_ssl_disable(self, mock_settings):
+        mock_settings.database_url = (
+            "postgresql://user:pass@host/db?ssl=disable"  # pragma: allowlist secret
+        )
+        from scripture.database import get_async_database_url
+
+        with patch("scripture.database.settings", mock_settings):
+            url, args = get_async_database_url()
+
+        assert "ssl=" not in url
+        assert "ssl" not in args
+
 
 class TestGetDbSession:
     """Tests for get_db_session()."""

--- a/api/tests/test_deploy_workflow_migrations.py
+++ b/api/tests/test_deploy_workflow_migrations.py
@@ -1,0 +1,87 @@
+"""Guards against the specific silent-failure mode BITB-089 exists to close.
+
+Before this story, a revision added under `api/alembic/versions/**` matched
+no path filter in the deploy workflow, so `run-migrations` never ran it --
+no error, no warning, just schema drift discovered later by a 500. These
+tests parse `.github/workflows/azure-deploy.yml` and assert the four things
+that would let that regress silently:
+
+  1. the `changes` job's path filter watches `api/alembic/versions/**`
+  2. `changes` exposes that as a job output
+  3. `run-migrations` actually invokes `alembic upgrade head`
+  4. that invocation is gated on the stamp preflight (so it can't reach an
+     unstamped production database), and does not reuse the legacy step's
+     `?ssl=require` URL form (BITB-089's other silent hazard).
+
+Deliberately narrow: this is a regression guard for one dangerous failure
+mode, not a full schema validation of the workflow file.
+"""
+
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "azure-deploy.yml"
+
+
+def _load_workflow() -> dict:
+    # PyYAML parses the `on:` mapping key as the boolean True in YAML 1.1,
+    # colliding with the `true`/`false` keys workflow files also use --
+    # irrelevant here since we only read `jobs`, but load raw to avoid
+    # surprises if that ever changes.
+    return yaml.safe_load(_WORKFLOW_PATH.read_text())
+
+
+def _run_migrations_steps() -> list[dict]:
+    workflow = _load_workflow()
+    return workflow["jobs"]["run-migrations"]["steps"]
+
+
+def test_changes_job_filters_alembic_versions():
+    workflow = _load_workflow()
+    filters = workflow["jobs"]["changes"]["steps"][-1]["with"]["filters"]
+    assert "alembic_migrations" in filters
+    assert "api/alembic/versions/**" in filters
+
+
+def test_changes_job_exposes_alembic_migrations_output():
+    workflow = _load_workflow()
+    outputs = workflow["jobs"]["changes"]["outputs"]
+    assert outputs.get("alembic_migrations") == "${{ steps.filter.outputs.alembic_migrations }}"
+
+
+def test_run_migrations_job_triggers_on_alembic_change():
+    workflow = _load_workflow()
+    condition = workflow["jobs"]["run-migrations"]["if"]
+    assert "needs.changes.outputs.alembic_migrations" in condition
+
+
+def test_run_migrations_job_invokes_alembic_upgrade_head():
+    steps = _run_migrations_steps()
+    upgrade_steps = [s for s in steps if "alembic upgrade head" in (s.get("run") or "")]
+    assert upgrade_steps, "no step in run-migrations invokes `alembic upgrade head`"
+
+
+def test_alembic_upgrade_step_is_gated_on_stamp_preflight():
+    steps = _run_migrations_steps()
+    upgrade_steps = [s for s in steps if "alembic upgrade head" in (s.get("run") or "")]
+    assert upgrade_steps, "no step in run-migrations invokes `alembic upgrade head`"
+    for step in upgrade_steps:
+        assert "stamped" in step.get("if", ""), (
+            f"step {step.get('name')!r} runs `alembic upgrade head` without checking the "
+            "stamp preflight output -- this could point an unstamped production database "
+            "at CREATE TABLE for an already-existing schema"
+        )
+
+
+def test_no_alembic_step_uses_the_ssl_require_url_form():
+    steps = _run_migrations_steps()
+    alembic_steps = [s for s in steps if "alembic" in (s.get("run") or "")]
+    assert alembic_steps, "expected at least one alembic step in run-migrations"
+    for step in alembic_steps:
+        assert "?ssl=require" not in step["run"], (
+            f"step {step.get('name')!r} builds a DATABASE_URL with `?ssl=require`, which "
+            "get_async_database_url() must strip -- use `?sslmode=require` for Alembic "
+            "steps (see BITB-089)"
+        )

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1323,9 +1323,9 @@ showing — so the tap becomes a silent paste with no feedback. The guard is unn
 
 ---
 
-### 🎯 BITB-089: Deploy Alembic Migrations from CI — Make the Framework Actually Load-Bearing
+### 🚧 BITB-089: Deploy Alembic Migrations from CI — Make the Framework Actually Load-Bearing
 
-**Status:** 🎯 Todo
+**Status:** 🚧 In Progress — Stage 3 (pipeline wiring) shipped; Stages 1-2 (prod cutover) pending operator
 **Size:** M
 **Depends on:** BITB-004 (PR #948) — merged, but **inert** until this ships
 **Unblocks:** BITB-090
@@ -1342,12 +1342,19 @@ under `api/alembic/versions/**` **silently never deploys**. No error, no warning
 **Acceptance Criteria (summary):**
 
 - [ ] `alembic check` against a *restored copy* of prod passes — the gate for everything else
+      (deferred: requires an operator with prod DB access, see the runbook)
 - [ ] Prod stamped at `r0001` (zero DDL), backup taken first, `alembic current` verified
-- [ ] Deploy workflow: path filter, `alembic` installed, `alembic upgrade head` replaces the legacy call
-- [ ] SSL form resolved — `:1498` emits `?ssl=require`, which `get_async_database_url()` does **not**
-      strip (`api/scripture/database.py:37`); covered by a test
+      (deferred: same operator step)
+- [x] Deploy workflow: path filter (`api/alembic/versions/**`), `alembic` installed
+      (`pip install -r api/requirements.txt`), `alembic upgrade head` runs alongside the legacy
+      call — gated on a "Check Alembic stamp" preflight so it self-skips until Stage 2 is done
+- [x] SSL form resolved — `get_async_database_url()` now strips `?ssl=require` in addition to
+      `sslmode=require`; covered by tests in `api/tests/test_database_church_coverage.py`
 - [ ] Proven by a trivial reversible revision reaching prod, not by inspecting YAML
-- [ ] Rollback path documented for a mid-deploy `upgrade head` failure
+      (deferred to the operator's first post-stamp revision; the cutover itself is rehearsed
+      in CI by `test_stamp_cutover_matches_the_deploy_gate` in `api/tests/test_alembic_migrations.py`)
+- [x] Rollback path documented for a mid-deploy `upgrade head` failure — see
+      `docs/MIGRATION_GUIDELINES.md` → "When `alembic upgrade head` fails mid-deploy"
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-089-deploy-alembic-migrations-from-ci.md`
 

--- a/docs/BACKLOG_STORIES/BITB-089-deploy-alembic-migrations-from-ci.md
+++ b/docs/BACKLOG_STORIES/BITB-089-deploy-alembic-migrations-from-ci.md
@@ -1,6 +1,8 @@
 # BITB-089: Deploy Alembic Migrations from CI — Make the Framework Actually Load-Bearing
 
-**Status:** 🎯 Todo
+**Status:** 🚧 In Progress — Stage 3 (pipeline wiring) shipped; Stages 1-2 (production cutover)
+deferred to an operator runbook (see `docs/MIGRATION_GUIDELINES.md`), since they require live
+production database credentials that no CI session holds.
 **Priority:** P1
 **Size:** M (one-time operator step + workflow wiring)
 **Created:** 2026-07-31
@@ -89,17 +91,31 @@ failure in the new path does not block an unrelated release.
 
 ## Acceptance Criteria
 
-- [ ] `alembic check` run against a restored copy of production, output recorded in the PR
-- [ ] Production stamped at `r0001`; `alembic current` verified; backup taken beforehand
-- [ ] Deploy workflow path filter includes `api/alembic/versions/**`
-- [ ] Deploy job installs `alembic`
-- [ ] Deploy job runs `alembic upgrade head` from `api/`
-- [ ] SSL form resolved and covered by a test (no `?ssl=require` reaching an asyncpg-driven tool)
+- [ ] `alembic check` run against a restored copy of production, output recorded in the PR —
+      **deferred**: this is a live-credential, human-run operator step; see the runbook in
+      `docs/MIGRATION_GUIDELINES.md`
+- [ ] Production stamped at `r0001`; `alembic current` verified; backup taken beforehand —
+      **deferred**, same reason
+- [x] Deploy workflow path filter includes `api/alembic/versions/**`
+- [x] Deploy job installs `alembic` (`pip install -r api/requirements.txt`)
+- [x] Deploy job runs `alembic upgrade head` from `api/` — gated behind a "Check Alembic stamp"
+      preflight so it is a no-op until Stage 2 (prod stamping) has happened; the legacy
+      `scripts/migrations/` step keeps running unconditionally alongside it
+- [x] SSL form resolved and covered by a test (no `?ssl=require` reaching an asyncpg-driven tool)
+      — `get_async_database_url()` now strips `ssl` as well as `sslmode`; see
+      `api/tests/test_database_church_coverage.py::TestGetAsyncDatabaseUrl`
 - [ ] Proven end-to-end by a **trivial, reversible** revision (e.g. add then drop a comment on a
-      column) that demonstrably reaches prod via the pipeline — not by asserting the YAML looks right
-- [ ] Rollback path documented: what an operator does when `upgrade head` fails mid-deploy
-- [ ] `docs/MIGRATION_GUIDELINES.md` updated — the "operator runbook note" added by #948 becomes
-      the real procedure, and the "Legacy CI workflow" reference is corrected
+      column) that demonstrably reaches prod via the pipeline — not by asserting the YAML looks
+      right. **Deferred** to the operator's first post-stamp revision (no live prod access from
+      CI). The cutover sequence itself (upgrade → drop bookkeeping → stamp → no-op upgrade) is
+      rehearsed against a throwaway database in
+      `api/tests/test_alembic_migrations.py::test_stamp_cutover_matches_the_deploy_gate`, and the
+      "does the pipeline actually wire this up" regression is guarded by
+      `api/tests/test_deploy_workflow_migrations.py`.
+- [x] Rollback path documented: what an operator does when `upgrade head` fails mid-deploy — see
+      `docs/MIGRATION_GUIDELINES.md` → "When `alembic upgrade head` fails mid-deploy"
+- [x] `docs/MIGRATION_GUIDELINES.md` updated — the "operator runbook note" added by #948 becomes
+      the real Stage 1-3 procedure, and the "Legacy CI workflow" reference is corrected
 
 ## Out of Scope
 

--- a/docs/MIGRATION_GUIDELINES.md
+++ b/docs/MIGRATION_GUIDELINES.md
@@ -1,7 +1,7 @@
 # Migration Best Practices & Guidelines
 
-**Version:** 1.1
-**Last Updated:** 2026-07-30
+**Version:** 1.2
+**Last Updated:** 2026-08-04
 **Owner:** Product & Engineering Team
 
 ---
@@ -15,7 +15,10 @@
 > columns go through an Alembic revision from now on. See
 > `api/alembic/README.md` for the day-to-day workflow and
 > "Long-Term Solution: Alembic" below for the full story, including the
-> **prod adoption runbook note** (this PR does not touch production).
+> **operator runbook** for the one-time production cutover (BITB-089).
+> The deploy pipeline is wired to run `alembic upgrade head` automatically
+> once that cutover is done; until then it self-skips (see "CI/CD
+> Integration" below).
 >
 > The manual-migration guidance below this banner still applies to everything
 > already in `scripts/migrations/` and is kept for historical reference; it is
@@ -577,17 +580,33 @@ conn = await asyncpg.connect(clean_url, **conn_kwargs)
 - Azure production (SSL required)
 - Both `postgresql://` and `postgresql+asyncpg://` schemes
 
+**BITB-089:** the API's own `get_async_database_url()`
+(`api/scripture/database.py`, used by `api/alembic/env.py`) now strips both
+`sslmode` and `ssl` the same way, so it's safe to pass it either URL form —
+this closed a gap where `?ssl=require` (the form the deploy workflow's
+legacy migration step builds) passed through untouched.
+
 ---
 
 ## CI/CD Integration
 
 ### When Migrations Run Automatically
 
-Migrations run in the `run-migrations` job if:
+The `run-migrations` job runs two migration systems side by side (BITB-089):
+the legacy `scripts/migrations/` runner, and `alembic upgrade head`. Both are
+gated the same way at the job level:
 
-1. Files in `scripts/migrations/` changed
+1. Files in `scripts/migrations/**` OR `api/alembic/versions/**` changed
 2. NOT a pull request (only on merge to main)
 3. Deploy job succeeded OR was skipped
+
+Within the job, the Alembic half has one more gate: a "Check Alembic stamp"
+preflight runs `alembic current` first and only runs `alembic upgrade head`
+if it reports a revision. Production has no `alembic_version` row until the
+operator completes the Stage 1-2 cutover below, so until then this step
+prints a step-summary note and does nothing — merging this wiring changes no
+observable behavior. The legacy runner is unaffected either way and keeps
+running every deploy.
 
 ### Manual Trigger
 
@@ -701,23 +720,74 @@ def upgrade() -> None:
         op.execute("CREATE INDEX CONCURRENTLY ...")
 ```
 
-### Operator runbook note: adopting Alembic against the existing prod database
+### Operator runbook: adopting Alembic against the existing prod database (BITB-089)
 
 The production database already has the full schema (built up over time by
-`scripts/migrations/`). Alembic has never run against it. Before Alembic can
-manage prod schema changes, an operator must run, once:
+`scripts/migrations/`). Alembic has never run against it, and CI cannot and
+must not perform this cutover — it needs prod credentials and a human
+decision, so it stays a manual, operator-run procedure. The deploy
+pipeline's "Check Alembic stamp" step (BITB-089, `run-migrations` job) skips
+itself until Stage 2 below is done, so there is no time pressure to rush it.
+
+**Stage 1 — rehearse against a restored copy (the gate for everything else).**
+Restore production into a throwaway target — Scenario A or C of
+[`docs/HOW-TO-BACKUP-RESTORE-DATABASE.md`](HOW-TO-BACKUP-RESTORE-DATABASE.md) — then:
+
+```bash
+DATABASE_URL="<restored-copy-url>" alembic check
+```
+
+If this reports drift, the restored copy (and therefore prod) does not
+match what `r0001` was generated from. **Do not proceed to Stage 2** —
+reconcile the difference (usually by hand-writing a follow-up revision)
+first. Stamping over a genuine mismatch would make Alembic's view of the
+schema wrong from the very first deploy.
+
+**Stage 2 — stamp production (one-time, manual).** Take a backup first
+(Scenario D of the same runbook) even though `stamp` is non-destructive —
+cheap insurance for a step that only runs once:
 
 ```bash
 DATABASE_URL="<prod-url>" alembic stamp r0001
 ```
 
-`stamp` only writes a row to `alembic_version` marking `r0001` as already
+`stamp` writes one row to `alembic_version` marking `r0001` as already
 applied — it executes **zero DDL** (it does not create or touch a single
 table), because prod already has the equivalent schema from the manual
-migrations. **This PR does not run that command anywhere** (see the hard
-constraint against contacting the production/Azure database) — it is a
-deliberate one-time, manual, operator-run step for whenever the team decides
-to cut prod over.
+migrations. Verify:
+
+```bash
+DATABASE_URL="<prod-url>" alembic current   # must print r0001
+DATABASE_URL="<prod-url>" alembic upgrade head   # must be a no-op
+```
+
+Rollback, if needed: `DROP TABLE alembic_version` (removes the bookkeeping
+row only; the schema itself is untouched either way).
+
+**Stage 3 — already shipped.** Once Stage 2 lands, the very next deploy's
+"Check Alembic stamp" step reports `stamped=true` and `alembic upgrade
+head` starts running automatically from then on — no second PR needed.
+
+### When `alembic upgrade head` fails mid-deploy
+
+Each revision runs inside a transaction (the `CREATE INDEX CONCURRENTLY`
+autocommit block above is the one documented exception), so Postgres rolls
+back a failed revision itself — a failure does not normally leave a
+half-applied schema change. If it happens anyway:
+
+1. Check `DATABASE_URL="<prod-url>" alembic current` to see what actually
+   landed.
+2. If a revision partially applied outside a transaction, `alembic
+   downgrade <previous-revision>` run manually against prod.
+3. Restore from backup as a last resort (see the backup/restore runbook).
+4. The legacy `scripts/migrations/` step in the same job is unaffected and
+   keeps running regardless — an Alembic failure does not block or roll
+   back anything the legacy runner already applied.
+
+The deploy job's "Apply Alembic migrations" step uses `continue-on-error:
+true` for the first release after Stage 2 specifically so a failure here
+warns loudly (step summary + `::warning`) instead of failing the whole
+deploy — remove that once one prod run has succeeded end-to-end.
 
 ---
 
@@ -741,8 +811,10 @@ to cut prod over.
 ## References
 
 - Backend SSL handling: `api/scripture/database.py` → `get_async_database_url()`
-- Legacy CI workflow (scripts/migrations/ only): `.github/workflows/azure-deploy.yml` → `run-migrations` job
-- Alembic CI check (new schema changes): `.github/workflows/test_update.yml` → `alembic-migrations` job
+- Deploy CI workflow (runs both legacy `scripts/migrations/` and, once
+  stamped, `alembic upgrade head`): `.github/workflows/azure-deploy.yml` →
+  `run-migrations` job (BITB-089)
+- Alembic CI check (new schema changes, ephemeral DB only): `.github/workflows/test_update.yml` → `alembic-migrations` job
 - Alembic usage: `api/alembic/README.md`
 - Existing legacy migrations: `scripts/migrations/001_*.py`, `002_*.py`
 - asyncpg docs: <https://magicstack.github.io/asyncpg/current/>
@@ -753,6 +825,10 @@ to cut prod over.
 
 **Version History:**
 
+- 1.2 (2026-08-04): BITB-089 — wired `alembic upgrade head` into the deploy
+  pipeline (gated on a stamp preflight so it self-skips until the operator
+  cutover), fixed `get_async_database_url()` to strip `?ssl=require` too,
+  and turned the prod-adoption note into a full Stage 1-3 operator runbook.
 - 1.1 (2026-07-30): BITB-004 — Alembic (`api/alembic/`) is now the current system for new
   schema changes; `scripts/migrations/` frozen as historical record. Added the "Long-Term
   Solution: Alembic" real usage section and the prod-adoption runbook note.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3692,9 +3692,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
   },
   "overrides": {
     "minimatch": ">=10.2.1",
+    "brace-expansion": ">=5.0.9",
     "esbuild": ">=0.28.1",
     "sharp": ">=0.35.0",
     "next": {


### PR DESCRIPTION
## What

BITB-004 (#948) added the Alembic migration framework but deliberately left it disconnected from
deploy: a revision under `api/alembic/versions/**` matched no path filter, so it would **silently
never deploy** — no error, no warning. This PR (BITB-089) closes that gap:

- `changes` job: new `alembic_migrations` path filter/output watching `api/alembic/versions/**`
- `run-migrations` job: triggers on that path too; installs deps from `api/requirements.txt`
  (was an unpinned `pip install asyncpg pydantic pydantic-settings`, now includes `alembic`)
- New **"Check Alembic stamp"** preflight (`alembic current`) gates a new **"Apply Alembic
  migrations"** step (`alembic upgrade head`) — it only runs once production has been stamped.
  The pre-existing legacy `scripts/migrations/` step is untouched and keeps running every deploy
  as the safety net.
- `continue-on-error: true` on the new upgrade step for the first release after cutover, paired
  with a step-summary + `::warning` so a failure is loud, not silent — planned to be removed
  after the first successful prod run.
- Fixed `get_async_database_url()` (`api/scripture/database.py`) to strip `?ssl=require` in
  addition to `sslmode=require`, matching `scripts/migrations/utils.py`. The deploy workflow's
  legacy migration step builds the URL with `?ssl=require`, and the new Alembic steps route
  through the same helper via `api/alembic/env.py` — without this fix that form would leak
  through to asyncpg.
- `docs/MIGRATION_GUIDELINES.md`, `docs/BACKLOG.md`, and the story file updated to an honest
  in-progress status (see **Notes** below for what's deferred and why).

**Scope note:** the story has 3 stages. This PR ships **Stage 3 only** (pipeline wiring). Stages 1
and 2 — rehearsing `alembic check` against a restored copy of production, and the one-time
`alembic stamp r0001` against the live database — require production credentials and a human
decision, so they're written up as an operator runbook in `docs/MIGRATION_GUIDELINES.md` rather
than executed here. **Merging this PR changes no observable behavior**: the stamp-preflight gate
means `alembic upgrade head` cannot run against production until an operator completes that
runbook.

## Test plan

- [x] Tests added/updated for changed behaviour
  - `api/tests/test_database_church_coverage.py`: 4 new cases for the `?ssl=require` fix
    (`ssl=require` alone, combined with other params, combined with `sslmode`, and `ssl=disable`)
  - `api/tests/test_alembic_migrations.py`: new `test_stamp_cutover_matches_the_deploy_gate`
    rehearses the exact upgrade → drop-bookkeeping → stamp → no-op-upgrade sequence the
    production cutover (and the deploy job's stamp preflight) depends on, against a throwaway
    database
  - `api/tests/test_deploy_workflow_migrations.py` (new): parses the workflow YAML and guards
    the specific silent-failure mode this story exists to close — the path filter includes
    `api/alembic/versions/**`, the job actually invokes `alembic upgrade head`, that invocation
    is gated on the stamp preflight, and no Alembic step uses the `?ssl=require` URL form
  - Ran all of the above locally against a real Postgres + pgvector instance (not just the
    ephemeral-DB-unavailable skip path): 64 tests passed, 0 failed
- [x] `make pre-commit` equivalent passed locally: `black --line-length=100`, `ruff check`,
  `yamllint --strict` (repo's exact config), `prettier --print-width 120`, and `markdownlint` all
  clean on every changed file
- [ ] CI (this PR cannot exercise the `run-migrations` job itself — it only runs on push to main
  with `environment: production`, correctly not on PRs)

## Notes

- Deferred to the operator runbook (not in scope for an unattended CI session): Stage 1
  (`alembic check` against a restored prod copy) and Stage 2 (`alembic stamp r0001` against
  production). Both require live production database credentials. The backlog story and
  `docs/BACKLOG.md` are updated to 🚧 In Progress reflecting this split, with the remaining
  acceptance criteria explicitly marked deferred rather than checked off.
- No new dependencies: `alembic` was already added to `api/requirements.txt` by #948; this PR
  just makes the deploy job install the full pinned requirements file instead of an ad-hoc subset.
- Once the operator completes the Stage 1-2 runbook, the very next deploy activates the new path
  automatically — no follow-up PR needed for that transition.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F7aW2JcxWo4iJmBB6pwhwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7aW2JcxWo4iJmBB6pwhwy)_