### PR TITLE
feat(ci): automate search-eval prod + smoke runs (BITB-051 P4a)

### DIFF
--- a/.github/workflows/search-eval-full.yml
+++ b/.github/workflows/search-eval-full.yml
@@ -1,0 +1,442 @@
+name: Search Eval — Full
+
+# BITB-051 P4a: nightly + manual live exercise of the retrieval-eval harness
+# (api/search_eval/, scripts/run_search_eval.py). Per-PR CI only ever runs
+# `--validate` (test_update.yml's search-eval-validate job) — no DB, no
+# secrets, works on forks. This workflow is where the harness actually talks
+# to real embeddings and real data, on a schedule nobody has to remember to
+# run by hand.
+#
+# Two routes:
+#   eval-prod  — read-only against the real production database + Azure
+#                OpenAI query embeddings. True prod numbers, no rebuild.
+#                Reuses the exact ARM-login / DB-connection-string pattern
+#                azure-deploy.yml already uses for migrations/seeding — no
+#                new DB secret is introduced.
+#   eval-smoke — loads 1 Corinthians into an ephemeral CI Postgres, Azure-
+#                embeds it, and runs `--run --smoke`. Proves the CLI/Azure
+#                plumbing end-to-end without ever touching prod. Scores are
+#                expected to be ~0 (the golden set's first 3 cases aren't in
+#                1 Corinthians) — this job is a plumbing check, not a
+#                relevance measurement.
+#
+# Route B (`eval-corpus`: full 11-translation rebuild in a cached pgvector,
+# for a reproducible-corpus A/B independent of prod drift) is intentionally
+# NOT implemented here — tracked as BITB-051 P4b. See the story file for why
+# it's deferred (GitHub Actions cache-eviction risk to unrelated per-PR
+# caches, unbounded first-run duration, and new cache-correctness surface
+# with no test coverage yet).
+#
+# Required repo secrets (all already provisioned for azure-deploy.yml):
+#   ARM_CLIENT_ID / ARM_CLIENT_SECRET / ARM_SUBSCRIPTION_ID / ARM_TENANT_ID
+#   TF_VAR_DB_ADMIN_USERNAME / TF_VAR_DB_ADMIN_PASSWORD / TF_VAR_DB_NAME
+#   AZURE_OPENAI_API_KEY
+#   TF_VAR_OPENROUTER_API_KEY (optional — enables the expansion_semantic leg
+#     of eval-prod; without it, eval-prod falls back to baseline_semantic only)
+# Required repo variables:
+#   AZURE_OPENAI_ENDPOINT
+#
+# Any of the above missing ⇒ the affected job is skipped with a clear notice
+# in the job summary, never failed. This workflow never runs on pull_request
+# and never gates merges.
+#
+# Manual run:
+#   Actions → Search Eval — Full → Run workflow
+#   route: both | prod | smoke (default: both)
+#   configs: comma-separated eval config names, default empty → the CLI's
+#            own default (baseline_semantic,expansion_semantic)
+#   language: optional golden-set language filter (e.g. it, de)
+
+# yamllint flags the unquoted `on` key as a YAML 1.1 truthy value.
+"on":
+  schedule:
+    # 04:23 UTC daily — a free slot among the other scheduled workflows.
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+    inputs:
+      route:
+        description: "Which route(s) to run"
+        type: choice
+        options:
+          - both
+          - prod
+          - smoke
+        default: both
+      configs:
+        description: "Comma-separated eval config names (blank = CLI default)"
+        required: false
+        default: ""
+      language:
+        description: "Restrict to one golden-set language code (blank = all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: search-eval-full
+  cancel-in-progress: false
+
+env:
+  RESOURCE_GROUP: bible-app-rg
+  AZURE_EMBEDDING_DEPLOYMENT: text-embedding-3-small
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Preflight — decide which routes can actually run. The `secrets` context
+  # isn't usable in a job-level `if:`, so read it into step outputs here and
+  # gate downstream jobs on those outputs instead.
+  # ---------------------------------------------------------------------------
+  preflight:
+    name: Check configuration
+    runs-on: ubuntu-latest
+    outputs:
+      has_arm: ${{ steps.check.outputs.has_arm }}
+      has_db: ${{ steps.check.outputs.has_db }}
+      has_azure: ${{ steps.check.outputs.has_azure }}
+      has_llm: ${{ steps.check.outputs.has_llm }}
+    steps:
+      - name: Check required secrets/vars
+        id: check
+        env:
+          HAS_ARM: >-
+            ${{ secrets.ARM_CLIENT_ID != '' && secrets.ARM_CLIENT_SECRET != '' &&
+            secrets.ARM_SUBSCRIPTION_ID != '' && secrets.ARM_TENANT_ID != '' }}
+          HAS_DB: >-
+            ${{ secrets.TF_VAR_DB_ADMIN_USERNAME != '' && secrets.TF_VAR_DB_ADMIN_PASSWORD != '' &&
+            secrets.TF_VAR_DB_NAME != '' }}
+          HAS_AZURE: ${{ vars.AZURE_OPENAI_ENDPOINT != '' && secrets.AZURE_OPENAI_API_KEY != '' }}
+          HAS_LLM: ${{ secrets.TF_VAR_OPENROUTER_API_KEY != '' }}
+        run: |
+          echo "has_arm=${HAS_ARM}" >> "$GITHUB_OUTPUT"
+          echo "has_db=${HAS_DB}" >> "$GITHUB_OUTPUT"
+          echo "has_azure=${HAS_AZURE}" >> "$GITHUB_OUTPUT"
+          echo "has_llm=${HAS_LLM}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Search Eval — configuration"
+            echo ""
+            echo "| requirement | present | disables |"
+            echo "| --- | --- | --- |"
+            echo "| Azure login (ARM_*) | ${HAS_ARM} | eval-prod |"
+            echo "| Prod DB creds (TF_VAR_DB_*) | ${HAS_DB} | eval-prod |"
+            echo "| Azure OpenAI (endpoint + key) | ${HAS_AZURE} | eval-prod, eval-smoke |"
+            echo "| OpenRouter key (expansion LLM) | ${HAS_LLM} | expansion_semantic leg only |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$HAS_ARM" != "true" ] || [ "$HAS_DB" != "true" ]; then
+            echo "::notice::eval-prod will be skipped — Azure login or prod DB secrets are not configured."
+          fi
+          if [ "$HAS_AZURE" != "true" ]; then
+            echo "::notice::eval-prod and eval-smoke will both be skipped — Azure OpenAI is not configured."
+          fi
+          if [ "$HAS_LLM" != "true" ]; then
+            echo "::notice::eval-prod will run baseline_semantic only — no OpenRouter key configured."
+          fi
+
+  # ---------------------------------------------------------------------------
+  # Route A — read-only eval against the real production database.
+  # ---------------------------------------------------------------------------
+  eval-prod:
+    name: eval-prod (Route A)
+    needs: preflight
+    if: >-
+      needs.preflight.outputs.has_arm == 'true' &&
+      needs.preflight.outputs.has_db == 'true' &&
+      needs.preflight.outputs.has_azure == 'true' &&
+      (github.event_name == 'schedule' || github.event.inputs.route != 'smoke')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: api/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r api/requirements.txt
+
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          creds: |
+            {
+              "clientId": "${{ secrets.ARM_CLIENT_ID }}",
+              "clientSecret": "${{ secrets.ARM_CLIENT_SECRET }}",
+              "subscriptionId": "${{ secrets.ARM_SUBSCRIPTION_ID }}",
+              "tenantId": "${{ secrets.ARM_TENANT_ID }}"
+            }
+
+      - name: Get Database Connection String
+        id: db
+        run: |
+          DB_HOST=$(az postgres flexible-server list \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --query "[0].fullyQualifiedDomainName" -o tsv)
+          echo "db_host=$DB_HOST" >> "$GITHUB_OUTPUT"
+
+      - name: Run eval against prod (read-only)
+        id: run
+        env:
+          DB_USER: ${{ secrets.TF_VAR_DB_ADMIN_USERNAME }}
+          DB_PASS: ${{ secrets.TF_VAR_DB_ADMIN_PASSWORD }}
+          DB_HOST: ${{ steps.db.outputs.db_host }}
+          DB_NAME: ${{ secrets.TF_VAR_DB_NAME }}
+          EMBEDDING_PROVIDER: azure_openai
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_EMBEDDING_DEPLOYMENT: ${{ env.AZURE_EMBEDDING_DEPLOYMENT }}
+          HAS_LLM: ${{ needs.preflight.outputs.has_llm }}
+          OPENROUTER_API_KEY_IF_SET: ${{ secrets.TF_VAR_OPENROUTER_API_KEY }}
+          INPUT_CONFIGS: ${{ github.event.inputs.configs }}
+          INPUT_LANGUAGE: ${{ github.event.inputs.language }}
+        run: |
+          set -o pipefail
+          export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@${DB_HOST}:5432/${DB_NAME}?sslmode=require"
+
+          # Leave LLM_PROVIDER unset (rather than "") when no OpenRouter key is
+          # configured — Settings' llm_provider is a Literal type and an
+          # empty-string env value fails pydantic validation (crashing
+          # Settings() at import time) rather than being ignored.
+          if [ "$HAS_LLM" == "true" ]; then
+            export LLM_PROVIDER=openrouter
+            export OPENROUTER_API_KEY="$OPENROUTER_API_KEY_IF_SET"
+          fi
+
+          config_flag=()
+          if [ -n "$INPUT_CONFIGS" ]; then
+            config_flag=(--config "$INPUT_CONFIGS")
+          elif [ "$HAS_LLM" != "true" ]; then
+            # No LLM credentials and no manual override: stay on the semantic-
+            # only config so the run doesn't fail-open every expansion_semantic
+            # row as an error.
+            config_flag=(--config baseline_semantic)
+          fi
+
+          language_flag=()
+          if [ -n "$INPUT_LANGUAGE" ]; then
+            language_flag=(--language "$INPUT_LANGUAGE")
+          fi
+
+          set +e
+          python scripts/run_search_eval.py --run --json "${config_flag[@]}" "${language_flag[@]}" \
+            > eval-prod.json 2> eval-prod.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Summarize results
+        if: always()
+        run: |
+          {
+            echo "### eval-prod (Route A) results"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -s eval-prod.json ] && jq -e . eval-prod.json > /dev/null 2>&1; then
+            {
+              echo "| config | P@5 | R@10 | MRR | FP@5 | n | errors |"
+              echo "| --- | --- | --- | --- | --- | --- | --- |"
+            } >> "$GITHUB_STEP_SUMMARY"
+            jq -r '
+              .aggregates[] |
+              "| " + (.config|tostring) + " | " + (.precision_at_5|tostring) +
+              " | " + (.recall_at_10|tostring) + " | " + (.mrr|tostring) +
+              " | " + (.total_false_positives_at_5|tostring) + " | " + (.n|tostring) +
+              " | " + (.n_errors|tostring) + " |"
+            ' eval-prod.json >> "$GITHUB_STEP_SUMMARY" \
+              || echo "(could not render aggregates table)" >> "$GITHUB_STEP_SUMMARY"
+
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### Per-language" >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "| language | config | P@5 | R@10 | MRR | n |"
+              echo "| --- | --- | --- | --- | --- | --- |"
+            } >> "$GITHUB_STEP_SUMMARY"
+            jq -r '
+              .by_language | to_entries[] as $lang | $lang.value[] |
+              "| " + ($lang.key|tostring) + " | " + (.config|tostring) +
+              " | " + (.precision_at_5|tostring) + " | " + (.recall_at_10|tostring) +
+              " | " + (.mrr|tostring) + " | " + (.n|tostring) + " |"
+            ' eval-prod.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+
+            fp_total=$(jq '[.aggregates[].total_false_positives_at_5] | add // 0' eval-prod.json)
+            err_total=$(jq '[.aggregates[].n_errors] | add // 0' eval-prod.json)
+            if [ "$fp_total" != "0" ]; then
+              fp_msg="::warning::eval-prod: ${fp_total} false-positive hit(s) at k=5"
+              fp_msg="${fp_msg} — a query surfaced a verse flagged as irrelevant. Investigate."
+              echo "$fp_msg"
+            fi
+            if [ "$err_total" != "0" ]; then
+              err_msg="::warning::eval-prod: ${err_total} query error(s) — check eval-prod.log;"
+              err_msg="${err_msg} this can be a transient provider/rate-limit issue, not necessarily a regression."
+              echo "$err_msg"
+            fi
+          else
+            echo "No parseable JSON output — see eval-prod.log:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 40 eval-prod.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: search-eval-prod-${{ github.run_id }}
+          path: |
+            eval-prod.json
+            eval-prod.log
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Fail the job if the run itself failed
+        if: always() && steps.run.outputs.exit_code != '0'
+        run: |
+          exit_code="${{ steps.run.outputs.exit_code }}"
+          echo "::error::run_search_eval.py exited ${exit_code} — see eval-prod.log in the uploaded artifact."
+          exit 1
+
+  # ---------------------------------------------------------------------------
+  # eval-smoke — end-to-end plumbing proof against an ephemeral CI database.
+  # Never touches prod. Scores are expected to be ~0 (see header note).
+  # ---------------------------------------------------------------------------
+  eval-smoke:
+    name: eval-smoke
+    needs: preflight
+    if: >-
+      needs.preflight.outputs.has_azure == 'true' &&
+      (github.event_name == 'schedule' || github.event.inputs.route != 'prod')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: bible
+          POSTGRES_PASSWORD: bible123 # pragma: allowlist secret
+          POSTGRES_DB: bibledb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: api/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r api/requirements.txt
+
+      - name: Load 1 Corinthians (CI subset)
+        env:
+          DATABASE_URL: postgresql://bible:bible123@localhost:5432/bibledb # pragma: allowlist secret
+        run: |
+          cd scripts
+          python load_bible.py --ci --dimensions 1536
+
+      - name: Generate Azure embeddings for the loaded subset
+        env:
+          DATABASE_URL: postgresql://bible:bible123@localhost:5432/bibledb # pragma: allowlist secret
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_EMBEDDING_DEPLOYMENT: ${{ env.AZURE_EMBEDDING_DEPLOYMENT }}
+        run: |
+          cd scripts
+          python create_azure_embeddings.py
+
+      - name: Run smoke eval
+        id: run
+        env:
+          DATABASE_URL: postgresql://bible:bible123@localhost:5432/bibledb # pragma: allowlist secret
+          EMBEDDING_PROVIDER: azure_openai
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_EMBEDDING_DEPLOYMENT: ${{ env.AZURE_EMBEDDING_DEPLOYMENT }}
+        run: |
+          set -o pipefail
+          set +e
+          python scripts/run_search_eval.py --run --smoke --json > eval-smoke.json 2> eval-smoke.log
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Summarize results
+        if: always()
+        run: |
+          {
+            echo "### eval-smoke results"
+            echo ""
+            echo "Plumbing check only — the corpus is 1 Corinthians alone, so the"
+            echo "golden set's first 3 cases (Matthew/Philippians/Proverbs refs)"
+            echo "cannot match. P@5/R@10/MRR of 0.00 here is expected, not a"
+            echo "regression; a non-zero exit code is the real failure signal."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit_code="${{ steps.run.outputs.exit_code }}"
+          if [ -s eval-smoke.json ] && jq -e . eval-smoke.json > /dev/null 2>&1; then
+            echo "Smoke run produced parseable JSON output (exit ${exit_code})." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No parseable JSON output — see eval-smoke.log:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 40 eval-smoke.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload results artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: search-eval-smoke-${{ github.run_id }}
+          path: |
+            eval-smoke.json
+            eval-smoke.log
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Fail the job if the run itself failed
+        if: always() && steps.run.outputs.exit_code != '0'
+        run: |
+          exit_code="${{ steps.run.outputs.exit_code }}"
+          echo "::error::run_search_eval.py --smoke exited ${exit_code} — see eval-smoke.log artifact."
+          exit 1
+
+  # ---------------------------------------------------------------------------
+  # Consolidated summary — always runs, never blocks anything downstream
+  # (there is nothing downstream; this workflow gates no merge).
+  # ---------------------------------------------------------------------------
+  eval-summary:
+    name: Summary
+    needs: [preflight, eval-prod, eval-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write final summary
+        run: |
+          {
+            echo "## Search Eval — Full run summary"
+            echo ""
+            echo "| route | result |"
+            echo "| --- | --- |"
+            echo "| eval-prod (Route A) | ${{ needs.eval-prod.result }} |"
+            echo "| eval-smoke | ${{ needs.eval-smoke.result }} |"
+            echo ""
+            echo "Route B (\`eval-corpus\` — full 11-translation rebuild in a cached"
+            echo "pgvector, for a reproducible-corpus A/B independent of prod drift)"
+            echo "is **not implemented** — tracked as BITB-051 P4b."
+            echo ""
+            echo "Result artifacts (JSON + log) are attached to this run, retained 30 days."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/search-eval-full.yml
+++ b/.github/workflows/search-eval-full.yml
@@ -101,8 +101,8 @@ jobs:
         id: check
         env:
           HAS_ARM: >-
-            ${{ secrets.ARM_CLIENT_ID != '' && secrets.ARM_CLIENT_SECRET != '' &&
-            secrets.ARM_SUBSCRIPTION_ID != '' && secrets.ARM_TENANT_ID != '' }}
+            ${{ secrets.ARM_CLIENT_ID != '' && secrets.ARM_CLIENT_SECRET != '' && secrets.ARM_SUBSCRIPTION_ID != '' &&
+            secrets.ARM_TENANT_ID != '' }}
           HAS_DB: >-
             ${{ secrets.TF_VAR_DB_ADMIN_USERNAME != '' && secrets.TF_VAR_DB_ADMIN_PASSWORD != '' &&
             secrets.TF_VAR_DB_NAME != '' }}
@@ -142,10 +142,9 @@ jobs:
     name: eval-prod (Route A)
     needs: preflight
     if: >-
-      needs.preflight.outputs.has_arm == 'true' &&
-      needs.preflight.outputs.has_db == 'true' &&
-      needs.preflight.outputs.has_azure == 'true' &&
-      (github.event_name == 'schedule' || github.event.inputs.route != 'smoke')
+      needs.preflight.outputs.has_arm == 'true' && needs.preflight.outputs.has_db == 'true' &&
+      needs.preflight.outputs.has_azure == 'true' && (github.event_name == 'schedule' || github.event.inputs.route !=
+      'smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -310,8 +309,8 @@ jobs:
     name: eval-smoke
     needs: preflight
     if: >-
-      needs.preflight.outputs.has_azure == 'true' &&
-      (github.event_name == 'schedule' || github.event.inputs.route != 'prod')
+      needs.preflight.outputs.has_azure == 'true' && (github.event_name == 'schedule' || github.event.inputs.route !=
+      'prod')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -509,7 +509,7 @@ into **BITB-051**. Topic boosting is excluded here — blocked on data (BITB-044
 
 ### 🚧 BITB-051: Search Retrieval-Evaluation Harness (golden set + scorer)
 
-**Status:** 🚧 In Progress (P0–P3 landed; P4 todo)
+**Status:** 🚧 In Progress (P0–P3 + P4a landed; P4b todo)
 **Size:** L (3-5 days, 5 small PRs)
 **Created:** 2026-06-16
 
@@ -519,12 +519,14 @@ that** I can validate whether query expansion / hybrid search actually help and 
 their weights instead of shipping search changes blind.
 
 **Why P1:** Directly unblocks BITB-043 validation — expansion is live but unmeasured.
-Delivered in 5 phases: **P0** trim PR #727 to the hybrid flip ✅; **P1** metric +
+Delivered in phases: **P0** trim PR #727 to the hybrid flip ✅; **P1** metric +
 normalization core (`api/search_eval/`) ✅; **P2** 55+ case golden set (all 11
 languages) + `--validate` + non-blocking CI ✅; **P3** runner over real retrieval + A/B
-report/CLI ✅; **P4** full-corpus eval automated in CI (prod read-only + cached rebuild,
-Azure embeddings, manual + nightly) — todo. Embeddings are **Azure `text-embedding-3-small`
-(1536) everywhere** to match prod; per-PR CI is validate-only.
+report/CLI ✅; **P4a** `eval-prod` (prod read-only, no new secret) + `eval-smoke`
+automated in CI (manual + nightly) ✅; **P4b** `eval-corpus` full-corpus cached
+rebuild (Route B) — deferred, todo (see story file for why). Embeddings are
+**Azure `text-embedding-3-small` (1536) everywhere** to match prod; per-PR CI is
+validate-only.
 
 **Acceptance Criteria (summary — full story has detail):**
 
@@ -532,7 +534,8 @@ Azure embeddings, manual + nightly) — todo. Embeddings are **Azure `text-embed
 - [x] P1: `api/search_eval/` core (normalize + P@5/R@10/MRR + false-positive guard) with no-DB tests
 - [x] P2: 55+ multilingual golden set (11 languages) + loader + `--validate` + non-blocking CI
 - [x] P3: runner (`api/search_eval/runner.py`) + report/CLI (`--run`); manual prod-read-only A/B table documented in `docs/SEARCH_EVAL_HOWTO.md`
-- [ ] P4: manual + nightly full-corpus eval (Routes A & B + smoke) on Azure
+- [x] P4a: `eval-prod` + `eval-smoke` automated in CI (manual + nightly, `.github/workflows/search-eval-full.yml`)
+- [ ] P4b: `eval-corpus` full-corpus rebuild (Route B) — deferred
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-051-search-retrieval-eval-harness.md`
 

--- a/docs/BACKLOG_STORIES/BITB-051-search-retrieval-eval-harness.md
+++ b/docs/BACKLOG_STORIES/BITB-051-search-retrieval-eval-harness.md
@@ -1,6 +1,6 @@
 # BITB-051: Search Retrieval-Evaluation Harness (golden set + scorer)
 
-**Status:** 🚧 In Progress (P0–P3 landed; P4 todo)
+**Status:** 🚧 In Progress (P0–P3 + P4a landed; P4b todo)
 **Priority:** P1 (High) — without it we cannot tell whether the now-enabled query
 expansion / hybrid search actually improve retrieval
 **Size:** L (3–5 days, delivered in 5 small PRs)
@@ -135,21 +135,53 @@ blocking `backend-tests` job.
   an unreachable DB was confirmed to fail-open per query yet still exit non-zero with
   a clear message (no traceback), and `--config`/`--language`/`--json` were exercised.
 
-### P4 — Full-corpus eval automated in CI (Routes A + B; manual + nightly) (todo)
+### P4a — `eval-prod` + `eval-smoke` automated in CI (manual + nightly) ✅ (landed)
 
-New `.github/workflows/search-eval-full.yml` (`workflow_dispatch` + nightly
-`schedule`), Azure embeddings, results as job summary + uploaded artifact, non-gating:
+`.github/workflows/search-eval-full.yml` (`workflow_dispatch` + nightly `schedule`
+at 04:23 UTC), Azure embeddings, results as job summary + uploaded artifact,
+non-gating (no `pull_request` trigger; nothing in `test_update.yml` depends on it):
 
-- **Route A (`eval-prod`):** `DATABASE_URL` from `PROD_DATABASE_URL` secret (read-only);
-  embed queries with Azure; retrieve from prod's vectors. True prod numbers, no rebuild.
-- **Route B (`eval-corpus`):** load all 11 translations + Azure-embed into pgvector,
-  cached via `actions/cache` (key = translations + model + script versions); full A/B.
-- **`eval-smoke`:** load 1 Corinthians + Azure-embed (~440 verses, cents); fast
-  end-to-end plumbing proof (replaces the old Ollama smoke).
-- Secrets: the read-only `PROD_DATABASE_URL` plus the `AZURE_OPENAI_*` endpoint /
-  key / deployment credentials; jobs no-op with a clear notice if absent.
-- **Done when:** dispatch produces an artifact + summary with the full-corpus A/B table
-  (Routes A + B + smoke); nightly runs unattended; per-PR CI unchanged.
+- **Route A (`eval-prod`):** no new secret — reuses the exact ARM-login +
+  `az postgres flexible-server list` + `TF_VAR_DB_ADMIN_*`/`TF_VAR_DB_NAME` pattern
+  `azure-deploy.yml` already uses for migrations/seeding, read-only, to build
+  `DATABASE_URL`; embeds queries with Azure; retrieves from prod's real vectors.
+  True prod numbers, no rebuild, zero writes. Falls back to `baseline_semantic`
+  only (skips the expansion leg) when no OpenRouter key is configured, so a
+  missing LLM credential doesn't show up as a wave of `n_errors`.
+- **`eval-smoke`:** loads 1 Corinthians into an ephemeral CI Postgres + Azure-embeds
+  it (~440 verses, cents), then runs `--run --smoke`; fast end-to-end plumbing
+  proof, never touches prod. Scores are expected to be ~0 (the golden set's first
+  3 cases aren't in 1 Corinthians) — documented as a plumbing check, not a
+  relevance measurement.
+- Preflight job reads secret/var presence into step outputs (the `secrets`
+  context isn't usable in a job-level `if:`) and gates each route independently;
+  missing config ⇒ job **skipped** with a `::notice::`, never failed.
+- **Done when:** manual `workflow_dispatch` produces an artifact + job-summary
+  table for both routes; nightly schedule runs unattended; per-PR CI unchanged.
+
+### P4b — `eval-corpus` full-corpus rebuild (Route B) (todo)
+
+Load all 11 translations + Azure-embed into pgvector, cached via `actions/cache`
+(key = translations + model + script versions), for a reproducible-corpus A/B
+that doesn't drift with prod's live data. **Deliberately not built alongside
+P4a** — the two are independent and P4a already delivers the story's headline
+("true prod numbers"). Reasons to keep this its own phase rather than land it
+blind on the first unattended run:
+
+- **Cache-eviction risk.** 11 translations ≈ ~340k verses × 1536 float4 ≈ ~2 GB
+  of vector data before index overhead. GitHub's per-repo Actions cache is 10 GB
+  and globally LRU-evicted — a nightly 2 GB cache could evict the `pip`/`gradle`/
+  `node` caches `test_update.yml` and the Android workflows depend on, which
+  would be an unrelated, non-obvious regression to per-PR CI.
+- **Unbounded first-run duration.** No existing evidence of full-corpus
+  embedding timing under a *cold* cache (the closest analog, `azure-deploy.yml`'s
+  `seed-database-post`, is normally incremental with almost nothing to do).
+- **New correctness surface with no test coverage yet:** cache-key design,
+  partial-cache poisoning (a half-embedded corpus restoring as "valid" and
+  silently scoring low), embedding-dimension drift.
+
+Track separately when picked up; `eval-prod` + `eval-smoke` already cover the
+"is the harness actually wired to real embeddings" need in the meantime.
 
 ## Acceptance Criteria
 
@@ -161,21 +193,23 @@ New `.github/workflows/search-eval-full.yml` (`workflow_dispatch` + nightly
 - [x] P3: runner over real retrieval + report/CLI; manual prod-read-only A/B table
       documented in `docs/SEARCH_EVAL_HOWTO.md` (not exercised against real prod
       data in this sandbox — no DB/Azure credentials available).
-- [ ] P4: manual + nightly full-corpus eval (Routes A & B + smoke) on Azure.
+- [x] P4a: manual + nightly `eval-prod` + `eval-smoke` on Azure
+      (`.github/workflows/search-eval-full.yml`).
+- [ ] P4b: `eval-corpus` full-corpus rebuild (Route B) — deferred, see above.
 - [ ] Retrospective once expansion/hybrid validated against the set (feeds BITB-043).
 
 ## Files / Config
 
 | Item | Location |
 |---|---|
-| Harness package | `api/search_eval/` (`normalize.py`, `metrics.py`, `models.py`, `loader.py`*, `runner.py`*, `report.py`*) |
-| Golden set | `api/search_eval/data/retrieval_golden_set.json`* |
-| CLI | `scripts/run_search_eval.py`* |
-| Tests | `api/tests/test_search_eval_metrics.py`, `…_dataset.py`* |
-| CI | `.github/workflows/test_update.yml` (validate)*, `search-eval-full.yml`* |
+| Harness package | `api/search_eval/` (`normalize.py`, `metrics.py`, `models.py`, `loader.py`, `runner.py`, `report.py`) |
+| Golden set | `api/search_eval/data/retrieval_golden_set.json` |
+| CLI | `scripts/run_search_eval.py` |
+| Tests | `api/tests/test_search_eval_metrics.py`, `…_dataset.py` |
+| CI | `.github/workflows/test_update.yml` (validate, per-PR), `search-eval-full.yml` (`eval-prod` + `eval-smoke`, manual + nightly) |
 | Reused utils | `utils/book_names.py`, `scripture/search.py`, `providers/factory.py`, `scripture/database.py` |
 
-Note: items marked with `*` above are future phases (P2–P4).
+Note: P4b (`eval-corpus` / Route B) is the only remaining unshipped item.
 
 ## Related
 

--- a/docs/SEARCH_EVAL_HOWTO.md
+++ b/docs/SEARCH_EVAL_HOWTO.md
@@ -94,6 +94,36 @@ DATABASE_URL=<prod-read-only-url> EMBEDDING_PROVIDER=azure_openai \
 and gets the expansion OFF-vs-ON A/B table with a per-language breakdown.
 This cannot be exercised inside a sandboxed dev environment with no prod DB
 or Azure credentials — the harness's *code* is tested against injected fakes
-(see `api/tests/test_search_eval_runner.py`); the *live* A/B numbers are a
-manual maintainer step (above) until **P4** automates a nightly/manual CI
-run against Azure.
+(see `api/tests/test_search_eval_runner.py`); the *live* A/B numbers are
+produced automatically by the CI workflow below (**P4a**).
+
+## Running it in CI (P4a)
+
+`.github/workflows/search-eval-full.yml` runs this harness for real, on a
+schedule and on demand — no maintainer machine required:
+
+- **`eval-prod`** — read-only against the production database (DB connection
+  built the same way `azure-deploy.yml` does for migrations/seeding — no new
+  DB secret), Azure-embeds the golden set's queries, and retrieves from prod's
+  real vectors. True prod numbers, no rebuild, no writes.
+- **`eval-smoke`** — loads 1 Corinthians into an ephemeral CI Postgres,
+  Azure-embeds it, and runs `--run --smoke`. Proves the CLI/Azure plumbing
+  end-to-end without touching prod. Its P@5/R@10/MRR are expected to be
+  **~0** — the golden set's first 3 cases live in Matthew/Philippians/Proverbs,
+  not 1 Corinthians — so a non-zero *exit code* is the failure signal here,
+  not the metric values.
+
+Both routes run nightly (04:23 UTC) and via **Actions → Search Eval — Full →
+Run workflow** (`route: both | prod | smoke`, optional `configs` / `language`
+inputs). Results land as a `$GITHUB_STEP_SUMMARY` table and as a downloadable
+JSON+log artifact (30-day retention). Missing secrets/vars make the affected
+job skip with a `::notice::` rather than fail — this workflow never runs on
+`pull_request` and never gates a merge.
+
+**Not yet built:** a third route (`eval-corpus`, tracked as **P4b**) that
+rebuilds all 11 translations from scratch into a cached pgvector instance, for
+a reproducible-corpus A/B that doesn't drift with prod's live data. Deferred
+deliberately — see the "P4b" section of
+`docs/BACKLOG_STORIES/BITB-051-search-retrieval-eval-harness.md` for why.
+Until it lands, `eval-prod` is the only source of real A/B numbers, and its
+per-language scores still carry the versification caveat above.


### PR DESCRIPTION
## What

Implements **BITB-051 P4a** — the last unshipped piece of the search retrieval-eval harness (P0–P3 already merged; the harness code, golden set, CLI, and docs all already exist and work, they just never ran against real embeddings anywhere).

- **New `.github/workflows/search-eval-full.yml`** (`workflow_dispatch` + nightly `schedule` at 04:23 UTC; **no `pull_request` trigger** — never gates a merge):
  - **`eval-prod` (Route A):** read-only against the real production database. Reuses `azure-deploy.yml`'s existing ARM-login → `az postgres flexible-server list` → `TF_VAR_DB_ADMIN_*`/`TF_VAR_DB_NAME` pattern to build `DATABASE_URL` — **no new secret introduced**. Embeds the golden set's ~58 queries with Azure OpenAI, retrieves from prod's real vectors, writes nothing. Falls back to `--config baseline_semantic` when no OpenRouter key is configured, so a missing LLM credential shows up as a clear notice rather than a wave of `n_errors`.
  - **`eval-smoke`:** loads 1 Corinthians into an ephemeral CI Postgres, Azure-embeds it (~440 verses, cents), and runs `--run --smoke`. Proves the CLI/Azure plumbing end-to-end without ever touching prod. P@5/R@10/MRR are expected to be **~0** here (the golden set's first 3 cases live in Matthew/Philippians/Proverbs, not 1 Corinthians) — documented in the summary and HOWTO so the first nightly run doesn't read as a regression.
  - A `preflight` job reads secret/var presence into step outputs (the `secrets` context isn't usable in a job-level `if:`) and gates each route independently — a missing secret **skips** the job with a `::notice::`, it never fails red.
  - Results land as a `$GITHUB_STEP_SUMMARY` table (aggregate + per-language + false-positive/error warnings) and as an uploaded JSON+log artifact (30-day retention).
- **`docs/BACKLOG_STORIES/BITB-051-search-retrieval-eval-harness.md`**, **`docs/BACKLOG.md`**, **`docs/SEARCH_EVAL_HOWTO.md`** — split P4 into P4a (this PR, done) and P4b (deferred, see below); corrected the stale `PROD_DATABASE_URL`-secret description to the actual ARM-login pattern used.

### Scope decision: Route B (`eval-corpus`) deferred as BITB-051 P4b

The story's original P4 scope also included a full 11-translation rebuild into a cached pgvector instance, for a reproducible-corpus A/B independent of prod drift. Deliberately **not** built in this PR:

- **Cache-eviction risk:** 11 translations ≈ ~340k verses × 1536 float4 ≈ ~2 GB of vector data. GitHub's per-repo Actions cache is 10 GB and globally LRU-evicted — a nightly 2 GB cache could evict the `pip`/`gradle`/`node` caches `test_update.yml` and the Android workflows depend on, which would be a non-obvious regression to unrelated per-PR CI.
- **Unbounded first-run duration** under a cold cache, with no existing timing evidence.
- **New correctness surface with no test coverage yet:** cache-key design, partial-cache poisoning, embedding-dimension drift.

`eval-prod` already delivers the story's headline ("true prod numbers"); Route B is reproducibility on top of that, worth its own phase rather than coupling to the first unattended nightly run.

## Risks worth a maintainer's attention

- **New automated read path into the production database.** Nothing writes, but this holds prod admin credentials (`TF_VAR_DB_ADMIN_*` — there's no separate read-only DB role today; "read-only" is enforced by the harness's own behavior, not by grants).
- **Small recurring Azure OpenAI cost.** ~58 query embeddings nightly (Route A) + re-embedding 1 Corinthians nightly (smoke) on `text-embedding-3-small` — fractions of a cent, but a new *perpetual* charge.
- **OpenRouter free-tier rate limits** would show up as `n_errors` on the `expansion_semantic` row; mitigated with a `::warning::` when `n_errors > 0` so it isn't misread as a quality regression.
- A genuine harness failure is left **red** (not `continue-on-error`) since this is the only signal that exists for an unattended job — happy to add `continue-on-error` if a maintainer would rather have silence over noise.

## Test plan

- [x] New workflow YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/search-eval-full.yml'))"` parses; `yamllint --strict` with this repo's exact ruleset (line-length 120, etc.) is clean.
- [x] Hand-verified the `jq` summary filters against a synthetic `run_search_eval.py --json` payload matching `report.to_json()`'s shape (aggregates + by_language) — renders correctly.
- [x] Verified in `api/config.py`/`api/scripture/database.py` that every env var name used (`EMBEDDING_PROVIDER`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_EMBEDDING_DEPLOYMENT`, `LLM_PROVIDER`, `OPENROUTER_API_KEY`) matches a real `Settings` field, and that `postgresql://...?sslmode=require` is the correct URL form (`get_async_database_url()` strips `sslmode` and rebuilds for asyncpg itself).
- [x] Caught and fixed a real bug during review: setting `LLM_PROVIDER=""` (rather than leaving it unset) crashes `Settings()` at import time, because `llm_provider` is a `Literal` type that rejects an empty string — confirmed with a local pydantic-settings repro. The workflow now only exports `LLM_PROVIDER` when an OpenRouter key is actually present.
- [ ] Could not run `python scripts/run_search_eval.py --validate` or install `api/requirements.txt` in this sandbox (Python 3.11 here vs. the repo's Python 3.12 requirement; `lingua-language-detector==2.2.0` needs `>=3.12`) — this is a pre-existing sandbox/version mismatch unrelated to this change, not a regression. CI's `backend-tests` / `search-eval-validate` jobs (unchanged by this PR) cover it.
- [ ] The first real exercise should be a manual `workflow_dispatch` with `route=smoke` (no prod contact) before letting the nightly schedule touch `eval-prod` — recommend doing that once this merges.

## Notes

- No changes to `api/`, `scripts/`, or `test_update.yml` — the harness itself was already complete; this PR only wires up its already-documented CI automation.
- `docs/SEARCH_EVAL_HOWTO.md` gained a "Running it in CI (P4a)" section describing how to dispatch and read results.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CHyNf5B56UDwHQdVEYZfjY)_