### PR TITLE
fix(dev): restore local database initialization (BITB-092)

### DIFF
--- a/api/tests/test_docker_compose_bible_cache.py
+++ b/api/tests/test_docker_compose_bible_cache.py
@@ -1,0 +1,91 @@
+"""
+Regression tests for the db-init data bind-mount / BIBLE_DOWNLOAD_CACHE_DIR contract shared by
+docker-compose.yml (main local stack) and docker-compose.dev.yml (second dev stack).
+
+These tests parse the compose files directly with PyYAML and assert on structure. They never
+invoke Docker/`docker compose`, so they run in any environment (CI, local, sandboxed) without a
+Docker daemon.
+
+Context (BITB-092 follow-up): db-init runs as a non-root container user (UID 1000, see
+api/Dockerfile) while the host-owned `./data` bind mount can be owned by a different host UID
+(observed: 1002). When `data/bible/translations/kjv.json` doesn't exist yet,
+`scripts/load_bible.py` downloaded KJV successfully but then crashed with a PermissionError trying
+to write the result back into `./data`, which db-init doesn't own.
+
+The fix: mount `./data` read-only in both compose files (the committed
+`data/bible/translations/*.json` files, including manual-only Hindi/Luther data with no download
+URL, are read-only source data and never need to be written by db-init) and set
+`BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations` so first-run downloads land in a writable
+location instead (see `scripts/load_bible.py`'s `resolve_bible_data_path()`).
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+COMPOSE_FILES = ["docker-compose.yml", "docker-compose.dev.yml"]
+
+EXPECTED_CACHE_DIR = str(Path(tempfile.gettempdir()) / "bible-translations")
+
+
+def _load_compose(filename: str) -> dict:
+    with open(REPO_ROOT / filename, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _env_list_to_dict(env_list):
+    """Convert a compose `environment: [KEY=VALUE, ...]` list to a dict."""
+    result = {}
+    for entry in env_list:
+        key, _, value = entry.partition("=")
+        result[key] = value
+    return result
+
+
+@pytest.mark.parametrize("compose_file", COMPOSE_FILES)
+def test_db_init_data_mount_is_read_only(compose_file):
+    """db-init must mount ./data read-only; it never needs write access to committed source data.
+
+    db-init runs as UID 1000 (api/Dockerfile) which does not necessarily own the host-owned
+    ./data bind mount, so a writable mount risks a PermissionError the moment a translation
+    needs downloading (e.g. first-run KJV). Downloads go to BIBLE_DOWNLOAD_CACHE_DIR instead.
+    """
+    compose_config = _load_compose(compose_file)
+    db_init_volumes = compose_config["services"]["db-init"]["volumes"]
+
+    assert "./data:/data:ro" in db_init_volumes, (
+        f"{compose_file}'s db-init must mount './data:/data:ro' (read-only) — found volumes: "
+        f"{db_init_volumes!r}"
+    )
+    assert (
+        "./data:/data" not in db_init_volumes
+    ), f"{compose_file}'s db-init must not also mount './data:/data' read-write"
+
+
+@pytest.mark.parametrize("compose_file", COMPOSE_FILES)
+def test_db_init_configures_bible_download_cache_dir(compose_file):
+    """db-init must set BIBLE_DOWNLOAD_CACHE_DIR so downloads avoid the read-only ./data mount."""
+    compose_config = _load_compose(compose_file)
+    db_init_env = _env_list_to_dict(compose_config["services"]["db-init"]["environment"])
+
+    assert "BIBLE_DOWNLOAD_CACHE_DIR" in db_init_env, (
+        f"{compose_file}'s db-init is missing BIBLE_DOWNLOAD_CACHE_DIR, required now that "
+        "./data is mounted read-only"
+    )
+    assert db_init_env["BIBLE_DOWNLOAD_CACHE_DIR"] == EXPECTED_CACHE_DIR, (
+        f"{compose_file}'s db-init BIBLE_DOWNLOAD_CACHE_DIR drifted: expected "
+        f"{EXPECTED_CACHE_DIR!r}, got {db_init_env['BIBLE_DOWNLOAD_CACHE_DIR']!r}"
+    )
+
+
+@pytest.mark.parametrize("compose_file", COMPOSE_FILES)
+def test_db_init_still_mounts_api_read_only(compose_file):
+    """Sanity check: the pre-existing ./api:/api:ro contract (BITB-092) must remain intact."""
+    compose_config = _load_compose(compose_file)
+    db_init_volumes = compose_config["services"]["db-init"]["volumes"]
+
+    assert "./api:/api:ro" in db_init_volumes

--- a/api/tests/test_docker_compose_dev.py
+++ b/api/tests/test_docker_compose_dev.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for docker-compose.dev.yml's db-init/api contract.
+
+These tests parse the compose file directly with PyYAML and assert on its
+structure. They never invoke Docker/`docker compose` and therefore run in
+any environment (CI, local, sandboxed) without a Docker daemon.
+
+Context (BITB-092): `make docker-up-dev` starts db-init, which runs
+scripts/migrations/run_migrations.py. That script resolves its `api/`
+package two directories up from its own file (../../api), matching the
+layout the main stack's docker-compose.yml exposes via `./api:/api:ro`.
+docker-compose.dev.yml lacked that mount, so db-init's migration step
+crashed with `ModuleNotFoundError: config`. Separately, the dev stack's
+EMBEDDING_PROVIDER/EMBEDDING_DIMENSIONS env vars were missing or
+inconsistent between the api and db-init services, causing embedding
+model/dimension drift versus the main local stack (docker-compose.yml).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+COMPOSE_PATH = Path(__file__).resolve().parent.parent.parent / "docker-compose.dev.yml"
+
+EXPECTED_EMBEDDING_ENV = {
+    "EMBEDDING_PROVIDER": "${EMBEDDING_PROVIDER:-ollama}",
+    "EMBEDDING_MODEL": "${EMBEDDING_MODEL:-mxbai-embed-large}",
+    "EMBEDDING_DIMENSIONS": "${EMBEDDING_DIMENSIONS:-1024}",
+}
+
+
+@pytest.fixture(scope="module")
+def compose_config():
+    """Load docker-compose.dev.yml with PyYAML (no Docker daemon needed)."""
+    with open(COMPOSE_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _env_list_to_dict(env_list):
+    """Convert a compose `environment: [KEY=VALUE, ...]` list to a dict."""
+    result = {}
+    for entry in env_list:
+        key, _, value = entry.partition("=")
+        result[key] = value
+    return result
+
+
+def test_db_init_mounts_api_read_only(compose_config):
+    """db-init must mount ./api at /api read-only, same contract as prod.
+
+    run_migrations.py resolves ../../api relative to its own path inside
+    /scripts, so /api must exist read-only in the container for the
+    migration step to import config.py successfully.
+    """
+    db_init_volumes = compose_config["services"]["db-init"]["volumes"]
+    assert "./api:/api:ro" in db_init_volumes, (
+        "db-init is missing the './api:/api:ro' mount that "
+        "run_migrations.py needs to import api/config.py "
+        "(see docker-compose.yml's db-init service for the reference contract)"
+    )
+
+
+def test_db_init_embedding_env_matches_main_stack(compose_config):
+    """db-init must carry the same embedding provider/model/dimensions defaults."""
+    db_init_env = _env_list_to_dict(compose_config["services"]["db-init"]["environment"])
+
+    for key, expected_value in EXPECTED_EMBEDDING_ENV.items():
+        assert key in db_init_env, f"db-init environment is missing {key}"
+        assert db_init_env[key] == expected_value, (
+            f"db-init {key} default drifted: expected {expected_value!r}, "
+            f"got {db_init_env[key]!r}"
+        )
+
+
+def test_api_embedding_env_matches_main_stack(compose_config):
+    """api must carry the same embedding provider/model/dimensions defaults."""
+    api_env = _env_list_to_dict(compose_config["services"]["api"]["environment"])
+
+    for key, expected_value in EXPECTED_EMBEDDING_ENV.items():
+        assert key in api_env, f"api environment is missing {key}"
+        assert api_env[key] == expected_value, (
+            f"api {key} default drifted: expected {expected_value!r}, " f"got {api_env[key]!r}"
+        )
+
+
+def test_db_init_and_api_embedding_env_are_identical(compose_config):
+    """api and db-init must never disagree on embedding provider/model/dimensions."""
+    api_env = _env_list_to_dict(compose_config["services"]["api"]["environment"])
+    db_init_env = _env_list_to_dict(compose_config["services"]["db-init"]["environment"])
+
+    for key in EXPECTED_EMBEDDING_ENV:
+        assert api_env.get(key) == db_init_env.get(key), (
+            f"api and db-init disagree on {key}: "
+            f"api={api_env.get(key)!r} db-init={db_init_env.get(key)!r}"
+        )

--- a/api/tests/test_load_bible_data_path.py
+++ b/api/tests/test_load_bible_data_path.py
@@ -1,0 +1,95 @@
+"""
+Tests for scripts/load_bible.py's Bible translation JSON path resolution.
+
+Context (BITB-092 follow-up): db-init runs as a non-root container user (UID 1000) while the
+host-owned `./data` bind mount is UID 1002. When `data/bible/translations/kjv.json` doesn't exist
+yet, `scripts/load_bible.py` downloaded KJV successfully but then crashed with a `PermissionError`
+trying to write the result into the read-write-but-not-writable-by-this-uid bind mount.
+
+The fix mounts `./data` read-only in both compose files and introduces `BIBLE_DOWNLOAD_CACHE_DIR`,
+an explicit opt-in env var pointing downloads at a writable cache directory instead. The committed
+`data/bible/translations/*.json` source files (including manual-only Hindi/Luther data with no
+download URL) always remain the primary read source when present.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+# Add scripts directory to path (mirrors api/tests/test_translations.py's import pattern)
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+
+from load_bible import download_translation, resolve_bible_data_path
+
+
+def test_resolve_prefers_existing_primary_path_even_with_cache_configured(tmp_path, monkeypatch):
+    """The committed source file always wins when it exists, cache configured or not.
+
+    This is what keeps manual-only translations (Hindi, Luther 1912) working: they have no
+    download URL, so their only data source is the committed file.
+    """
+    primary = tmp_path / "primary" / "kjv.json"
+    primary.parent.mkdir(parents=True)
+    primary.write_text("[]", encoding="utf-8")
+
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("BIBLE_DOWNLOAD_CACHE_DIR", str(cache_dir))
+
+    resolved = resolve_bible_data_path("kjv", primary)
+
+    assert resolved == primary
+
+
+def test_resolve_uses_configured_cache_when_primary_missing(tmp_path, monkeypatch):
+    """A missing source file with BIBLE_DOWNLOAD_CACHE_DIR set writes to the cache instead."""
+    primary = tmp_path / "primary" / "kjv.json"  # never created
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("BIBLE_DOWNLOAD_CACHE_DIR", str(cache_dir))
+
+    resolved = resolve_bible_data_path("kjv", primary)
+
+    assert resolved == cache_dir / "kjv.json"
+
+
+def test_resolve_falls_back_to_primary_path_without_cache_configured(tmp_path, monkeypatch):
+    """Unset BIBLE_DOWNLOAD_CACHE_DIR preserves the historical bare-host default path/behavior."""
+    primary = tmp_path / "primary" / "kjv.json"  # never created
+    monkeypatch.delenv("BIBLE_DOWNLOAD_CACHE_DIR", raising=False)
+
+    resolved = resolve_bible_data_path("kjv", primary)
+
+    assert resolved == primary
+
+
+@pytest.mark.asyncio
+async def test_download_translation_writes_to_resolved_writable_path(tmp_path, monkeypatch):
+    """Downloading a missing translation writes into BIBLE_DOWNLOAD_CACHE_DIR, not the (here,
+    intentionally non-writable-by-design) primary directory, and never touches the network.
+    """
+    primary = tmp_path / "primary" / "kjv.json"  # never created; parent dir also absent
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("BIBLE_DOWNLOAD_CACHE_DIR", str(cache_dir))
+
+    resolved_path = resolve_bible_data_path("kjv", primary)
+    assert resolved_path == cache_dir / "kjv.json"
+
+    fake_payload = [{"name": "Genesis", "chapters": [["In the beginning..."]]}]
+    mock_response = httpx.Response(
+        status_code=200,
+        json=fake_payload,
+        request=httpx.Request("GET", "https://example.invalid/kjv.json"),
+    )
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        data = await download_translation("kjv", resolved_path)
+
+    assert data == fake_payload
+    assert resolved_path.exists(), "download_translation must write into the resolved cache path"
+    assert json.loads(resolved_path.read_text(encoding="utf-8")) == fake_payload
+    # The primary (source-of-truth) directory must never have been created/written to.
+    assert not primary.exists()
+    assert not primary.parent.exists()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -90,6 +90,9 @@ services:
       - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-ollama}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-mxbai-embed-large}
       - EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}
