### PR TITLE
fix(deploy): auto-remediate origin cert binding on post-deploy 525/526 (BITB-067)

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -124,6 +124,8 @@ env:
   FRONTEND_APP_NAME: bible-app-frontend
   ACR_NAME: bibleappacrmb0172
   RESOURCE_GROUP: bible-app-rg
+  # azurerm_container_app_environment.main = "${var.project_name}-env" (main.tf:358)
+  CONTAINER_APP_ENV_NAME: bible-app-env
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
@@ -1175,52 +1177,175 @@ jobs:
             echo "Frontend URL: https://$FRONTEND_FQDN"
           fi
 
+      # BITB-067 gap #5: a Container App replacement (e.g. the OpenRouter key
+      # rotation that fires terraform_data.backend_secret_trigger) drops the
+      # imperative custom-domain + certificate binding and prod starts serving
+      # Cloudflare 525. Terraform re-binds in the same apply, but any other path
+      # that loses the binding needed the manual deployment/README.md >
+      # "Rollback: Emergency Cert Rebind" runbook. Now attempted automatically.
       - name: Verify Custom Domain HTTPS
+        env:
+          RG: ${{ env.RESOURCE_GROUP }}
+          CA_ENV: ${{ env.CONTAINER_APP_ENV_NAME }}
+          FRONTEND_APP: ${{ env.FRONTEND_APP_NAME }}
+          BACKEND_APP: ${{ env.BACKEND_APP_NAME }}
         run: |
           set -euo pipefail
           DOMAINS=("voxquieta.org" "api.voxquieta.org")
+          APPS=("$FRONTEND_APP" "$BACKEND_APP")
           FAILED=0
-          for DOMAIN in "${DOMAINS[@]}"; do
-            echo "Checking https://$DOMAIN ..."
-            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
-              --max-time 15 "https://$DOMAIN/health" 2>/dev/null || echo "000")
-            CF_RAY=$(curl -sI --max-time 15 "https://$DOMAIN/health" 2>/dev/null | grep -i 'cf-ray' || echo "")
 
-            case "$HTTP_CODE" in
+          # Probe one domain through Cloudflare. Echoes "<http_code>|<cf-ray>".
+          probe_domain() {
+            local domain="$1" code ray
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              --max-time 15 "https://$domain/health" 2>/dev/null || echo "000")
+            ray=$(curl -sI --max-time 15 "https://$domain/health" 2>/dev/null \
+              | grep -i 'cf-ray' || echo "")
+            printf '%s|%s' "$code" "$ray"
+          }
+
+          # Classify one domain; prints one human-readable line.
+          # Exit: 0 = acceptable, 1 = origin TLS broken (a re-bind may fix it),
+          #       2 = broken in a way a cert re-bind cannot fix.
+          check_domain() {
+            local domain="$1" result code ray
+            result=$(probe_domain "$domain")
+            code="${result%%|*}"
+            ray="${result#*|}"
+            case "$code" in
               200)
-                if [ -z "$CF_RAY" ]; then
-                  echo "::error::$DOMAIN returned 200 but no cf-ray header — traffic is bypassing Cloudflare"
-                  FAILED=1
-                else
-                  echo "$DOMAIN OK — HTTP 200, $CF_RAY"
+                if [ -z "$ray" ]; then
+                  echo "$domain returned 200 but no cf-ray header — traffic is bypassing Cloudflare"
+                  return 2
                 fi
+                echo "$domain OK — HTTP 200, $ray"
                 ;;
               525)
-                echo "::error::$DOMAIN returned 525 (SSL Handshake Failed) — origin cert missing or not bound"
-                FAILED=1
+                echo "$domain returned 525 (SSL Handshake Failed) — origin cert missing or not bound"
+                return 1
                 ;;
               526)
-                echo "::error::$DOMAIN returned HTTP 526 (Invalid SSL Certificate) — origin cert chain is wrong"
-                FAILED=1
+                echo "$domain returned HTTP 526 (Invalid SSL Certificate) — origin cert chain is wrong"
+                return 1
                 ;;
               000)
-                echo "::error::$DOMAIN is unreachable (HTTP 000) — DNS or Cloudflare misconfigured"
-                FAILED=1
+                echo "$domain is unreachable (HTTP 000) — DNS or Cloudflare misconfigured"
+                return 2
                 ;;
               5*)
-                echo "::error::$DOMAIN returned HTTP $HTTP_CODE — origin error"
-                FAILED=1
+                echo "$domain returned HTTP $code — origin error"
+                return 2
                 ;;
               *)
