### PR TITLE
fix(api): remove stale mypy suppressions in scripture search routes (BITB-009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ pytest
 
 ### Technical Improvements
 
-- [ ] Refactor SQLAlchemy models to use `Mapped[]` type annotations (see [docs/TECHNICAL_DEBT.md](docs/TECHNICAL_DEBT.md))
+- [x] Refactor SQLAlchemy models to use `Mapped[]` type annotations (see [docs/TECHNICAL_DEBT.md](docs/TECHNICAL_DEBT.md))
 - [x] Add Vitest for frontend unit tests (186 tests across 17 suites)
 - [ ] Add Playwright/Cypress for E2E tests
 - [ ] Add code coverage reporting

--- a/api/routes/scripture.py
+++ b/api/routes/scripture.py
@@ -281,12 +281,12 @@ async def get_verse_range(
 
 @router.get("/search", response_model=SearchResults)
 async def search_scripture(
+    db: DbSession,
+    embedding: EmbeddingProviderDep,
     q: str = Query(..., min_length=2, description="Search query"),
     max_verses: int = Query(5, ge=1, le=20),
     max_passages: int = Query(2, ge=0, le=5),
     translation: str | None = Query(None, description="Translation code (e.g., 'kjv', 'ita1927')"),
-    db: DbSession = None,  # type: ignore
-    embedding: EmbeddingProviderDep = None,  # type: ignore
 ):
     """
     Semantic search for relevant scripture.
@@ -313,10 +313,10 @@ async def search_scripture(
 
 @router.get("/search/text")
 async def search_text(
+    db: DbSession,
+    embedding: EmbeddingProviderDep,
     q: str = Query(..., min_length=2, description="Text to search"),
     limit: int = Query(20, ge=1, le=100),
-    db: DbSession = None,  # type: ignore
-    embedding: EmbeddingProviderDep = None,  # type: ignore
 ):
     """
     Simple text search in verse content.

--- a/api/tests/test_routes_main_coverage.py
+++ b/api/tests/test_routes_main_coverage.py
@@ -1574,7 +1574,14 @@ class TestScriptureRoutes:
             mock_service.search = AsyncMock(return_value=expected)
             mock_service_cls.return_value = mock_service
 
-            result = await search_scripture("love", 5, 2, None, mock_db, mock_embedding)
+            result = await search_scripture(
+                db=mock_db,
+                embedding=mock_embedding,
+                q="love",
+                max_verses=5,
+                max_passages=2,
+                translation=None,
+            )
 
         assert result.query == "love"
 
@@ -1590,7 +1597,7 @@ class TestScriptureRoutes:
             mock_service.text_search = AsyncMock(return_value=[])
             mock_service_cls.return_value = mock_service
 
-            result = await search_text("love", 20, mock_db, mock_embedding)
+            result = await search_text(db=mock_db, embedding=mock_embedding, q="love", limit=20)
 
         assert result["query"] == "love"
         assert result["verses"] == []

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -383,18 +383,20 @@ async def chat(
 
 ### 4.2 SQLAlchemy Models
 
-**Verse Model with Vector:**
+**Verse Model with Vector** (SQLAlchemy 2.0 `Mapped[]` syntax — see `scripture/models.py`):
 
 ```python
 class Verse(Base):
     __tablename__ = "verses"
 
-    id = Column(Integer, primary_key=True)
-    book_id = Column(Integer, ForeignKey("books.id"))
-    chapter_number = Column(Integer)
-    verse_number = Column(Integer)
-    text = Column(Text)
-    embedding = Column(Vector(1024))  # pgvector type (mxbai-embed-large)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    book_id: Mapped[int] = mapped_column(Integer, ForeignKey("books.id"))
+    chapter_number: Mapped[int] = mapped_column(Integer)
+    verse_number: Mapped[int] = mapped_column(Integer)
+    text: Mapped[str] = mapped_column(Text)
+    embedding: Mapped[Optional[Vector]] = mapped_column(
+        Vector(settings.embedding_dimensions), nullable=True  # pgvector type (mxbai-embed-large)
+    )
 ```
 
 ### 4.3 Vector Search

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Prioritized list of user stories and features for Vox Quieta.
 
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-13
 
 **Verification Note (2026-04-20):** PR status reconciliation pass completed against GitHub.
 Confirmed merged PRs: #68, #171, #182, #191, #193, #194, #195, #196, #197, #208, #225, #226,
@@ -1884,10 +1884,10 @@ because it's data work gated behind BITB-043's eval set, not a live regression.
 
 ---
 
-### 🎯 BITB-009: Refactor SQLAlchemy Models to 2.0 Syntax
+### ✅ BITB-009: Refactor SQLAlchemy Models to 2.0 Syntax
 
-**Status:** 🎯 Todo
-**Size:** L
+**Status:** ✅ Done (PR #984, 2026-08-13)
+**Size:** L (found already ~90% done by an earlier, undocumented PR; this PR closed the remainder)
 
 **As a** developer,
 **I want** SQLAlchemy models to use `Mapped[]` annotations,
@@ -1895,11 +1895,19 @@ because it's data work gated behind BITB-043's eval set, not a live regression.
 
 **Acceptance Criteria:**
 
-- [ ] All models in `api/scripture/models.py` use `Mapped[]` syntax
-- [ ] MyPy suppressions removed from `scripture/*` and `routes/*`
-- [ ] All tests pass with no type errors
-- [ ] Database queries still work correctly
-- [ ] Documentation updated with new model syntax examples
+- [x] All models in `api/scripture/models.py` use `Mapped[]` syntax (already done pre-PR)
+- [x] MyPy suppressions removed from `scripture/*` and `routes/*` (4 lines in `routes/scripture.py`, unrelated to model typing — see below)
+- [x] All tests pass with no type errors
+- [x] Database queries still work correctly
+- [x] Documentation updated with new model syntax examples
+
+**Resolution note:** `scripture/models.py` and `feedback/models.py` were already fully
+`Mapped[]`/`mapped_column()` when this story was picked up, and the `pyproject.toml`
+mypy overrides the story references no longer exist. The only remaining suppressions in
+scope were `# type: ignore` on `db`/`embedding` params in `search_scripture` and
+`search_text` (`routes/scripture.py`), caused by FastAPI dependency params being
+defaulted to `None` after `Query(...)`-defaulted params — unrelated to model typing.
+Fixed by reordering params (DI params first), matching `get_verse`/`get_verse_range`.
 
 **Tech Constraints:**
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -124,7 +124,7 @@ Organized by priority and category. Each item includes effort estimate and impac
 - **Issue**: Uses `Column()` instead of SQLAlchemy 2.0 `Mapped[]` annotations,
   causing mypy suppressions across `scripture.*` and `routes.*`.
 - **Fix**: Migrate to `Mapped[]` annotations.
-- **Effort**: L | **Impact**: Medium | **Status**: Open
+- **Effort**: L | **Impact**: Medium | **Status**: Done (BITB-009, PR #984)
 - **Note**: Already tracked in `docs/TECHNICAL_DEBT.md`.
 
 ### 3.4 Magic Number: Similarity Threshold

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -6,102 +6,56 @@ This document tracks known technical debt and planned refactoring work.
 
 ### Refactor SQLAlchemy Models to Use `Mapped[]` Type Annotations
 
-**Status:** Planned
+**Status:** ✅ Done (BITB-009, PR #984)
 **Priority:** Medium
-**Effort:** 2-3 hours
 **Impact:** Improved type safety, removes mypy suppressions
 
-#### Problem
+#### Resolution
 
-Current models use SQLAlchemy 1.x-style `Column()` declarations:
+All models in `scripture/models.py` and `feedback/models.py` already use SQLAlchemy 2.0's
+`Mapped[]` / `mapped_column()` syntax (landed in an earlier, undocumented PR — this entry
+was stale). No `Column()`-style declarations remain in the ORM layer, and the
+`[[tool.mypy.overrides]]` suppressions described below are no longer present in
+`api/pyproject.toml`.
 
-```python
-class Book(Base):
-    __tablename__ = "books"
-
-    id = Column(Integer, primary_key=True)
-    name = Column(String(50), nullable=False, unique=True)
-    # ... more columns
-```
-
-This causes mypy to see `Column[str]` types when analyzing code, but at runtime these are
-actual `str` values. This mismatch requires suppressing `arg-type` errors in `scripture.*`
-and `routes.*` modules.
-
-#### Root Cause
-
-1. **Static vs Runtime Types**: Mypy performs static analysis and sees the Column type
-descriptors, not the runtime attribute values
-2. **Legacy Syntax**: The Column-based syntax predates SQLAlchemy 2.0's improved type
-annotations
-3. **ORM Magic**: SQLAlchemy uses Python descriptors and metaclasses that mypy cannot
-fully understand
-
-#### Current Workaround
-
-In `api/pyproject.toml`:
-
-```toml
-[[tool.mypy.overrides]]
-module = "scripture.*"
-disable_error_code = ["arg-type"]
-
-[[tool.mypy.overrides]]
-module = "routes.*"
-disable_error_code = ["arg-type"]
-```
-
-This suppresses errors when passing ORM model attributes to Pydantic models:
+Current shape, e.g. `scripture/models.py`:
 
 ```python
-# Mypy sees: Column[str] passed where str expected
-# Runtime: actual str value passed correctly
-VerseResult(
-    text=verse.text,  # mypy thinks this is Column[str], actually str
-    chapter=verse.chapter_number,  # mypy thinks Column[int], actually int
-)
+class Verse(Base):
+    __tablename__ = "verses"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    book_id: Mapped[int] = mapped_column(Integer, ForeignKey("books.id"))
+    text: Mapped[str] = mapped_column(Text)
+    translation: Mapped[str] = mapped_column(
+        String(20), ForeignKey("translations.code", ondelete="CASCADE"), default="kjv"
+    )
+    embedding: Mapped[Optional[Vector]] = mapped_column(
+        Vector(settings.embedding_dimensions), nullable=True
+    )
 ```
 
-#### Proposed Solution
+The only remaining `# type: ignore` suppressions in `scripture/*` and `routes/*` were four
+lines in `routes/scripture.py` (`search_scripture`, `search_text`), and they were unrelated
+to model typing — they suppressed a FastAPI parameter-ordering issue (`Depends`-based
+params defaulted to `None` after `Query(...)`-defaulted params). BITB-009 closed those out
+by reordering the dependency-injection params first, matching the existing pattern in
+`get_verse` / `get_verse_range`.
 
-Refactor to SQLAlchemy 2.0's `Mapped[]` syntax:
+#### Historical context (superseded)
 
-```python
-from sqlalchemy.orm import Mapped, mapped_column
+The section below described the original problem before the `Mapped[]` conversion landed;
+kept for reference.
 
-class Book(Base):
-    __tablename__ = "books"
+<details>
+<summary>Original problem writeup</summary>
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    name: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
-    # ... more columns
-```
+Models previously used SQLAlchemy 1.x-style `Column()` declarations, which mypy saw as
+`Column[str]` rather than the runtime `str` value, requiring `arg-type` suppressions in
+`scripture.*` and `routes.*`. The fix was to convert to `Mapped[type] = mapped_column(...)`
+so mypy understands `book.name` is `str`, not `Column[str]`.
 
-Benefits:
-
-- ✅ Mypy understands that `book.name` is `str`, not `Column[str]`
-- ✅ Better IDE autocomplete
-- ✅ Removes need for error suppressions
-- ✅ Aligns with SQLAlchemy 2.0 best practices
-- ✅ More explicit about nullable vs non-nullable fields
-
-#### Migration Steps
-
-1. Update `scripture/models.py`:
-   - Add `from sqlalchemy.orm import Mapped, mapped_column`
-   - Convert each `Column()` to `Mapped[type] = mapped_column(...)`
-   - Update relationship annotations
-
-2. Update affected files:
-   - `scripture/search.py`
-   - `scripture/repository.py`
-   - `routes/scripture.py`
-
-3. Remove mypy overrides from `pyproject.toml`
-
-4. Run full test suite to verify no regressions
-
-5. Update documentation
+</details>
 
 #### References
 


### PR DESCRIPTION
## What

- Closes out BITB-009 ("Refactor SQLAlchemy Models to 2.0 `Mapped[]` Syntax"). Investigation found the story was already ~90% done: `scripture/models.py` and `feedback/models.py` were already fully converted to `Mapped[]`/`mapped_column()` by an earlier, undocumented PR, and the `pyproject.toml` mypy overrides the story describes no longer exist.
- The only remaining `# type: ignore` suppressions in `scripture/*`/`routes/*` scope were 4 lines in `api/routes/scripture.py` (`search_scripture`, `search_text`) — unrelated to model typing. They existed because FastAPI `Depends`-based params (`db`, `embedding`) were defaulted to `None` after `Query(...)`-defaulted params. Fixed by reordering params (DI params first), matching the existing pattern already used by `get_verse`/`get_verse_range` in the same file.
- Updated the two test call sites in `api/tests/test_routes_main_coverage.py` that called `search_scripture`/`search_text` positionally, to keyword args (avoids the tests becoming order-sensitive to the param reorder).
- Reconciled `docs/TECHNICAL_DEBT.md`, `docs/TASKS.md`, `docs/ARCHITECTURE.md`, `docs/BACKLOG.md`, and `README.md`, which all still described the pre-`Mapped[]` state as open work.

## Test plan

- [x] `cd api && mypy . --ignore-missing-imports --no-strict-optional` — identical 5 pre-existing baseline errors (yaml stubs, alembic attrs), zero new errors introduced; verified by diffing against a `git stash`-baseline run.
- [x] `cd api && python -m pytest tests/test_models.py tests/test_database_schema.py tests/test_routes_main_coverage.py tests/test_scripture_coverage.py tests/test_multilanguage_routes.py tests/test_hybrid_search.py -v` — 271 passed.
- [x] `cd api && python -m pytest -m "not network and not golden_set and not functional and not e2e"` — 3716 passed, 6 failed. All 6 failures reproduce on `main` (pre-existing DB-backup-script/security-suite flakiness, confirmed via baseline stash + isolated reruns — 2 of the 6 only fail under full-suite ordering and pass individually, indicating pre-existing test-pollution, not a regression from this change).
- [x] `cd api && python -m pytest tests/test_alembic_migrations.py` — 17 passed, 2 skipped.
- [x] `cd api && ruff check . --select E,F,W,C90,I,N --ignore E501` — all checks passed.
- [x] `cd api && black --check --diff routes/scripture.py tests/test_routes_main_coverage.py` — no changes needed.

## Notes

- `Vector`/pgvector column typing (`Mapped[Optional[Vector]]` on `Verse.embedding`) was deliberately left untouched — it type-checks green today and changing it is the one edit that could plausibly affect `cosine_distance`/HNSW index resolution. Not in scope for this story.
- PR #980 (BITB-093, open) also touches `scripture/models.py`/`feedback/models.py`, but only adds `server_default=` args to existing columns — no structural overlap with this PR, which doesn't touch either models file. Only expected friction is a trivial `docs/BACKLOG.md` "Last Updated" conflict on merge order.

---
_Generated by [Claude Code](https://claude.ai/code/session_017wqK5iDSwrx5MaNCBtCZfH)_