+      # db-init runs as a non-root container user (UID 1000) while ./data is host-owned; mounting
+      # it read-only (below) means a missing translation download must land somewhere writable.
+      - BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations
     depends_on:
       postgres:
         condition: service_healthy
@@ -97,7 +100,12 @@ services:
         condition: service_started
     volumes:
       - ./scripts:/scripts
-      - ./data:/data
+      # Read-only: committed translations (data/bible/translations/*.json) are the source of
+      # truth, including manual-only Hindi/Luther data with no download URL. db-init runs as a
+      # non-root UID that doesn't own the host-owned bind mount, so this must stay read-only;
+      # first-run downloads (e.g. KJV) are written to BIBLE_DOWNLOAD_CACHE_DIR instead (see
+      # scripts/load_bible.py's resolve_bible_data_path()).
+      - ./data:/data:ro
       # Read-only: run_migrations.py resolves ../../api relative to its own
       # path (matching the layout azure-deploy.yml's run-migrations job sees
       # from a full checkout), so it needs api/ visible at /api here.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,6 +32,7 @@ services:
       - DATABASE_URL=postgresql://bible:bible123@postgres:5432/bibledb
       - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-ollama}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-mxbai-embed-large}
+      - EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}
     depends_on:
       postgres:
         condition: service_healthy