-                if [ -z "$CF_RAY" ]; then
-                  echo "::error::$DOMAIN responded HTTP $HTTP_CODE with no cf-ray header"
-                  FAILED=1
-                else
-                  echo "$DOMAIN responded HTTP $HTTP_CODE (non-200 but reached Cloudflare), $CF_RAY"
+                if [ -z "$ray" ]; then
+                  echo "$domain responded HTTP $code with no cf-ray header"
+                  return 2
                 fi
+                echo "$domain responded HTTP $code (non-200 but reached Cloudflare), $ray"
                 ;;
             esac
+          }
+
+          # Re-run the cert lookup + hostname bind for one domain, mirroring
+          # null_resource.{frontend,backend}_ssl_cert_bind (deployment/main.tf
+          # :931 / :1015). Only ever called for an already-TLS-broken domain, so
+          # it cannot regress a healthy one. Non-zero = could not re-bind.
+          rebind_cert() {
+            local domain="$1" app="$2" parent query cert_id attached
+            # Wildcard SAN one level up, e.g. api.voxquieta.org -> *.voxquieta.org.
+            # For an apex domain this yields a harmless *.tld that matches nothing.
+            parent="*.${domain#*.}"
+            echo "Auto-remediation: re-binding origin cert for $domain on $app ..."
+
+            # A replaced app loses the hostname itself, so re-add it first
+            # (same guard as null_resource.backend_custom_domain, main.tf:875).
+            attached=$(az containerapp show --name "$app" --resource-group "$RG" \
+              --query "properties.configuration.ingress.customDomains[].name" \
+              -o tsv 2>/dev/null || true)
+            if ! echo "$attached" | grep -qx "$domain"; then
+              echo "  hostname $domain not attached to $app — adding it"
+              az containerapp hostname add --name "$app" --resource-group "$RG" \
+                --hostname "$domain" --output none \
+                || echo "  hostname add failed (may already exist) — continuing"
+            fi
+
+            query="[?contains(properties.subjectAlternativeNames, '$domain')"
+            query="$query || contains(properties.subjectAlternativeNames, '$parent')]"
+            query="$query | sort_by(@, &properties.expirationDate) | reverse(@) | [0].id"
+            cert_id=$(az containerapp env certificate list --name "$CA_ENV" \
+              --resource-group "$RG" --query "$query" -o tsv 2>/dev/null || true)
+
+            if [ -z "$cert_id" ]; then
+              echo "  no certificate in $CA_ENV has a SAN covering $domain or $parent"
+              az containerapp env certificate list --name "$CA_ENV" \
+                --resource-group "$RG" -o table \
+                --query "[].{name:name,SANs:properties.subjectAlternativeNames,expiry:properties.expirationDate}" \
+                || true
+              return 1
+            fi
+
+            echo "  binding certificate $cert_id"
+            az containerapp hostname bind --name "$app" --resource-group "$RG" \
+              --hostname "$domain" --certificate "$cert_id" \
+              --environment "$CA_ENV" --output none
+          }
+
+          for i in "${!DOMAINS[@]}"; do
+            DOMAIN="${DOMAINS[$i]}"
+            APP="${APPS[$i]}"
+            echo "Checking https://$DOMAIN ..."
+            MSG=""; STATUS=0
+            MSG=$(check_domain "$DOMAIN") || STATUS=$?
+
+            if [ "$STATUS" -eq 0 ]; then
+              echo "$MSG"
+              continue
+            fi
+            if [ "$STATUS" -eq 2 ]; then
+              echo "::error::$MSG"
+              FAILED=1
+              continue
+            fi
+
+            # Origin TLS broken — try one automatic re-bind before failing.
+            echo "::warning::$MSG — attempting an automatic origin-cert re-bind"
+            if ! rebind_cert "$DOMAIN" "$APP"; then
+              echo "::error::$MSG. Automatic cert re-bind could NOT be performed" \
+                "(see the az output above) — follow deployment/README.md >" \
+                "'Rollback: Emergency Cert Rebind' manually."
+              FAILED=1
+              continue
+            fi
+
+            # Same criteria as the first pass, deliberately: the re-check is a
+            # re-run of the identical check, never a laxer one.
+            RECOVERED=0
+            MSG2=""
+            for attempt in 1 2 3; do
+              echo "Re-checking $DOMAIN after re-bind (attempt $attempt/3, 30s wait) ..."
+              sleep 30
+              MSG2=""; STATUS2=0
+              MSG2=$(check_domain "$DOMAIN") || STATUS2=$?
+              if [ "$STATUS2" -eq 0 ]; then
+                RECOVERED=1
+                break
+              fi
+            done
+
+            if [ "$RECOVERED" -eq 1 ]; then
+              echo "$MSG2"
+              echo "::notice::$DOMAIN recovered after an automatic origin-cert re-bind" \
+                "(was: $MSG). The Container App lost its custom-domain binding —" \
+                "see BITB-067 gap #5."
+            else
+              echo "::error::$DOMAIN still broken after an automatic cert re-bind:" \
+                "$MSG2 (original: $MSG). Auto-remediation ran and did NOT fix it —" \
+                "follow deployment/README.md > 'Rollback: Emergency Cert Rebind' manually."
+              FAILED=1
+            fi
           done