@@ -86,7 +87,9 @@ services:
     environment:
       - DATABASE_URL=postgresql+asyncpg://bible:bible123@postgres:5432/bibledb
       - OLLAMA_HOST=http://ollama:11434
+      - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-ollama}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-mxbai-embed-large}
+      - EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}
     depends_on:
       postgres:
         condition: service_healthy
@@ -95,6 +98,10 @@ services:
     volumes:
       - ./scripts:/scripts
       - ./data:/data
+      # Read-only: run_migrations.py resolves ../../api relative to its own
+      # path (matching the layout azure-deploy.yml's run-migrations job sees
+      # from a full checkout), so it needs api/ visible at /api here.
+      - ./api:/api:ro
     working_dir: /scripts
     entrypoint: ["/bin/bash", "/scripts/init-db.sh"]
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,9 @@ services:
       - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-ollama}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-mxbai-embed-large}
       - EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}
+      # db-init runs as a non-root container user (UID 1000) while ./data is host-owned; mounting
+      # it read-only (below) means a missing translation download must land somewhere writable.
+      - BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations
     depends_on:
       postgres:
         condition: service_healthy
@@ -87,7 +90,12 @@ services:
         condition: service_started
     volumes:
       - ./scripts:/scripts
-      - ./data:/data
+      # Read-only: committed translations (data/bible/translations/*.json) are the source of
+      # truth, including manual-only Hindi/Luther data with no download URL. db-init runs as a
+      # non-root UID that doesn't own the host-owned bind mount, so this must stay read-only;
+      # first-run downloads (e.g. KJV) are written to BIBLE_DOWNLOAD_CACHE_DIR instead (see
+      # scripts/load_bible.py's resolve_bible_data_path()).
+      - ./data:/data:ro
       # Read-only: run_migrations.py resolves ../../api relative to its own
       # path (matching the layout azure-deploy.yml's run-migrations job sees
       # from a full checkout), so it needs api/ visible at /api here.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1368,6 +1368,14 @@ relative to itself), so migrations crashed with `ModuleNotFoundError: config`. S
 was missing `EMBEDDING_DIMENSIONS` and `db-init` was missing `EMBEDDING_PROVIDER` /
 `EMBEDDING_DIMENSIONS`, causing embedding config drift versus the main stack.
 
+**Follow-up (same day):** `db-init` runs as non-root UID 1000 while the host-owned `./data` bind
+mount can be a different host UID, so `scripts/load_bible.py` downloaded KJV successfully but then
+crashed with a `PermissionError` writing it back into `./data`. Fixed by mounting `./data:/data:ro`
+in both compose files and adding an optional `BIBLE_DOWNLOAD_CACHE_DIR` env var
+(`scripts/load_bible.py`'s `resolve_bible_data_path()`) that redirects first-run downloads to a
+writable container path (`/tmp/bible-translations`) while committed source files (including
+manual-only Hindi/Luther data) still always win when present.
+
 **Acceptance Criteria (summary):**
 
 - [x] `db-init` mounts `./api:/api:ro`, matching `docker-compose.yml`'s reference contract
@@ -1375,6 +1383,14 @@ was missing `EMBEDDING_DIMENSIONS` and `db-init` was missing `EMBEDDING_PROVIDER
       `EMBEDDING_DIMENSIONS` defaults (`ollama` / `mxbai-embed-large` / `1024`)
 - [x] Regression test in `api/tests/test_docker_compose_dev.py`, collected by the standard API suite
 - [x] No production files changed
+- [x] `db-init` mounts `./data:/data:ro` (read-only) in both `docker-compose.yml` and
+      `docker-compose.dev.yml`, and sets `BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations`, so a
+      fresh `docker-up`/`docker-up-dev` can download KJV without a host-UID-mismatch
+      `PermissionError`, with no chmod/chown/root workaround
+- [x] Committed manual-only translations (Hindi, Luther 1912) remain loadable from the read-only
+      primary path unchanged
+- [x] Regression tests in `api/tests/test_load_bible_data_path.py` and
+      `api/tests/test_docker_compose_bible_cache.py`
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-092-fix-dev-db-initialization.md`
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Prioritized list of user stories and features for Vox Quieta.
 
-**Last Updated:** 2026-07-30
+**Last Updated:** 2026-08-09
 
 **Verification Note (2026-04-20):** PR status reconciliation pass completed against GitHub.
 Confirmed merged PRs: #68, #171, #182, #191, #193, #194, #195, #196, #197, #208, #225, #226,
@@ -1350,6 +1350,33 @@ under `api/alembic/versions/**` **silently never deploys**. No error, no warning
 - [ ] Rollback path documented for a mid-deploy `upgrade head` failure
 
 **Full Story:** `docs/BACKLOG_STORIES/BITB-089-deploy-alembic-migrations-from-ci.md`
+
+---
+
+### ✅ BITB-092: Fix Dev Stack `db-init` Migration Failure and Embedding Config Drift
+
+**Status:** ✅ Done (2026-08-09)
+**Size:** S
+
+**As a** developer running `make docker-up-dev`, **I want** `db-init` to successfully run
+migrations and embedding config to match the main local stack, **so that** local dev testing
+works out of the box.
+
+`db-init` in `docker-compose.dev.yml` lacked the `./api:/api:ro` mount that
+`scripts/migrations/run_migrations.py` needs to import `api/config.py` (it resolves `../../api`
+relative to itself), so migrations crashed with `ModuleNotFoundError: config`. Separately, `api`
+was missing `EMBEDDING_DIMENSIONS` and `db-init` was missing `EMBEDDING_PROVIDER` /
+`EMBEDDING_DIMENSIONS`, causing embedding config drift versus the main stack.
+
+**Acceptance Criteria (summary):**
+
+- [x] `db-init` mounts `./api:/api:ro`, matching `docker-compose.yml`'s reference contract
+- [x] `api` and `db-init` both set matching `EMBEDDING_PROVIDER` / `EMBEDDING_MODEL` /
+      `EMBEDDING_DIMENSIONS` defaults (`ollama` / `mxbai-embed-large` / `1024`)
+- [x] Regression test in `api/tests/test_docker_compose_dev.py`, collected by the standard API suite
+- [x] No production files changed
+
+**Full Story:** `docs/BACKLOG_STORIES/BITB-092-fix-dev-db-initialization.md`
 
 ---
 

--- a/docs/BACKLOG_STORIES/BITB-092-fix-dev-db-initialization.md
+++ b/docs/BACKLOG_STORIES/BITB-092-fix-dev-db-initialization.md
@@ -1,0 +1,99 @@
+# BITB-092: Fix Dev Stack `db-init` Migration Failure and Embedding Config Drift
+
+**Status:** ✅ Done
+**Priority:** P1
+**Size:** S
+**Created:** 2026-08-09
+**Completed:** 2026-08-09
+
+## User Story
+
+**As a** developer running `make docker-up-dev`, **I want** the dev stack's `db-init` service to
+successfully run migrations and the API/db-init embedding configuration to match the main local
+stack, **so that** local dev testing works out of the box instead of crashing on startup.
+
+## Problem
+
+`docker-compose.dev.yml`'s `db-init` service runs `scripts/migrations/run_migrations.py`, which
+resolves its `api/` package two directories up from its own file (`../../api`) — the same layout
+`docker-compose.yml`'s (production/main local stack's) `db-init` service exposes via the
+`./api:/api:ro` mount. The dev compose file was missing that mount entirely, so `db-init` crashed
+with `ModuleNotFoundError: config` before migrations could run, and `/api/config.py` was never
+visible inside the container.
+
+Separately, the dev stack's embedding configuration had drifted between services:
+
+- `api` was missing `EMBEDDING_DIMENSIONS`.
+- `db-init` was missing `EMBEDDING_PROVIDER` and `EMBEDDING_DIMENSIONS`.
+
+This meant the mxbai-embed-large / 1024-dimension defaults used by the main stack were not
+consistently applied across the dev stack's `api` and `db-init` services, risking embedding
+dimension mismatches between what the API expects and what migrations/db-init set up.
+
+## Root Cause
+
+- `docker-compose.dev.yml`'s `db-init` service lacked the `./api:/api:ro` read-only bind mount
+  present in `docker-compose.yml`'s equivalent service.
+- `EMBEDDING_PROVIDER` / `EMBEDDING_MODEL` / `EMBEDDING_DIMENSIONS` env vars were inconsistently
+  set (or missing) across the dev stack's `api` and `db-init` services.
+
+## Fix
+
+- `docker-compose.dev.yml`:
+  - Added `EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}` to the `api` service.
+  - Added `EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-ollama}` and
+    `EMBEDDING_DIMENSIONS=${EMBEDDING_DIMENSIONS:-1024}` to the `db-init` service (alongside the
+    existing `EMBEDDING_MODEL`).
+  - Added `./api:/api:ro` to `db-init`'s volumes, mirroring the production/main stack's contract so
+    `run_migrations.py` can import `api/config.py`.
+- Added a regression test, `api/tests/test_docker_compose_dev.py`, that parses
+  `docker-compose.dev.yml` with PyYAML (no Docker daemon required) and asserts:
+  - `db-init` mounts `./api:/api:ro`.
+  - `api` and `db-init` both carry `EMBEDDING_PROVIDER` / `EMBEDDING_MODEL` /
+    `EMBEDDING_DIMENSIONS` with the expected `mxbai-embed-large` / `1024` defaults.
+  - `api` and `db-init` never disagree on those embedding defaults.
+
+## Acceptance Criteria
+
+- [x] `db-init` in `docker-compose.dev.yml` mounts `./api:/api:ro` so `run_migrations.py` can
+      import `api/config.py`, matching `docker-compose.yml`'s contract.
+- [x] `api` and `db-init` in `docker-compose.dev.yml` both set `EMBEDDING_PROVIDER`,
+      `EMBEDDING_MODEL`, and `EMBEDDING_DIMENSIONS` with identical defaults
+      (`ollama` / `mxbai-embed-large` / `1024`).
+- [x] Regression test lives in `api/tests/test_docker_compose_dev.py` and is collected by the
+      standard `cd api && pytest tests/` suite (no separate test entry point under `scripts/`).
+- [x] `docker-compose.dev.yml` still validates via `docker compose ... config` using a temporary
+      env file derived from `.env.dev.example` (since `.env.dev` is a local, gitignored file not
+      present in every checkout).
+- [x] No production files (`docker-compose.yml`, `azure-deploy.yml`, etc.) changed.
+
+## Verification
+
+```bash
+# Targeted regression test
+.venv/bin/python -m pytest api/tests/test_docker_compose_dev.py -q
+
+# Full API suite still collects it
+cd api && python -m pytest tests/ -k docker_compose_dev -q
+
+# Compose file validates without Docker being started, using a throwaway env file
+tmp=$(mktemp)
+cp .env.dev.example "$tmp"
+docker compose -p getinspired-dev --env-file "$tmp" -f docker-compose.dev.yml config >/dev/null
+rm -f "$tmp"
+```
+
+## Out of Scope
+
+- Changes to `.env.dev` itself (local file, not tracked in this worktree; user's actual file is
+  already correct).
+- Changes to the production/main stack (`docker-compose.yml`) — already correct and used as the
+  reference contract.
+
+## Related
+
+- `docker-compose.yml`'s `db-init` service — the reference contract this story brings the dev
+  stack's `db-init` in line with.
+- `scripts/migrations/run_migrations.py` — the script whose `../../api` import path requires the
+  `/api` mount.
+- `docs/LOCAL_DEVELOPMENT.md` — documents the `make docker-up-dev` workflow this story fixes.