+
           if [ "$FAILED" -ne 0 ]; then
             echo "::error::One or more domains failed the post-deploy SSL/health check"
             exit 1

--- a/docs/BACKLOG_STORIES/BITB-067-deploy-and-smoke-monitor-reliability-gaps.md
+++ b/docs/BACKLOG_STORIES/BITB-067-deploy-and-smoke-monitor-reliability-gaps.md
@@ -1,6 +1,6 @@
 # BITB-067: Deploy & Smoke-Monitor Reliability — Gaps From the 2026-07-07 False-Alarm Incident
 
-**Status:** 🚧 In Progress (gaps #1/#2/#3/#4 shipped — #1 in PR #848, #2/#3/#4 in PR #845; #5/#6 open — Terraform/Azure infra work)
+**Status:** 🚧 In Progress (gaps #1–#5 shipped — #1 in PR #848, #2/#3/#4 in PR #845, #5 auto cert re-bind in the post-deploy HTTPS check; #6 open — Terraform/Azure infra work)
 **Priority:** P1 (High) — the monitoring we just added (BITB-064/065/066) produced a false "production
 down" alert while the site was healthy, and a routine deploy silently broke origin TLS. These gaps
 erode trust in the alerts and can turn a no-op deploy into an outage.
@@ -68,7 +68,7 @@ upload `frontend/test-results/` + `frontend/playwright-report/` as an artifact, 
 `$RUNNER_TEMP/detail.txt` (which `notify-telegram` already appends) pointing at the artifact + the
 "check the deploy" hypothesis.
 
-### 5. Routine deploys can break origin TLS (Cloudflare 525) — recurring
+### 5. Routine deploys can break origin TLS (Cloudflare 525) — recurring — ✅ Shipped
 
 A deploy failed post-check with `525 SSL Handshake Failed` on `api.voxquieta.org` (origin cert
 missing/unbound). This has recurred (the repo already ships a "Rollback: Emergency Cert Rebind"
@@ -79,6 +79,22 @@ replacement*, i.e. adding a monitoring secret can now trigger the exact replace�
 **Fix direction:** make the cert bind reliably re-run after any backend replacement (correct
 `depends_on`/trigger wiring so the rebind is not skipped), and/or decouple secret changes from full app
 replacement; add an automatic post-deploy rebind-and-retry rather than a manual runbook.
+
+**Shipped as:** the trigger half was already wired — `null_resource.backend_custom_domain` and
+`backend_ssl_cert_bind` key on `terraform_data.backend_secret_trigger.id`, so the *same* apply
+re-binds after a replacement. This pass adds the missing auto-remediation: `azure-deploy.yml`'s
+"Verify Custom Domain HTTPS" step now, on a 525/526 for either custom domain, re-adds the hostname
+(a replaced app loses it) and re-runs the cert lookup + `az containerapp hostname bind` for that
+domain's app, then re-checks up to 3× at 30s intervals before failing. A recovered domain logs a
+`::notice::`; a still-broken one fails with a message distinguishing "auto-remediation ran and did
+not fix it" from the original error and pointing at the `deployment/README.md` runbook. This also
+covers the frontend, whose `frontend_ssl_cert_bind` has no replacement trigger (the frontend app has
+no `replace_triggered_by`). Remediation only runs for a domain that is *already* TLS-broken, so a bug
+in it cannot regress a healthy domain — worst case is the identical loud failure as before. The
+criterion's "fails loudly *before* flipping traffic" branch is not satisfiable under
+`revision_mode = "Single"` (traffic flips on apply); this satisfies the "or auto-remediates" branch.
+The az invocations are copied from the Terraform provisioners they mirror and cannot be exercised
+against real Azure from CI.
 
 ### 6. Secret rotation is coupled to full app replacement
 
@@ -127,7 +143,7 @@ Telegram-token deploy step rather than inventing a new mechanism.
 - [x] `prod-chat-smoke.spec.ts` fails fast with a descriptive message on a stale/mismatched bundle
       (asserts the user bubble first), and its test-level timeout exceeds its assertion budgets.
 - [x] `prod-browser-smoke.yml` uploads a trace/report artifact and a `detail.txt` on failure.
-- [ ] A backend app replacement (incl. secret rotation) reliably re-binds the origin cert with no
+- [x] A backend app replacement (incl. secret rotation) reliably re-binds the origin cert with no
       manual runbook step; a deploy that would leave origin TLS broken fails loudly *before* flipping
       traffic, or auto-remediates.
 - [ ] (Investigate) probe-secret changes no longer force a full Container App replacement.


### PR DESCRIPTION
## What

- Closes gap #5 of BITB-067 (`docs/BACKLOG_STORIES/BITB-067-deploy-and-smoke-monitor-reliability-gaps.md`): routine deploys can break origin TLS (Cloudflare 525/526) when a Container App replacement (e.g. secret rotation) drops the imperative custom-domain cert binding.
- The Terraform trigger-wiring half of gap #5 was already in place (`null_resource.backend_ssl_cert_bind` / `backend_custom_domain` key on `terraform_data.backend_secret_trigger.id`). What was missing was auto-remediation for any other path that loses the binding (or a lagging propagation) — previously the deploy just failed loudly and pointed at a manual runbook (`deployment/README.md` > "Rollback: Emergency Cert Rebind").
- `.github/workflows/azure-deploy.yml`'s "Verify Custom Domain HTTPS" step now, on a 525/526 for either `voxquieta.org` or `api.voxquieta.org`, attempts one automatic re-bind (re-add the hostname if missing, look up the newest cert in the Container App Environment covering the domain's SAN, `az containerapp hostname bind`), then re-checks up to 3× at 30s intervals before failing. This also covers the frontend, whose `frontend_ssl_cert_bind` has no replacement trigger today.
- Updated the backlog story file: status line, gap #5 marked shipped with a "Shipped as" note, and its acceptance-criteria checkbox checked.

## Why this is safe

Remediation is only reachable from a domain that has *already* failed the check (525/526) — every failure mode of the new code (wrong env name, az auth issue, no matching cert, bind rejected, still broken after 3 retries) sets `FAILED=1` and exits non-zero with strictly more diagnostic output than today. There is no path where a domain that would fail today now falsely passes; a bug in the remediation logic cannot regress a healthy domain.

**Residual risk to flag:** this step now issues write operations (`hostname add`/`bind`) from what was previously a read-only post-deploy check. It runs in the same `environment: production`-gated `deploy` job, under the same service principal Terraform already uses for these exact calls.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses cleanly
- [x] Line-length check (repo's yamllint config caps at 120) — no violations
- [x] `yamllint --strict` with the repo's exact `.pre-commit-config.yaml` rule set — clean
- [x] `prettier --prose-wrap always --print-width 120 --check` on the workflow file — clean
- [x] `markdownlint --fix` on the backlog story file — no additional changes needed
- [x] `bash -n` on the extracted step body — valid syntax
- [x] Behavioral dry-run with stubbed `az`/`curl`/`sleep` covering: (1) a domain that recovers after re-bind → `::notice::` + exit 0, (2) a domain that stays broken after 3 retries → `::error::` + exit 1, (3) no matching certificate found → fails safely without a false re-bind claim, (4) fully healthy domains → `az` never invoked, exit 0
- [ ] Cannot be exercised against real Azure Container Apps from this environment — the az CLI calls mirror the Terraform provisioners' logic byte-for-byte and those are exercised on every `terraform apply`.
- [x] `make pre-commit` equivalents run individually as above (full `pre-commit` binary not installed in this sandbox)

## Notes

- Gap #6 of BITB-067 ("Secret rotation is coupled to full app replacement") was already shipped separately in PR #896, but the backlog story file's status line and its acceptance-criteria checkbox were never updated for it. Left untouched here to keep this PR scoped to gap #5 only — flagging so the doc can be cleaned up in a follow-up.
- No `.tf` files changed, so no `terraform validate`/`plan` impact beyond what's already covered by the existing `tf-validate`/`tf-plan` CI jobs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RpizAcoxGHDptg9RFBwZ37)_