--- a/docs/BACKLOG_STORIES/BITB-092-fix-dev-db-initialization.md
+++ b/docs/BACKLOG_STORIES/BITB-092-fix-dev-db-initialization.md
@@ -4,7 +4,7 @@
 **Priority:** P1
 **Size:** S
 **Created:** 2026-08-09
-**Completed:** 2026-08-09
+**Completed:** 2026-08-09 (follow-up permission fix also completed 2026-08-09)
 
 ## User Story
 
@@ -97,3 +97,94 @@ rm -f "$tmp"
 - `scripts/migrations/run_migrations.py` — the script whose `../../api` import path requires the
   `/api` mount.
 - `docs/LOCAL_DEVELOPMENT.md` — documents the `make docker-up-dev` workflow this story fixes.
+
+## Follow-up: `db-init` Permission Failure Writing Downloaded Translations (2026-08-09)
+
+### Problem
+
+After the fix above, `make docker-up`/`make docker-up-dev` still failed on a fresh `./data`
+checkout: `db-init` runs as non-root UID 1000 (`api/Dockerfile`), while the host-owned bind mount
+`./data` was owned by a different host UID (observed: 1002). `scripts/load_bible.py` successfully
+**downloaded** KJV from its source URL, then crashed writing
+`/data/bible/translations/kjv.json` with a `PermissionError` — the container user couldn't write
+into the host-owned directory it didn't own, even though the mount itself was read-write.
+
+### Root Cause
+
+- `docker-compose.yml`/`docker-compose.dev.yml`'s `db-init` mounted `./data:/data` read-write, but
+  db-init's non-root container UID doesn't necessarily match (and can't be assumed to match) the
+  host UID that owns `./data` on every developer machine.
+- `scripts/load_bible.py`'s `download_translation()` always wrote newly-downloaded translation
+  JSON straight back into `data/bible/translations/`, with no alternative writable location
+  configurable for container use.
+
+### Fix
+
+- **`scripts/load_bible.py`**: added `resolve_bible_data_path(translation_code, primary_path)`,
+  a small typed helper (independently unit-testable, no I/O side effects beyond `Path.exists()`)
+  that decides where to read/write a translation's JSON:
+  1. The committed `data/bible/translations/<code>.json` source file always wins when it exists —
+     this keeps manual-only translations (Hindi, Luther 1912, no download URL) working exactly as
+     before, since they have no other source.
+  2. If it's missing and the new optional `BIBLE_DOWNLOAD_CACHE_DIR` env var is set, downloads are
+     written to `<BIBLE_DOWNLOAD_CACHE_DIR>/<code>.json` instead.
+  3. If it's missing and `BIBLE_DOWNLOAD_CACHE_DIR` is unset, falls back to the primary path — the
+     historical bare-host default, unchanged for anyone running the script directly (no Docker).
+  - No permission errors are silently caught; explicit configuration is expected to prevent them
+    in containers, and `download_translation()`'s actual file write still raises normally if the
+    resolved path turns out not to be writable.
+- **`docker-compose.yml`** and **`docker-compose.dev.yml`** (`db-init` service, both stacks — the
+  main stack has the identical UID-mismatch exposure):
+  - Changed `./data:/data` to `./data:/data:ro` — db-init never needs to write into the committed
+    source tree.
+  - Added `BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations` so first-run downloads (e.g. KJV) land
+    in the container's own writable filesystem instead. This cache is ephemeral by design: source
+    data is re-downloadable, and `db-init` skips the whole load step on restart once verses are in
+    the database (`scripts/init-db.sh`'s `VERSE_COUNT` check).
+  - This is local-stack (`make docker-up`/`make docker-up-dev`) configuration only; no production
+    deployment file (`azure-deploy.yml`, etc.) was touched.
+- **Tests:**
+  - `api/tests/test_load_bible_data_path.py` (new) — unit tests for `resolve_bible_data_path()`
+    and `download_translation()`: existing committed/source path wins even when a cache dir is
+    configured; a missing source uses the configured cache; a missing source with no cache
+    preserves the default path; a download (HTTP mocked, no network) writes to the resolved
+    writable path and never touches the primary directory.
+  - `api/tests/test_docker_compose_bible_cache.py` (new) — parses both `docker-compose.yml` and
+    `docker-compose.dev.yml` with PyYAML (no Docker daemon needed) and asserts `db-init` mounts
+    `./data:/data:ro` (and not read-write) and sets
+    `BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations` in both stacks, plus a sanity check that the
+    pre-existing `./api:/api:ro` mount is unaffected.
+
+### Acceptance Criteria (follow-up)
+
+- [x] A fresh `make docker-up` or `make docker-up-dev` can download KJV without writing into the
+      host-owned `./data` bind mount, regardless of host/container UID mismatch.
+- [x] Committed manual-only translations (Hindi, Luther 1912) remain loadable unchanged — they
+      still read directly from `data/bible/translations/*.json`.
+- [x] No chmod/chown/root workaround; no silent catching of `PermissionError`.
+- [x] `docker-compose.yml` and `docker-compose.dev.yml` both mount `./data:/data:ro` and set
+      `BIBLE_DOWNLOAD_CACHE_DIR=/tmp/bible-translations` for `db-init`.
+- [x] Regression tests added and passing:
+      `.venv/bin/python -m pytest api/tests/test_load_bible_data_path.py api/tests/test_docker_compose_bible_cache.py -q`
+- [x] Both compose files still validate via `docker compose ... config` using throwaway env file
+      copies (`.env.local.example` / `.env.dev.example`), without starting/stopping containers.
+- [x] `.env.dev` (local, gitignored) left untouched.
+
+### Verification (follow-up)
+
+```bash
+# Targeted regression tests
+.venv/bin/python -m pytest api/tests/test_load_bible_data_path.py \
+  api/tests/test_docker_compose_bible_cache.py api/tests/test_docker_compose_dev.py -q
+
+# Compose config validates for both stacks (throwaway env copies, no containers started)
+cp .env.local.example /path/to/scratch/env.local.tmp
+docker compose -f docker-compose.yml --env-file /path/to/scratch/env.local.tmp config >/dev/null
+cp .env.dev.example /path/to/scratch/env.dev.tmp
+docker compose -f docker-compose.dev.yml --env-file /path/to/scratch/env.dev.tmp config >/dev/null
+
+# Manual container-level proof (UID 1000, read-only /data bind mount): a missing translation
+# resolves to BIBLE_DOWNLOAD_CACHE_DIR and writes succeed there, while a direct write attempt to
+# the read-only /data mount still raises PermissionError/OSError as expected; a committed
+# manual-only translation (hindi.json) is still read directly from the read-only primary path.
+```

--- a/scripts/load_bible.py
+++ b/scripts/load_bible.py
@@ -14,8 +14,15 @@ Usage:
     python load_bible.py --status           # Show verse count and embedding coverage per translation
 
 Environment Variables:
-    DATABASE_URL          - PostgreSQL connection string
-    EMBEDDING_DIMENSIONS  - Vector dimensions (default: 1024 for Ollama, use 1536 for Azure OpenAI)
+    DATABASE_URL              - PostgreSQL connection string
+    EMBEDDING_DIMENSIONS      - Vector dimensions (default: 1024 for Ollama, use 1536 for Azure OpenAI)
+    BIBLE_DOWNLOAD_CACHE_DIR  - Optional directory for freshly downloaded translation JSON. Only
+                                used when the committed data/bible/translations/<code>.json source
+                                file does not already exist. Lets containers bind-mount
+                                data/bible/translations read-only while still allowing first-run
+                                downloads (e.g. KJV) to land in a writable cache instead of failing
+                                with a PermissionError. Unset preserves the historical bare-host
+                                behavior of writing straight into data/bible/translations/.
 """
 
 import argparse
@@ -120,6 +127,33 @@ def log(message: str, flush: bool = True):
     """Print timestamped log message and flush immediately for CI visibility."""
     timestamp = datetime.now().strftime("%H:%M:%S")
     print(f"[{timestamp}] {message}", flush=flush)
+
+
+def resolve_bible_data_path(translation_code: str, primary_path: Path) -> Path:
+    """Choose where to read/write a translation's Bible JSON.
+
+    Precedence:
+    1. `primary_path` (the committed `data/bible/translations/<code>.json` source) wins whenever
+       it already exists on disk — this is the read-only source of truth, and the only place
+       manual-only translations (e.g. Hindi, Luther) live, since they have no download URL.
+    2. If it doesn't exist and `BIBLE_DOWNLOAD_CACHE_DIR` is set, downloads are written under
+       `<BIBLE_DOWNLOAD_CACHE_DIR>/<translation_code>.json` instead. This lets containers bind
+       `data/` read-only (so a UID mismatch between the container user and the host-owned bind
+       mount can't produce a `PermissionError`) while still allowing a first-run download.
+    3. Otherwise, fall back to `primary_path` — the historical bare-host default, where the
+       process account owns `data/` and can write directly into it.
+
+    This function never swallows permission errors itself; the caller's actual file write will
+    raise normally if the resolved path turns out not to be writable.
+    """
+    if primary_path.exists():
+        return primary_path
+
+    cache_dir = os.environ.get("BIBLE_DOWNLOAD_CACHE_DIR")
+    if cache_dir:
+        return Path(cache_dir) / f"{translation_code}.json"
+
+    return primary_path
 
 
 async def download_translation(translation_code: str, output_path: Path) -> dict:
@@ -760,14 +794,16 @@ async def load_translation_to_db(
             # Ensure books and chapters exist
             book_ids = await ensure_books_and_chapters(session)
 
-            # Download translation data
-            bible_path = (
+            # Download translation data. Prefer the committed source file; fall back to
+            # BIBLE_DOWNLOAD_CACHE_DIR (if configured) when it's missing and needs downloading.
+            primary_bible_path = (
                 Path(__file__).parent.parent
                 / "data"
                 / "bible"
                 / "translations"
                 / f"{translation_code}.json"
             )
+            bible_path = resolve_bible_data_path(translation_code, primary_bible_path)
             bible_data = await download_translation(translation_code, bible_path)
 
             # Skip verse loading if no data available (e.g. manual-only translations with no URL)


### PR DESCRIPTION
## Summary
- mount API source read-only into dev `db-init` so migration imports resolve
- align Ollama embedding provider, model, and dimensions across dev API and initialization
- keep committed Bible data read-only and cache downloaded translations in the container, avoiding host/container UID permission failures in both local stacks
- add regression coverage for path selection and both Compose contracts

## Verification
- `.venv/bin/python -m pytest api/tests/test_load_bible_data_path.py api/tests/test_docker_compose_bible_cache.py api/tests/test_docker_compose_dev.py api/tests/test_translations.py -q` — 62 passed
- post-merge focused suite — 14 passed
- both Compose files pass `docker compose config`
- live `make docker-up-dev`: API healthy, KJV saved to `/tmp/bible-translations/kjv.json`, 31,100 verses loaded, `db-init` exited 0
- all pre-commit hooks passed

## Notes
- `.env.dev` is unchanged
- no root, chmod, or chown workaround
- deployed production configuration is unchanged